### PR TITLE
Decouple App and Repository, introduce AppLoader type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: baur
+          POSTGRES_HOST_AUTH_METHOD: trust
 
     working_directory: ~/baur
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           TEST_RESULTS: /tmp/test-results
           BAUR_POSTGRESQL_URL: "postgres://root@localhost:5432/baur?sslmode=disable"
 
-      - image: circleci/postgres:10
+      - image: circleci/postgres:12
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: baur

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dist/**
 *~
 *.swp
 *.swo
+
+*.orig

--- a/apploader.go
+++ b/apploader.go
@@ -1,0 +1,263 @@
+package baur
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/simplesurance/baur/cfg"
+	"github.com/simplesurance/baur/fs"
+)
+
+type Logger interface {
+	Debugf(format string, v ...interface{})
+}
+
+// AppLoader discovers and instantiates apps in a repository.
+type AppLoader struct {
+	logger          Logger
+	includeDB       *cfg.IncludeDB
+	repositoryRoot  string
+	appConfigPaths  []string
+	gitCommitIDFunc func() (string, error)
+}
+
+// NewAppLoader instantiates an AppLoader.
+// When an app config is loaded the DefaultResolvers are applied on the content
+// before they are merged with their includes.
+// The gitCommitIDFunc is used as config resolved to resolve $GITCOMMIT variables.
+func NewAppLoader(repoCfg *cfg.Repository, gitCommitIDFunc func() (string, error), logger Logger) (*AppLoader, error) {
+	repositoryRootDir := filepath.Dir(repoCfg.FilePath())
+
+	appConfigPaths, err := findAppConfigs(fs.AbsPaths(repositoryRootDir, repoCfg.Discover.Dirs), repoCfg.Discover.SearchDepth)
+	if err != nil {
+		return nil, fmt.Errorf("discovering application config files failed: %w", err)
+	}
+
+	logger.Debugf("apploader: found the following application configs:\n%s", strings.Join(appConfigPaths, "\n"))
+
+	return &AppLoader{
+		logger:          logger,
+		repositoryRoot:  repositoryRootDir,
+		includeDB:       cfg.NewIncludeDB(logger),
+		appConfigPaths:  appConfigPaths,
+		gitCommitIDFunc: gitCommitIDFunc,
+	}, nil
+}
+
+// splitSpecifiers splits the specifiers by apps to load by Name or by Path.
+// If the specifiers contain a '*' specifier, nil slices are returned and star is true.
+func splitSpecifiers(specifiers []string) (names, cfgPaths []string, star bool) {
+	for _, spec := range specifiers {
+		if spec == "*" {
+			return nil, nil, true
+		}
+
+		cfgPath, isAppDir := IsAppDirectory(spec)
+		if isAppDir {
+			cfgPaths = append(cfgPaths, cfgPath)
+
+			continue
+		}
+
+		names = append(names, spec)
+	}
+
+	return names, cfgPaths, false
+}
+
+// Load loads the apps that match the passed specifiers.
+// Valid specifiers are:
+// - application directory path
+// - <APP-NAME>
+// - '*'
+// If multiple specifiers match the same app, it's only returned 1x in the returned slice.
+func (a *AppLoader) Load(specifier ...string) ([]*App, error) {
+	names, cfgPaths, star := splitSpecifiers(specifier)
+
+	if star {
+		return a.All()
+	}
+
+	result := make([]*App, 0, len(specifier))
+	for _, path := range cfgPaths {
+		app, err := a.Path(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+
+		result = append(result, app)
+	}
+
+	apps, err := a.AppNames(names...)
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result, apps...)
+
+	return dedupApps(result), nil
+}
+
+// AppNames discovers and loads the apps with the given names.
+func (a *AppLoader) AppNames(names ...string) ([]*App, error) {
+	namesMap := make(map[string]struct{}, len(names))
+	result := make([]*App, 0, len(names))
+
+	a.logger.Debugf("apploader: loading app %q", names)
+
+	for _, name := range names {
+		namesMap[name] = struct{}{}
+	}
+
+	for _, path := range a.appConfigPaths {
+		if len(namesMap) == 0 {
+			return result, nil
+		}
+
+		path, err := filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+
+		appCfg, err := cfg.AppFromFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+
+		if _, exist := namesMap[appCfg.Name]; !exist {
+			continue
+		}
+
+		app, err := a.fromCfg(appCfg)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+
+		result = append(result, app)
+
+		delete(namesMap, appCfg.Name)
+	}
+
+	notFoundApps := make([]string, 0, len(namesMap))
+	for name := range namesMap {
+		notFoundApps = append(notFoundApps, name)
+	}
+
+	if len(notFoundApps) != 0 {
+		return nil, fmt.Errorf("could not find the following apps: %s", strings.Join(names, ", "))
+	}
+
+	return result, nil
+}
+
+// All loads all apps in the repository.
+func (a *AppLoader) All() ([]*App, error) {
+	a.logger.Debugf("apploader: loading all apps")
+
+	result := make([]*App, 0, len(a.appConfigPaths))
+
+	for _, path := range a.appConfigPaths {
+		app, err := a.Path(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+
+		result = append(result, app)
+	}
+
+	return result, nil
+}
+
+// Path loads the app from the config file.
+func (a *AppLoader) Path(appConfigPath string) (*App, error) {
+	a.logger.Debugf("apploader: loading app from %q", appConfigPath)
+
+	appConfigPath, err := filepath.Abs(appConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	appCfg, err := cfg.AppFromFile(appConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.fromCfg(appCfg)
+}
+
+func (a *AppLoader) fromCfg(appCfg *cfg.App) (*App, error) {
+	includeResolvers := IncludeCfgVarResolvers(a.repositoryRoot, appCfg.Name)
+
+	err := appCfg.Merge(a.includeDB, includeResolvers)
+	if err != nil {
+		return nil, fmt.Errorf("merging includes failed: %w", err)
+	}
+
+	resolvers := DefaultAppCfgResolvers(a.repositoryRoot, appCfg.Name, a.gitCommitIDFunc)
+	err = appCfg.Resolve(resolvers)
+	if err != nil {
+		return nil, fmt.Errorf("resolving variables in config failed: %w", err)
+	}
+
+	err = appCfg.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("validation failed: %w", err)
+	}
+
+	app, err := NewApp(appCfg, a.repositoryRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return app, nil
+}
+
+// IsAppDirectory returns true and the path to the app config file if the
+// directory contains an app config file.
+func IsAppDirectory(dir string) (string, bool) {
+	cfgPath := path.Join(dir, AppCfgFile)
+	isFile, _ := fs.IsFile(cfgPath)
+
+	return cfgPath, isFile
+}
+
+func findAppConfigs(searchDirs []string, searchDepth int) ([]string, error) {
+	var result []string
+
+	for _, searchDir := range searchDirs {
+		if err := fs.DirsExist(searchDir); err != nil {
+			return nil, fmt.Errorf("application search directory: %w", err)
+		}
+
+		cfgPaths, err := fs.FindFilesInSubDir(searchDir, AppCfgFile, searchDepth)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, cfgPaths...)
+	}
+
+	return result, nil
+}
+
+func dedupApps(apps []*App) []*App {
+	dedupMap := make(map[string]*App, len(apps))
+
+	for _, app := range apps {
+		if _, exist := dedupMap[app.Path]; exist {
+			continue
+		}
+
+		dedupMap[app.Path] = app
+	}
+
+	result := make([]*App, 0, len(dedupMap))
+
+	for _, app := range dedupMap {
+		result = append(result, app)
+	}
+
+	return result
+}

--- a/apploader.go
+++ b/apploader.go
@@ -146,7 +146,7 @@ func (a *AppLoader) AppNames(names ...string) ([]*App, error) {
 	}
 
 	if len(notFoundApps) != 0 {
-		return nil, fmt.Errorf("could not find the following apps: %s", strings.Join(names, ", "))
+		return nil, fmt.Errorf("could not find the following apps: %s", strings.Join(notFoundApps, ", "))
 	}
 
 	return result, nil

--- a/cfg_resolvers.go
+++ b/cfg_resolvers.go
@@ -10,11 +10,11 @@ const (
 )
 
 // DefaultAppCfgResolvers returns the default set of resolvers that is applied on application configs.
-func DefaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string, error)) resolver.Resolver {
+func DefaultAppCfgResolvers(rootPath, appName, gitCommit string) resolver.Resolver {
 	return resolver.List{
 		&resolver.StrReplacement{Old: appVarName, New: appName},
 		&resolver.StrReplacement{Old: rootVarName, New: rootPath},
 		&resolver.UUIDVar{Old: uuidVarname},
-		&resolver.CallbackReplacement{Old: gitCommitVarname, NewFunc: gitCommitFn},
+		&resolver.StrReplacement{Old: gitCommitVarname, New: gitCommit},
 	}
 }

--- a/cfg_resolvers.go
+++ b/cfg_resolvers.go
@@ -10,11 +10,20 @@ const (
 )
 
 // DefaultAppCfgResolvers returns the default set of resolvers that is applied on application configs.
-func DefaultAppCfgResolvers(rootPath, appName, gitCommit string) resolver.Resolver {
+func DefaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string, error)) resolver.Resolver {
 	return resolver.List{
 		&resolver.StrReplacement{Old: appVarName, New: appName},
 		&resolver.StrReplacement{Old: rootVarName, New: rootPath},
 		&resolver.UUIDVar{Old: uuidVarname},
-		&resolver.StrReplacement{Old: gitCommitVarname, New: gitCommit},
+		&resolver.CallbackReplacement{Old: gitCommitVarname, NewFunc: gitCommitFn},
+	}
+}
+
+// IncludeCfgVarResolvers returns the default resolvers for variables in the
+// Includes field in config files.
+func IncludeCfgVarResolvers(rootPath, appName string) resolver.Resolver {
+	return resolver.List{
+		&resolver.StrReplacement{Old: appVarName, New: appName},
+		&resolver.StrReplacement{Old: rootVarName, New: rootPath},
 	}
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -193,3 +193,15 @@ func FileSize(path string) (int64, error) {
 func Mkdir(path string) error {
 	return os.MkdirAll(path, os.FileMode(0755))
 }
+
+// AbsPaths prepends to all paths in relPaths the passed rootPath.
+func AbsPaths(rootPath string, relPaths []string) []string {
+	result := make([]string, 0, len(rootPath))
+
+	for _, relPath := range relPaths {
+		absPath := filepath.Join(rootPath, relPath)
+		result = append(result, absPath)
+	}
+
+	return result
+}

--- a/git/git.go
+++ b/git/git.go
@@ -67,9 +67,9 @@ func LsFiles(dir string, arg ...string) (string, error) {
 	return res.StrOutput(), nil
 }
 
-// WorkTreeIsDirty returns true if the repository contains modified files,
+// WorktreeIsDirty returns true if the repository contains modified files,
 // untracked files are considered, files in .gitignore are ignored
-func WorkTreeIsDirty(dir string) (bool, error) {
+func WorktreeIsDirty(dir string) (bool, error) {
 	res, err := exec.Command("git", "status", "-s").Directory(dir).ExpectSuccess().Run()
 	if err != nil {
 		return false, err

--- a/git/state.go
+++ b/git/state.go
@@ -1,0 +1,59 @@
+package git
+
+import (
+	"sync"
+)
+
+// RepositoryState lazyLoads and caches the commitID and worktree state of a Git repository.
+type RepositoryState struct {
+	path string
+
+	lock            sync.Mutex
+	commitID        *string
+	worktreeIsDirty *bool
+}
+
+// NewRepositoryState initializes a RepositoryState for the given git repository.
+func NewRepositoryState(repositoryPath string) *RepositoryState {
+	return &RepositoryState{
+		path: repositoryPath,
+	}
+}
+
+// GitCommitID calls git.CommitID() for the repository.
+// After the first successful call the commit ID is stored and the stored value
+// is returned on successive calls.
+func (g *RepositoryState) CommitID() (string, error) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	if g.commitID == nil {
+		commitID, err := CommitID(g.path)
+		if err != nil {
+			return "", err
+		}
+
+		g.commitID = &commitID
+	}
+
+	return *g.commitID, nil
+}
+
+// WorktreeIsDirty calls git.WorktreeIsDirty.
+// After the first successful call the result is stored and the stored value is
+// returned on successive calls.
+func (g *RepositoryState) WorktreeIsDirty() (bool, error) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	if g.worktreeIsDirty == nil {
+		isDirty, err := WorktreeIsDirty(g.path)
+		if err != nil {
+			return false, err
+		}
+
+		g.worktreeIsDirty = &isDirty
+	}
+
+	return *g.worktreeIsDirty, nil
+}

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -120,24 +120,6 @@ func MustGetPostgresClt(r *baur.Repository) *postgres.Client {
 	return clt
 }
 
-func mustGetCommitID(r *baur.Repository) string {
-	commitID, err := r.GitCommitID()
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	return commitID
-}
-
-func mustGetGitWorktreeIsDirty(r *baur.Repository) bool {
-	isDirty, err := r.GitWorkTreeIsDirty()
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	return isDirty
-}
-
 func vcsStr(v *storage.VCSState) string {
 	if len(v.CommitID) == 0 {
 		return ""

--- a/repository.go
+++ b/repository.go
@@ -3,26 +3,23 @@ package baur
 import (
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/cfg"
 	"github.com/simplesurance/baur/fs"
-	"github.com/simplesurance/baur/git"
 	"github.com/simplesurance/baur/log"
 )
 
 // Repository represents an repository containing applications
 type Repository struct {
-	Path               string
-	CfgPath            string
-	AppSearchDirs      []string
-	SearchDepth        int
-	PSQLURL            string
-	includeDB          *cfg.IncludeDB
-	GitCommitID        string
-	GitWorktreeIsDirty bool
+	Path          string
+	CfgPath       string
+	Cfg           *cfg.Repository
+	AppSearchDirs []string
+	SearchDepth   int
+	PSQLURL       string
+	includeDB     *cfg.IncludeDB
 }
 
 // FindRepository searches for a repository config file. The search starts in
@@ -63,29 +60,14 @@ func NewRepository(cfgPath string) (*Repository, error) {
 	}
 	repoPath := path.Dir(cfgPath)
 
-	gitCommit, err := git.CommitID(repoPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "determining Git commit ID failed, "+
-			"ensure that the git command is in a directory in $PATH and "+
-			"that the .baur.toml file is part of a git repository")
-	}
-
-	worktreeIsDirty, err := git.WorktreeIsDirty(repoPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "determining Git worktree state failed, "+
-			"ensure that the git command is in a directory in $PATH and "+
-			"that the .baur.toml file is part of a git repository")
-	}
-
 	r := Repository{
-		CfgPath:            cfgPath,
-		Path:               repoPath,
-		AppSearchDirs:      fs.PathsJoin(path.Dir(cfgPath), repoCfg.Discover.Dirs),
-		SearchDepth:        repoCfg.Discover.SearchDepth,
-		PSQLURL:            repoCfg.Database.PGSQLURL,
-		includeDB:          cfg.NewIncludeDB(log.StdLogger),
-		GitCommitID:        gitCommit,
-		GitWorktreeIsDirty: worktreeIsDirty,
+		Cfg:           repoCfg,
+		CfgPath:       cfgPath,
+		Path:          repoPath,
+		AppSearchDirs: fs.PathsJoin(repoPath, repoCfg.Discover.Dirs),
+		SearchDepth:   repoCfg.Discover.SearchDepth,
+		PSQLURL:       repoCfg.Database.PGSQLURL,
+		includeDB:     cfg.NewIncludeDB(log.StdLogger),
 	}
 
 	err = fs.DirsExist(r.AppSearchDirs...)
@@ -95,64 +77,4 @@ func NewRepository(cfgPath string) (*Repository, error) {
 	}
 
 	return &r, nil
-}
-
-// FindApps searches for application config files in the AppSearchDirs of the
-// repository and returns all found apps
-func (r *Repository) FindApps() ([]*App, error) {
-	var result []*App
-
-	for _, searchDir := range r.AppSearchDirs {
-		appsCfgPaths, err := fs.FindFilesInSubDir(searchDir, AppCfgFile, r.SearchDepth)
-		if err != nil {
-			return nil, errors.Wrap(err, "finding application configs failed")
-		}
-
-		for _, appCfgPath := range appsCfgPaths {
-			a, err := NewApp(r.includeDB, r.Path, appCfgPath, r.GitCommitID)
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, a)
-		}
-	}
-
-	return result, nil
-}
-
-// AppByDir reads an application config file from the direcory and returns an
-// App
-func (r *Repository) AppByDir(appDir string) (*App, error) {
-	cfgPath := path.Join(appDir, AppCfgFile)
-
-	cfgPath, err := filepath.Abs(cfgPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewApp(r.includeDB, r.Path, cfgPath, r.GitCommitID)
-}
-
-// AppByName searches for an App with the given name in the repository and
-// returns it. If none is found os.ErrNotExist is returned.
-func (r *Repository) AppByName(name string) (*App, error) {
-	for _, searchDir := range r.AppSearchDirs {
-		appsCfgPaths, err := fs.FindFilesInSubDir(searchDir, AppCfgFile, r.SearchDepth)
-		if err != nil {
-			return nil, errors.Wrap(err, "finding application failed")
-		}
-
-		for _, appCfgPath := range appsCfgPaths {
-			a, err := NewApp(r.includeDB, r.Path, appCfgPath, r.GitCommitID)
-			if err != nil {
-				return nil, err
-			}
-			if a.Name == name {
-				return a, nil
-			}
-		}
-	}
-
-	return nil, os.ErrNotExist
 }

--- a/resolve/gitpath/gitpaths.go
+++ b/resolve/gitpath/gitpaths.go
@@ -12,23 +12,23 @@ import (
 // git ls-files.
 // Glob path only resolve to files that are tracked in the repository.
 type Resolver struct {
-	path  string
-	globs []string
+	workingDir string
+	globs      []string
 }
 
 // NewResolver returns a resolver that resolves the passed git glob paths to absolute
 // paths
-func NewResolver(path string, globs ...string) *Resolver {
+func NewResolver(workingDir string, globs ...string) *Resolver {
 	return &Resolver{
-		path:  path,
-		globs: globs,
+		workingDir: workingDir,
+		globs:      globs,
 	}
 }
 
 // Resolve the glob paths to absolute file paths by calling
 // git ls-files
 func (r *Resolver) Resolve() ([]string, error) {
-	out, err := git.LsFiles(r.path, r.globs...)
+	out, err := git.LsFiles(r.workingDir, r.globs...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func (r *Resolver) Resolve() ([]string, error) {
 	res := make([]string, 0, len(relPaths))
 
 	for _, relPath := range relPaths {
-		absPath := filepath.Join(r.path, relPath)
+		absPath := filepath.Join(r.workingDir, relPath)
 
 		isFile, err := fs.IsFile(absPath)
 		if err != nil {


### PR DESCRIPTION
```
Author: Fabian Holler
Committer: Fabian Holler

        move discovering and loading Apps to AppLoader
        
        The functionality to discover and load apps from configs is moved from the
        Repository type to an own AppLoader type.
        
-------------------------------------------------------------------------------
Author: Fabian Holler
Committer: Fabian Holler

        decouple App from Repository
        
        Remove the reference from the App to the Repository type.
        This will make it easier to refactor App for implementing the task type.
        
-------------------------------------------------------------------------------
Author: Fabian Holler
Committer: Fabian Holler

        resolver: improve parameter names of gitpath resolver
        
-------------------------------------------------------------------------------
Author: Fabian Holler
Committer: Fabian Holler

        git: rename WorkTreeIsDirty to WorktreeIsDirty
        
        It's not a tree.
        
-------------------------------------------------------------------------------
Author: Fabian Holler
Committer: Fabian Holler

        gitignore: add *.orig files

```

- includedb not referenced in the Repository object anymore, it can be garbage collected after the app discovery phase finished
- The commit ID is during a `baur build` invocation now evaluated up to 2x instead of only 1x.