### PR TITLE
Support to specify Build.Inputs in include files

### DIFF
--- a/app.go
+++ b/app.go
@@ -129,7 +129,8 @@ func (a *App) addIncludes(appCfg *cfg.App) error {
 	for _, includeID := range appCfg.Build.InputIncludes {
 		include, exist := a.Repository.Includes[includeID]
 		if !exist {
-			return fmt.Errorf("can not find include with id '%s'", includeID)
+			return fmt.Errorf("include '%s' listed in 'input_includes' does not exist'",
+				includeID)
 		}
 
 		bi := include.ToBuildInput()
@@ -157,7 +158,7 @@ func NewApp(repository *Repository, cfgPath string) (*App, error) {
 	appAbsPath := path.Dir(cfgPath)
 	appRelPath, err := filepath.Rel(repository.Path, appAbsPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "resolving repository relative application path failed")
+		return nil, errors.Wrapf(err, "%s: resolving repository relative application path failed", appCfg.Name)
 	}
 
 	app := App{
@@ -169,18 +170,18 @@ func NewApp(repository *Repository, cfgPath string) (*App, error) {
 	}
 
 	if err := app.setDockerOutputsFromCfg(appCfg); err != nil {
-		return nil, errors.Wrap(err, "processing docker output declarations failed")
+		return nil, errors.Wrapf(err, "%s: processing docker output declarations failed", app.Name)
 	}
 
 	if err := app.setFileOutputsFromCFG(appCfg); err != nil {
-		return nil, errors.Wrap(err, "processing S3 output declarations failed")
+		return nil, errors.Wrapf(err, "%s: processing S3 output declarations failed", app.Name)
 	}
 
 	app.UnresolvedInputs = []*cfg.BuildInput{&appCfg.Build.Input}
 
 	err = app.addIncludes(appCfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing Build.Input includes failed")
+		return nil, errors.Wrapf(err, "%s: processing includes failed", app.Name)
 	}
 
 	return &app, nil

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -3,7 +3,6 @@ package cfg
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/pelletier/go-toml"
@@ -184,27 +183,7 @@ func removeEmptySections(a *App) {
 // ToFile writes an exemplary Application configuration file to
 // filepath. The name setting is set to appName
 func (a *App) ToFile(filepath string) error {
-	data, err := toml.Marshal(*a)
-	if err != nil {
-		return errors.Wrapf(err, "marshalling failed")
-	}
-
-	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(data)
-	if err != nil {
-		return errors.Wrap(err, "writing to file failed")
-	}
-
-	err = f.Close()
-	if err != nil {
-		return errors.Wrap(err, "closing file failed")
-	}
-
-	return err
+	return toFile(a, filepath, false)
 }
 
 // Validate validates a App configuration

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -17,9 +17,10 @@ type App struct {
 
 // Build the build section
 type Build struct {
-	Command string      `toml:"command" commented:"false" comment:"Command to build the application"`
-	Input   BuildInput  `comment:"Specification of build inputs like source files, Makefiles, etc"`
-	Output  BuildOutput `comment:"Specification of build outputs produced by the [Build.command]"`
+	Command       string      `toml:"command" commented:"false" comment:"Command to build the application"`
+	InputIncludes []string    `toml:"input_includes" comment:"IDs of BuildInput includes that the Build inherits."`
+	Input         BuildInput  `comment:"Specification of build inputs like source files, Makefiles, etc"`
+	Output        BuildOutput `comment:"Specification of build outputs produced by the [Build.command]"`
 }
 
 // BuildInput contains information about build inputs

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -31,8 +31,8 @@ type BuildInput struct {
 
 // GolangSources specifies inputs for Golang Applications
 type GolangSources struct {
-	Paths       []string `toml:"paths" comment:"Paths to directories containing Golang source files.\n All source files including imported packages are discovered,\n files from Go's stdlib package and testfiles are ignored." commented:"true"`
 	Environment []string `toml:"environment" comment:"Environment to use when discovering Golang source files\n This can be environment variables understood by the Golang tools, like GOPATH, GOFLAGS, etc.\n If empty the default Go environment is used.\n Valid variables: $ROOT " commented:"true"`
+	Paths       []string `toml:"paths" comment:"Paths to directories containing Golang source files.\n All source files including imported packages are discovered,\n files from Go's stdlib package and testfiles are ignored." commented:"true"`
 }
 
 // FileInputs describes a file source
@@ -48,15 +48,15 @@ type GitFileInputs struct {
 
 // BuildOutput the build output section
 type BuildOutput struct {
-	File        []*FileOutput        `comment:"Files that are produces by the [Build.command]"`
 	DockerImage []*DockerImageOutput `comment:"Docker images that are produced by the [Build.command]"`
+	File        []*FileOutput        `comment:"Files that are produces by the [Build.command]"`
 }
 
 // FileOutput describes where a file artifact should be uploaded to
 type FileOutput struct {
 	Path     string   `toml:"path" comment:"Path relative to the application directory" commented:"true"`
-	S3Upload S3Upload `comment:"Upload the file to S3"`
 	FileCopy FileCopy `comment:"Copy the file to a local directory"`
+	S3Upload S3Upload `comment:"Upload the file to S3"`
 }
 
 // FileCopy describes where a file artifact should be copied to

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -11,11 +11,6 @@ import (
 func toFile(data interface{}, filepath string, overwrite bool) error {
 	var openFlags int
 
-	tomlData, err := toml.Marshal(data)
-	if err != nil {
-		return errors.Wrapf(err, "marshalling failed")
-	}
-
 	if overwrite {
 		openFlags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 	} else {
@@ -27,9 +22,12 @@ func toFile(data interface{}, filepath string, overwrite bool) error {
 		return err
 	}
 
-	_, err = f.Write(tomlData)
+	encoder := toml.NewEncoder(f)
+	encoder.Order(toml.OrderPreserve)
+	err = encoder.Encode(data)
 	if err != nil {
-		return errors.Wrap(err, "writing to file failed")
+		f.Close()
+		return err
 	}
 
 	err = f.Close()

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -1,0 +1,41 @@
+package cfg
+
+import (
+	"os"
+
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
+)
+
+// toFile serializes a struct to TOML format and writes it to a file.
+func toFile(data interface{}, filepath string, overwrite bool) error {
+	var openFlags int
+
+	tomlData, err := toml.Marshal(data)
+	if err != nil {
+		return errors.Wrapf(err, "marshalling failed")
+	}
+
+	if overwrite {
+		openFlags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	} else {
+		openFlags = os.O_WRONLY | os.O_CREATE | os.O_EXCL
+	}
+
+	f, err := os.OpenFile(filepath, openFlags, 0640)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(tomlData)
+	if err != nil {
+		return errors.Wrap(err, "writing to file failed")
+	}
+
+	err = f.Close()
+	if err != nil {
+		return errors.Wrap(err, "closing file failed")
+	}
+
+	return err
+}

--- a/cfg/include.go
+++ b/cfg/include.go
@@ -1,0 +1,80 @@
+package cfg
+
+import (
+	"io/ioutil"
+
+	"github.com/pelletier/go-toml"
+)
+
+// Include represents an include configuration file.
+type Include struct {
+	BuildInput []BuildInputInclude
+}
+
+// TODO: how to prevent duplicating the comment and name  tags here, how to reuse it from the BuildInput struct?
+
+// BuildInputInclude contains information about an includeable BuildInput section.
+type BuildInputInclude struct {
+	ID            string        `toml:"id" comment:"Identifier to reference the include"`
+	Files         FileInputs    `comment:"Inputs specified by file glob paths"`
+	GitFiles      GitFileInputs `comment:"Inputs specified by path, matching only Git tracked files"`
+	GolangSources GolangSources `comment:"Inputs specified by directories containing Golang applications"`
+}
+
+// ExampleInclude returns an Include struct with exemplary values.
+func ExampleInclude() *Include {
+	return &Include{
+		BuildInput: []BuildInputInclude{
+			{
+				ID: "go_app_build_inputs",
+				GolangSources: GolangSources{
+					Paths:       []string{"."},
+					Environment: []string{"GOFLAGS=-mod=vendor", "GO111MODULE=on"},
+				},
+				Files: FileInputs{
+					Paths: []string{".app.toml"},
+				},
+			},
+			{
+				ID: "c_app_build_inputs",
+				Files: FileInputs{
+					Paths: []string{".app.toml"},
+				},
+				GitFiles: GitFileInputs{
+					Paths: []string{"Makefile", "*.c", "include/*.h"},
+				},
+			},
+		},
+	}
+}
+
+// IncludeToFile serializes the Include struct to TOML and writes it to filepath.
+func (in *Include) IncludeToFile(filepath string) error {
+	return toFile(in, filepath, false)
+}
+
+// IncludeFromFile deserializes an Include struct from a file.
+func IncludeFromFile(path string) (*Include, error) {
+	config := Include{}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, err
+}
+
+// ToBuildInput returns a BuildInput struct with values set to the same then in the BuildInputInclude
+func (bi *BuildInputInclude) ToBuildInput() BuildInput {
+	return BuildInput{
+		Files:         bi.Files,
+		GitFiles:      bi.GitFiles,
+		GolangSources: bi.GolangSources,
+	}
+}

--- a/cfg/repository.go
+++ b/cfg/repository.go
@@ -20,6 +20,7 @@ const (
 // Repository contains the repository configuration.
 type Repository struct {
 	ConfigVersion int      `toml:"config_version" comment:"Version of baur configuration format"`
+	IncludeDirs   []string `toml:"include_dirs" commented:"true" comment:"Directories that contain include files for app.toml files"`
 	Database      Database `toml:"Database"`
 	Discover      Discover `comment:"Application discovery settings"`
 }
@@ -56,6 +57,11 @@ func RepositoryFromFile(cfgPath string) (*Repository, error) {
 func ExampleRepository() *Repository {
 	return &Repository{
 		ConfigVersion: configVersion,
+
+		IncludeDirs: []string{
+			"baur_includes/",
+		},
+
 		Discover: Discover{
 			Dirs:        []string{"."},
 			SearchDepth: 1,

--- a/cfg/repository.go
+++ b/cfg/repository.go
@@ -19,9 +19,9 @@ const (
 
 // Repository contains the repository configuration.
 type Repository struct {
-	Discover      Discover `comment:"Application discovery settings"`
 	ConfigVersion int      `toml:"config_version" comment:"Version of baur configuration format"`
 	Database      Database `toml:"Database"`
+	Discover      Discover `comment:"Application discovery settings"`
 }
 
 // Database contains database configuration

--- a/cfg/repository.go
+++ b/cfg/repository.go
@@ -3,7 +3,6 @@ package cfg
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
@@ -72,35 +71,7 @@ func ExampleRepository() *Repository {
 // If overwrite is true an existent file will be overwriten. If it's false the
 // function returns an error if the file exist.
 func (r *Repository) ToFile(filepath string, overwrite bool) error {
-	var openFlags int
-
-	data, err := toml.Marshal(*r)
-	if err != nil {
-		return errors.Wrap(err, "marshalling config failed")
-	}
-
-	if overwrite {
-		openFlags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
-	} else {
-		openFlags = os.O_WRONLY | os.O_CREATE | os.O_EXCL
-	}
-
-	f, err := os.OpenFile(filepath, openFlags, 0640)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(data)
-	if err != nil {
-		return errors.Wrap(err, "writing to file failed")
-	}
-
-	err = f.Close()
-	if err != nil {
-		return errors.Wrap(err, "closing file failed")
-	}
-
-	return err
+	return toFile(r, filepath, overwrite)
 }
 
 // Validate validates a repository configuration

--- a/command/init_include.go
+++ b/command/init_include.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/simplesurance/baur"
 	"github.com/simplesurance/baur/cfg"
+	"github.com/simplesurance/baur/fs"
 	"github.com/simplesurance/baur/log"
 )
 
@@ -30,8 +32,9 @@ var initIncludeCmd = &cobra.Command{
 }
 
 func initInclude(cmd *cobra.Command, args []string) {
-	// TODO: Warn if an include file is created in a directory that is not listed in the IncludeDirs directive of the .baur.toml file?
 	var filename string
+
+	repo := MustFindRepository()
 
 	if len(args) == 1 {
 		filename = args[0]
@@ -51,4 +54,11 @@ func initInclude(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("Include configuration file was written to %s\n",
 		highlight(filename))
+
+	if !fs.PathIsInDirectories(filename, repo.IncludeDirs...) {
+		log.Warnf("File is not in the '%s' defined in the %s file.\n"+
+			"baur will not be able to find the include file.",
+			highlight("include_dirs"),
+			highlight(baur.RepositoryCfgFile))
+	}
 }

--- a/command/init_include.go
+++ b/command/init_include.go
@@ -1,0 +1,54 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simplesurance/baur/cfg"
+	"github.com/simplesurance/baur/log"
+)
+
+func init() {
+	initCmd.AddCommand(initIncludeCmd)
+}
+
+const defIncludeFilename = "includes.toml"
+
+const initIncludeLongHelp = `
+Create an include config file in the current directory.
+If no argument is passed, the file is named +` + defIncludeFilename + `.`
+
+var initIncludeCmd = &cobra.Command{
+	Use:   "include [<FILENAME>]",
+	Short: "create an include config file",
+	Long:  strings.TrimSpace(initIncludeLongHelp),
+	Run:   initInclude,
+	Args:  cobra.MaximumNArgs(1),
+}
+
+func initInclude(cmd *cobra.Command, args []string) {
+	// TODO: Warn if an include file is created in a directory that is not listed in the IncludeDirs directive of the .baur.toml file?
+	var filename string
+
+	if len(args) == 1 {
+		filename = args[0]
+	} else {
+		filename = defIncludeFilename
+	}
+
+	cfg := cfg.ExampleInclude()
+	err := cfg.IncludeToFile(filename)
+	if err != nil {
+		if os.IsExist(err) {
+			log.Fatalf("%s already exist\n", filename)
+		}
+
+		log.Fatalln(err)
+	}
+
+	fmt.Printf("Include configuration file was written to %s\n",
+		highlight(filename))
+}

--- a/command/show.go
+++ b/command/show.go
@@ -84,38 +84,45 @@ func showApp(arg string) {
 		mustWriteRow(formatter, []interface{}{})
 		mustWriteRow(formatter, []interface{}{underline("Inputs:")})
 
-		if len(app.UnresolvedInputs.Files.Paths) > 0 {
-			mustWriteRow(formatter, []interface{}{"", "Type:", highlight("File")})
-			mustWriteRow(formatter, []interface{}{"",
-				"Paths:", highlight(strings.Join(app.UnresolvedInputs.Files.Paths, ", ")),
-			})
+		for _, bi := range app.UnresolvedInputs {
+			if len(bi.Files.Paths) > 0 {
+				if printNewLine {
+					mustWriteRow(formatter, []interface{}{})
+				}
 
-			printNewLine = true
+				mustWriteRow(formatter, []interface{}{"", "Type:", highlight("File")})
+				mustWriteRow(formatter, []interface{}{"",
+					"Paths:", highlight(strings.Join(bi.Files.Paths, ", ")),
+				})
 
-		}
-
-		if len(app.UnresolvedInputs.GitFiles.Paths) > 0 {
-			if printNewLine {
-				mustWriteRow(formatter, []interface{}{})
+				printNewLine = true
 			}
 
-			mustWriteRow(formatter, []interface{}{"", "Type:", highlight("GitFile")})
-			mustWriteRow(formatter, []interface{}{"",
-				"Paths:", highlight(strings.Join(app.UnresolvedInputs.GitFiles.Paths, ", "))})
+			if len(bi.GitFiles.Paths) > 0 {
+				if printNewLine {
+					mustWriteRow(formatter, []interface{}{})
+				}
 
-			printNewLine = true
-		}
+				mustWriteRow(formatter, []interface{}{"", "Type:", highlight("GitFile")})
+				mustWriteRow(formatter, []interface{}{"",
+					"Paths:", highlight(strings.Join(bi.GitFiles.Paths, ", "))})
 
-		if len(app.UnresolvedInputs.GolangSources.Paths) > 0 {
-			if printNewLine {
-				mustWriteRow(formatter, []interface{}{})
+				printNewLine = true
 			}
 
-			mustWriteRow(formatter, []interface{}{"", "Type:", highlight("GolangSources")})
-			mustWriteRow(formatter, []interface{}{"",
-				"Paths:", highlight(strings.Join(app.UnresolvedInputs.GolangSources.Paths, ", "))})
-			mustWriteRow(formatter, []interface{}{"",
-				"Environment:", highlight(strings.Join(app.UnresolvedInputs.GolangSources.Environment, ", "))})
+			if len(bi.GolangSources.Paths) > 0 {
+				if printNewLine {
+					mustWriteRow(formatter, []interface{}{})
+				}
+
+				mustWriteRow(formatter, []interface{}{"", "Type:", highlight("GolangSources")})
+				mustWriteRow(formatter, []interface{}{"",
+					"Paths:", highlight(strings.Join(bi.GolangSources.Paths, ", "))})
+				mustWriteRow(formatter, []interface{}{"",
+					"Environment:", highlight(strings.Join(bi.GolangSources.Environment, ", "))})
+
+				printNewLine = true
+			}
 		}
 	}
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -193,3 +193,27 @@ func FileSize(path string) (int64, error) {
 func Mkdir(path string) error {
 	return os.MkdirAll(path, os.FileMode(0755))
 }
+
+// PathIsInDirectories returns true if path is in one the directories.
+// It does not resolve symlinks.
+func PathIsInDirectories(path string, directory ...string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	for _, dir := range directory {
+		absDir := filepath.Clean(dir)
+
+		if absPath == absDir {
+			return true
+		}
+
+		if filepath.Dir(absPath) == absDir {
+			return true
+		}
+
+	}
+
+	return false
+}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,0 +1,82 @@
+package fs
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPathIsInDirectories(t *testing.T) {
+	tests := []struct {
+		name         string
+		pathArg      string
+		directoryArg []string
+		want         bool
+	}{
+		{
+			"inPathLastDir",
+			"/tmp/test.log",
+			[]string{"/var/", "/tmp/"},
+			true,
+		},
+
+		{
+			"inPathFirstDir",
+			"/tmp/test.log",
+			[]string{"/tmp", "/var"},
+			true,
+		},
+
+		{
+			"DirInDir",
+			"/tmp",
+			[]string{"/etc", "/tmp/"},
+			true,
+		},
+
+		{
+			"NotInPaths",
+			"/tmp/test.log",
+			[]string{"/etc/", "/var/"},
+			false,
+		},
+
+		{
+			"NotInPathPartMatches",
+			"/tmp/etc/test.log",
+			[]string{"/etc/", "/var/"},
+			false,
+		},
+
+		{
+			"NoDirectoriesPassed",
+			"/tmp/test.log",
+			[]string{},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PathIsInDirectories(tt.pathArg, tt.directoryArg...); got != tt.want {
+				t.Errorf("PathIsInDirectories() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathIsInDirectories_Rel(t *testing.T) {
+	err := os.Chdir("/tmp/")
+	if err != nil {
+		t.Fatal("chdir failed", err.Error())
+	}
+
+	inDir := PathIsInDirectories("log.txt", "/tmp")
+	if !inDir {
+		t.Error("PathIsInDirectories returned false when file is in relPath")
+	}
+
+	inDir = PathIsInDirectories("log.txt", "/etc")
+	if inDir {
+		t.Error("PathIsInDirectories returned true, when path of current dir was not passed")
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,7 @@ import (
 )
 
 var errorPrefix = color.New(color.FgRed).Sprint("ERROR: ")
+var warnPrefix = color.New(color.FgYellow).Sprint("WARN: ")
 
 // Logger logs messages
 type Logger struct {
@@ -86,6 +87,11 @@ func (l *Logger) Errorf(format string, v ...interface{}) {
 	l.logger.Printf(errorPrefix+" "+format, v...)
 }
 
+// Warnf logs a message to stderr
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	l.logger.Printf(warnPrefix+format, v...)
+}
+
 // Infoln logs a message to stdout
 /*
 func (l *Logger) Infoln(v ...interface{}) {
@@ -135,6 +141,11 @@ func Errorln(v ...interface{}) {
 // Errorf logs a message to stderr
 func Errorf(format string, v ...interface{}) {
 	StdLogger.Errorf(format, v...)
+}
+
+// Warnf logs a message to stderr
+func Warnf(format string, v ...interface{}) {
+	StdLogger.Warnf(format, v...)
 }
 
 // Infoln logs a message to stdout

--- a/repository.go
+++ b/repository.go
@@ -113,7 +113,8 @@ func NewRepository(cfgPath string) (*Repository, error) {
 
 	err = fs.DirsExist(r.AppSearchDirs...)
 	if err != nil {
-		return nil, errors.Wrap(err, "application_dirs parameter is invalid")
+		return nil, errors.Wrapf(err, "validating repository config %q failed, "+
+			"application_dirs parameter is invalid", cfgPath)
 	}
 
 	err = r.populateIncludes(cfg)

--- a/repository.go
+++ b/repository.go
@@ -23,6 +23,7 @@ type Repository struct {
 	gitWorktreeIsDirty *bool
 	PSQLURL            string
 	Includes           map[string]cfg.BuildInputInclude
+	IncludeDirs        []string
 }
 
 // FindRepository searches for a repository config file. The search starts in
@@ -109,6 +110,7 @@ func NewRepository(cfgPath string) (*Repository, error) {
 		AppSearchDirs: fs.PathsJoin(path.Dir(cfgPath), cfg.Discover.Dirs),
 		SearchDepth:   cfg.Discover.SearchDepth,
 		PSQLURL:       cfg.Database.PGSQLURL,
+		IncludeDirs:   fs.PathsJoin(path.Dir(cfgPath), cfg.IncludeDirs),
 	}
 
 	err = fs.DirsExist(r.AppSearchDirs...)


### PR DESCRIPTION
This PR adds support for specifying build input in include files (https://github.com/simplesurance/baur/issues/76).
The `.baur.toml` got a new setting `include_dirs` to specify a list of directories that can contain include files.
The command `baur init include` creates a new exemplary include file.
The include file can contain multiple `BuildInput` sections, with the same members then in the `.app.toml` plus an additional `id` field.
The `id` field is used to reference the include section in an `.app.toml` file.

Example Include file:
```toml
[[BuildInput]]
  # Identifier to reference the include
  id = "go_app_build_inputs"

  [BuildInput.Files]
    paths = [".app.toml", ".build.sh"]

  [BuildInput.GolangSources]
    environment = ["GOFLAGS=-mod=vendor","GO111MODULE=on"]
    paths = ["."]
```

Use in `.app.toml` file:
```toml
name = "claim-service"

[Build]
  command = "./build ci_build"
  input_includes = ["go_default_build_inputs"]

  [Build.Output]
    [[Build.Output.File]]
      path = "dist/claim-service.tar.xz"

      [Build.Output.File.S3Upload]
        bucket = "apps"
        dest_file = "$APPNAME-$GITCOMMIT.tar.xz"
```