### PR TITLE
Fix parseRepositoryURI to accept URIs formatted as gcr.io/a/b/c/...

### DIFF
--- a/upload/docker/docker.go
+++ b/upload/docker/docker.go
@@ -148,7 +148,7 @@ func (c *Client) getAuth(server string) docker.AuthConfiguration {
 // parseRepositoryURI splits a URI in the format:
 // [<host[:port]>]/<owner>/<repository>:<tag> into it's parts
 func parseRepositoryURI(dest string) (server, repository, tag string, err error) {
-	spl := strings.Split(dest, "/")
+	spl := strings.SplitN(dest, "/", 3)
 	if len(spl) == 3 {
 		server = spl[0]
 		repository = spl[1] + "/" + spl[2]
@@ -193,6 +193,7 @@ func (c *Client) Upload(image, destURI string) (string, error) {
 	outStream := bufio.NewWriter(&outBuf)
 
 	err = c.clt.PushImage(docker.PushImageOptions{
+        Registry:   server,
 		Name:         repository,
 		Tag:          tag,
 		OutputStream: outStream,

--- a/upload/docker/docker.go
+++ b/upload/docker/docker.go
@@ -193,7 +193,7 @@ func (c *Client) Upload(image, destURI string) (string, error) {
 	outStream := bufio.NewWriter(&outBuf)
 
 	err = c.clt.PushImage(docker.PushImageOptions{
-        Registry:   server,
+		Registry:  		server,
 		Name:         repository,
 		Tag:          tag,
 		OutputStream: outStream,

--- a/upload/docker/docker_test.go
+++ b/upload/docker/docker_test.go
@@ -36,7 +36,13 @@ func Test_parseRepositoryURI(t *testing.T) {
 			wantRepository: "simplesurance/calculator",
 			wantTag:        "latest",
 		},
-
+		{
+			name:           "serverWithPortLongRepo",
+			destArg:        "localhost/simplesurance/app/calculator:latest",
+			wantServer:     "localhost",
+			wantRepository: "simplesurance/app/calculator",
+			wantTag:        "latest",
+		},
 		{
 			name:    "emptyArg",
 			wantErr: true,


### PR DESCRIPTION
The fix was done by using `strings.SplitN` and limit the splits to 3. 

This is in attempt to fix https://github.com/simplesurance/baur/issues/96