### PR TITLE
Deduplicate application names and paths passed to the commandline

### DIFF
--- a/app.go
+++ b/app.go
@@ -173,7 +173,7 @@ func (a *App) String() string {
 }
 
 func (a *App) pathsToUniqFiles(paths []string) ([]*File, error) {
-	dedupMap := map[string]struct{}{}
+	dedupMap := make(map[string]struct{}, len(paths))
 	res := make([]*File, 0, len(paths))
 
 	for _, path := range paths {

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -180,8 +180,15 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 		return apps
 	}
 
+	dedupMap := make(map[string]struct{}, len(args))
 	apps := make([]*baur.App, 0, len(args))
 	for _, arg := range args {
+		app := mustArgToApp(repo, arg)
+		if _, exist := dedupMap[app.Path]; exist {
+			continue
+		}
+
+		dedupMap[app.Path] = struct{}{}
 		apps = append(apps, mustArgToApp(repo, arg))
 	}
 


### PR DESCRIPTION
```
commit 4c4115cc18f357bfdf9e16ef2e673c8f12b77287 (HEAD -> dedupargs, origin/dedupargs)
Author: Fabian Holler <fabian.holler@simplesurance.de>
Date:   Thu Dec 13 17:23:56 2018 +0100

    cmd: deduplicate the passed appnames and paths
    
    Deduplicate the returned list of discovered applications in mustArgsToApps().
    
    This prevents that an operation is run multiple times if an application is
    specified multiple time on the commandline, to e.g. baur build.

commit 37dae640475521d588cc0d71248cbb4a7120742c
Author: Fabian Holler <fabian.holler@simplesurance.de>
Date:   Thu Dec 13 17:31:02 2018 +0100

    app: allocate map with required capacity in pathsToUniqFiles()
    
    We know the max. number of elements that we store in the map in advance,
    therefore allocate it with the needed capacity to save alloc operations.

```