### PR TITLE
resolve: resolving unusual filenames as gitfile input failed

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -37,7 +37,7 @@ func CommitID(dir string) (string, error) {
 // output
 // If no files match, ErrNotExist is returned
 func LsFiles(cwd, args string) (string, error) {
-	cmd := "git ls-files --error-unmatch " + args
+	cmd := "git -c core.quotepath=off ls-files --error-unmatch " + args
 
 	out, exitCode, err := exec.Command(cwd, cmd)
 	if err != nil {


### PR DESCRIPTION
Git has by default the 'core.quotePath' option enabled.
This caused that git ls-files printed some filenames enclosed in quotes and with
escaped characters.
Opening files were the quotePath option took effect failed because no file with
that name existed.

Disable the quotePath git option when running git ls-files to get the raw
filename.