### PR TITLE
cfg: make the [Build] section in the .app.toml file optional

### DIFF
--- a/build.go
+++ b/build.go
@@ -15,6 +15,8 @@ const (
 	_ BuildStatus = iota
 	// BuildStatusInputsUndefined inputs of the application are undefined,
 	BuildStatusInputsUndefined
+	// BuildStatusBuildCommandUndefined build.command of the application is undefined,
+	BuildStatusBuildCommandUndefined
 	// BuildStatusExist a build exist
 	BuildStatusExist
 	// BuildStatusPending no build exist
@@ -29,6 +31,8 @@ func (b BuildStatus) String() string {
 		return "Exist"
 	case BuildStatusPending:
 		return "Pending"
+	case BuildStatusBuildCommandUndefined:
+		return "Build Command Undefined"
 	default:
 		panic(fmt.Sprintf("incompatible BuildStatus value: %d", b))
 	}
@@ -39,6 +43,10 @@ func (b BuildStatus) String() string {
 // If the function returns BuildStatusExist the returned build pointer is valid
 // otherwise it is nil.
 func GetBuildStatus(storer storage.Storer, app *App) (BuildStatus, *storage.BuildWithDuration, error) {
+	if len(app.BuildCmd) == 0 {
+		return BuildStatusBuildCommandUndefined, nil, nil
+	}
+
 	if !app.HasBuildInputs() {
 		return BuildStatusInputsUndefined, nil, nil
 	}

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -219,8 +219,9 @@ func (a *App) Validate() error {
 // Validate validates the build section
 func (b *Build) Validate() error {
 	if len(b.Command) == 0 {
-		return errors.New("[Build] section contains errors: command can not be empty")
+		return nil
 	}
+
 	if err := b.Input.Validate(); err != nil {
 		return err
 	}

--- a/cfg/repository.go
+++ b/cfg/repository.go
@@ -15,7 +15,7 @@ const (
 	// configVersion identifies the format of the configuration files,
 	// whenever an incompatible change is made, this number has to be
 	// increased
-	configVersion int = 1
+	configVersion int = 2
 )
 
 // Repository contains the repository configuration.

--- a/command/build.go
+++ b/command/build.go
@@ -28,6 +28,9 @@ import (
 const (
 	dockerEnvUsernameVar = "BAUR_DOCKER_USERNAME"
 	dockerEnvPasswordVar = "BAUR_DOCKER_PASSWORD"
+
+	appColSep = " => "
+	sepLen    = len(appColSep)
 )
 
 var buildLongHelp = fmt.Sprintf(`
@@ -363,17 +366,17 @@ func maxAppNameLen(apps []*baur.App) int {
 func appsWithBuildCommand(apps []*baur.App) []*baur.App {
 	res := make([]*baur.App, 0, len(apps))
 
-	maxAppNameLen := maxAppNameLen(apps) + 4
+	appNameColLen := maxAppNameLen(apps) + sepLen
 
 	for _, app := range apps {
 		if len(app.BuildCmd) == 0 {
-			fmt.Printf("%-*s => %s\n",
-				maxAppNameLen, app.Name, coloredBuildStatus(baur.BuildStatusBuildCommandUndefined))
+			fmt.Printf("%-*s%s%s\n",
+				appNameColLen, app.Name, appColSep, coloredBuildStatus(baur.BuildStatusBuildCommandUndefined))
 			continue
 		}
 
-		fmt.Printf("%-*s => %s\n",
-			maxAppNameLen, app.Name, coloredBuildStatus(baur.BuildStatusPending))
+		fmt.Printf("%-*s%s%s\n",
+			appNameColLen, app.Name, appColSep, coloredBuildStatus(baur.BuildStatusPending))
 		res = append(res, app)
 	}
 
@@ -383,19 +386,19 @@ func appsWithBuildCommand(apps []*baur.App) []*baur.App {
 func pendingBuilds(storage storage.Storer, apps []*baur.App) []*baur.App {
 	var res []*baur.App
 
-	maxAppNameLen := maxAppNameLen(apps) + 4
+	appNameColLen := maxAppNameLen(apps) + sepLen
 
 	for _, app := range apps {
 		buildStatus, build, _ := mustGetBuildStatus(app, storage)
 
 		if buildStatus == baur.BuildStatusExist {
-			fmt.Printf("%-*s => %s (%s)\n",
-				maxAppNameLen, app.Name, coloredBuildStatus(buildStatus), highlight(build.ID))
+			fmt.Printf("%-*s%s%s (%s)\n",
+				appNameColLen, app.Name, appColSep, coloredBuildStatus(buildStatus), highlight(build.ID))
 			continue
 		}
 
-		fmt.Printf("%-*s => %s\n",
-			maxAppNameLen, app.Name, coloredBuildStatus(buildStatus))
+		fmt.Printf("%-*s%s%s\n",
+			appNameColLen, app.Name, appColSep, coloredBuildStatus(buildStatus))
 
 		if buildStatus == baur.BuildStatusBuildCommandUndefined {
 			continue

--- a/command/flag/buildstatus.go
+++ b/command/flag/buildstatus.go
@@ -10,16 +10,18 @@ import (
 
 // Valid commandline values
 const (
-	buildStatusExist          = "exist"
-	buildStatusPending        = "pending"
-	buildStatusInputUndefined = "inputs-undefined"
+	buildStatusExist                 = "exist"
+	buildStatusPending               = "pending"
+	buildStatusInputUndefined        = "inputs-undefined"
+	buildStatusBuildCommandUndefined = "build-command-undefined"
 )
 
 // BuildStatusFormatDescription is the format description for the flag
 const BuildStatusFormatDescription string = "one of " +
 	buildStatusExist + ", " +
 	buildStatusPending + ", " +
-	buildStatusInputUndefined
+	buildStatusInputUndefined + ", " +
+	buildStatusBuildCommandUndefined
 
 // BuildStatus is a commandline parameter to specify build status filters
 type BuildStatus struct {
@@ -43,6 +45,8 @@ func (b *BuildStatus) Set(val string) error {
 		b.Status = baur.BuildStatusPending
 	case buildStatusInputUndefined:
 		b.Status = baur.BuildStatusPending
+	case buildStatusBuildCommandUndefined:
+		b.Status = baur.BuildStatusBuildCommandUndefined
 	default:
 		return errors.New("status must be " + BuildStatusFormatDescription)
 	}
@@ -61,12 +65,13 @@ func (b *BuildStatus) Usage(highlightFn func(a ...interface{}) string) string {
 	return strings.TrimSpace(fmt.Sprintf(`
 Only show applications with this build status
 Format: %s
-where %s is one of: %s, %s, %s`,
+where %s is one of: %s, %s, %s, %s`,
 		highlightFn(b.Type()),
 		highlightFn("STATUS"),
 		highlightFn(buildStatusExist),
 		highlightFn(buildStatusPending),
 		highlightFn(buildStatusInputUndefined),
+		highlightFn(buildStatusBuildCommandUndefined),
 	))
 }
 

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -206,6 +206,8 @@ func coloredBuildStatus(status baur.BuildStatus) string {
 	switch status {
 	case baur.BuildStatusInputsUndefined:
 		return yellowHighlight(status.String())
+	case baur.BuildStatusBuildCommandUndefined:
+		return yellowHighlight(status.String())
 	case baur.BuildStatusExist:
 		return greenHighlight(status.String())
 	case baur.BuildStatusPending:


### PR DESCRIPTION
.app.toml files are now also valid if they have no [Build] section defined.
This allows to use baur for discovering apps in a repository without building
them with baur.

"baur ls apps" shows the status "Build Command Undefined" for apps that have no
[Build] section.
When "baur build" is called, apps without a [Build] section are skipped.

The "baur build" output is now more similar with and without "--force" option.
In both cases it now lists the applications that will be build before starting
the build.
If --force is passed, apps that will be build will be shown with Pending status.

The application list that is printed by "baur build" is now also sorted.