### PR TITLE
fs: only return true from IsFile(), if it is a regular file

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -19,7 +19,7 @@ func IsFile(path string) (bool, error) {
 		return false, err
 	}
 
-	return !fi.IsDir(), nil
+	return fi.Mode().IsRegular(), nil
 }
 
 // FileExists returns true if path exist and is a file


### PR DESCRIPTION
```
        fs: only return true from IsFile(), if it is a regular file
        
        The function was returning true if the path was not pointing to a directory.
        If it was a device file, symlink or socket it was returning true.
        
        Change the function to only return true if it's a regular file.
        

```