### PR TITLE
cfg: improve file write operations

### DIFF
--- a/cfg/app.go
+++ b/cfg/app.go
@@ -210,6 +210,14 @@ func (a *App) ToFile(filepath string) error {
 	}
 
 	_, err = f.Write(data)
+	if err != nil {
+		return errors.Wrap(err, "writing to file failed")
+	}
+
+	err = f.Close()
+	if err != nil {
+		return errors.Wrap(err, "closing file failed")
+	}
 
 	return err
 }


### PR DESCRIPTION
- close the files explicitly and check for errors, I/O operations are
  buffered, errors might only happen when the close triggers the real
  write to the file
- pass the o.TRUNC flag to the open() call when overwriting existing
  config files to ensure existing files are emptied