### PR TITLE
upload: improve error message on upload failures

### DIFF
--- a/upload/seq/manager.go
+++ b/upload/seq/manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/simplesurance/baur/log"
 	"github.com/simplesurance/baur/upload"
 )
@@ -63,8 +64,14 @@ func (u *Uploader) Start() {
 			log.Debugf("uploading %s\n", job)
 			if job.Type() == upload.JobS3 {
 				url, err = u.s3.Upload(job.LocalPath(), job.RemoteDest())
+				if err != nil {
+					err = errors.Wrap(err, "S3 upload failed")
+				}
 			} else if job.Type() == upload.JobDocker {
 				url, err = u.docker.Upload(context.Background(), job.LocalPath(), job.RemoteDest())
+				if err != nil {
+					err = errors.Wrap(err, "Docker upload failed")
+				}
 			} else {
 				panic(fmt.Sprintf("invalid job %+v", job))
 			}
@@ -88,7 +95,6 @@ func (u *Uploader) Start() {
 			return
 		}
 		u.lock.Unlock()
-
 	}
 }
 


### PR DESCRIPTION
The error message was missing the information which uploader failed, the
message was before like:
"ERROR: upload of "acl-service.tar.xz" failed: MissingRegion: could not find region configuration"

Add the information if it's an docker or S3 upload to the error