### PR TITLE
s3: add scheme component to URL that is returned by Upload()

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -110,7 +110,7 @@ func (c *Client) Upload(ctx context.Context, image, dest string) (string, error)
 		}
 	}
 
-	return dest, nil
+	return "docker://" + dest, nil
 }
 
 // Size returns the size of an image in Bytes


### PR DESCRIPTION
Prefix the URLs that are returned by s3.Upload() with "docker://".
This will cause that the URLs stored in the database to docker
BuildOutputs will have this prefix.
URLs for files uploaded to S3 already have a https(s):// prefix.
URLs for docker containers should also contain the scheme component.