### PR TITLE
inputs: include path of BuildInput files in digest

### DIFF
--- a/digest/sha384/sha384_test.go
+++ b/digest/sha384/sha384_test.go
@@ -1,0 +1,116 @@
+package sha384_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/simplesurance/baur/digest"
+	"github.com/simplesurance/baur/digest/sha384"
+)
+
+func TestDigestOnEmptyHashErrors(t *testing.T) {
+	const emptySHA384Digest = "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	sha := sha384.New()
+	d := sha.Digest()
+
+	if d.Sum.Text(16) != emptySHA384Digest {
+		t.Errorf("hash of nothing is %q expected %q", d.Sum.Text(16), emptySHA384Digest)
+	}
+
+	if d.Algorithm != digest.SHA384 {
+		t.Errorf("Algorithm of Digest is set to %q expected %q", d.Algorithm, digest.SHA384)
+	}
+}
+
+func TestAddBytes(t *testing.T) {
+	const (
+		helloSha384    = "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f"
+		hellobyeSha384 = "f9904746d036ce9df915c4d2cae83acdd12aa9ef046648c4bc415cce6b86e64870b9c369d1a9b675b302d557b0a49ba5"
+		helloStr       = "hello"
+		byeStr         = "bye"
+	)
+
+	sha := sha384.New()
+	err := sha.AddBytes([]byte(helloStr))
+	if err != nil {
+		t.Fatalf("AddBytes(%q) failed: %s", helloStr, err.Error())
+	}
+
+	d1 := sha.Digest()
+	if d1.Algorithm != digest.SHA384 {
+		t.Errorf("Algorithm of Digest is set to %q expected %q", d1.Algorithm, digest.SHA384)
+	}
+
+	if d1.Sum.Text(16) != helloSha384 {
+		t.Errorf("calculated hash of %q is %q, expected %q", helloStr, d1.Sum.Text(16), helloSha384)
+	}
+
+	expectedStrRepr := "sha384:" + helloSha384
+	if d1.String() != expectedStrRepr {
+		t.Errorf("string representation of digest is %q, expected %q", d1.String(), expectedStrRepr)
+	}
+
+	err = sha.AddBytes([]byte(byeStr))
+	if err != nil {
+		t.Fatalf("AddBytes(%q) failed: %s", byeStr, err)
+	}
+
+	d2 := sha.Digest()
+	if d1.Sum.Cmp(&d2.Sum) == 0 {
+		t.Fatalf("adding %q to hash didn't change digest", byeStr)
+	}
+
+	if d2.Sum.Text(16) != hellobyeSha384 {
+		t.Errorf("calculated hash of 'hellobye' is %q, expected %q", d1.Sum.Text(16), hellobyeSha384)
+	}
+}
+
+func TestAddFile(t *testing.T) {
+	const (
+		testStr       = "this is a baur sha384 test file"
+		testStrSHA384 = "63e291131dbf905a7fea3ffa4dbd8a49bee10055242e6ff1eea3c3862aefc33a4eb9580dd0c706d48b9ee861abfdacdf"
+	)
+
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal("creating tempfile failed:", err.Error())
+	}
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte(testStr))
+	if err != nil {
+		file.Close()
+		t.Fatal("writing to file failed:", err.Error())
+	}
+
+	if err := file.Close(); err != nil {
+		t.Fatal("closing file failed:", err.Error())
+	}
+
+	sha := sha384.New()
+
+	err = sha.AddFile(file.Name())
+	if err != nil {
+		t.Fatal("hashing file failed:", err.Error())
+	}
+	d := sha.Digest()
+
+	if d.Sum.Text(16) != testStrSHA384 {
+		t.Errorf("hash of file is %q expeted %q", d.Sum.Text(16), testStrSHA384)
+	}
+}
+
+func TestHashingNonExistingFileFails(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal("creating tempfile failed:", err.Error())
+	}
+	os.Remove(file.Name())
+
+	sha := sha384.New()
+	err = sha.AddFile(file.Name())
+	if err == nil {
+		t.Errorf("hashing non existing file was successful")
+	}
+}

--- a/file.go
+++ b/file.go
@@ -31,12 +31,19 @@ func (f *File) Digest() (digest.Digest, error) {
 		return *f.digest, nil
 	}
 
-	d, err := sha384.File(filepath.Join(f.absPath))
+	sha := sha384.New()
+
+	err := sha.AddBytes([]byte(f.relPath))
 	if err != nil {
-		return digest.Digest{}, nil
+		return digest.Digest{}, err
 	}
 
-	f.digest = d
+	err = sha.AddFile(filepath.Join(f.absPath))
+	if err != nil {
+		return digest.Digest{}, err
+	}
+
+	f.digest = sha.Digest()
 
 	return *f.digest, nil
 }

--- a/fileartifact.go
+++ b/fileartifact.go
@@ -50,7 +50,14 @@ func (f *FileArtifact) UploadDestination() string {
 
 // Digest returns the file digest
 func (f *FileArtifact) Digest() (*digest.Digest, error) {
-	return sha384.File(f.LocalPath())
+	sha := sha384.New()
+
+	err := sha.AddFile(f.LocalPath())
+	if err != nil {
+		return nil, err
+	}
+
+	return sha.Digest(), err
 }
 
 // Size returns the size of the file in bytes


### PR DESCRIPTION
The digest of BuildInput files was computed only over the content of the
file.
This had the problem that if a file was moved but it's content didn't
change an application wasn't rebuild because It's TotalInputDigest did
not change.
This causes a problem in the following scenario:
- BuildInput A contains the path to BuildInput B,
  the path is correct but BuildInput B is a different path in the
  repository
- BuildInput B is moved to the path in seperate commit

Until now the application would not have been rebuild.
This is fixed by including the repository relative path of the file in
the hash.

To be able to add the path of the file to the digest, the sha384 package
was refactored.
It now offers a Hash object to which data can be added and the digest is
retrieved by a separate function call. This allows to add the content of
the file and in a septate call the path of the file to the hash and then
retrieving it's Digest.