### PR TITLE
Introduce baur.Task type

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,111 +5,25 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/cfg"
-	"github.com/simplesurance/baur/digest"
-	"github.com/simplesurance/baur/digest/sha384"
-	"github.com/simplesurance/baur/log"
-	"github.com/simplesurance/baur/resolve/gitpath"
-	"github.com/simplesurance/baur/resolve/glob"
-	"github.com/simplesurance/baur/resolve/gosource"
-	"github.com/simplesurance/baur/upload/scheduler"
 )
 
 // App represents an application
 type App struct {
-	RelPath          string
-	Path             string
-	Name             string
-	BuildCmd         string
-	Outputs          []BuildOutput
-	totalInputDigest *digest.Digest
-
-	UnresolvedInputs []*cfg.Input
-	buildInputs      []*File
+	RelPath string
+	Path    string
+	Name    string
 
 	repositoryRootPath string
-}
 
-func (a *App) addBuildOutput(buildOutput *cfg.Output) error {
-	if err := a.addDockerBuildOutputs(buildOutput); err != nil {
-		return errors.Wrap(err, "error in DockerImage section")
-	}
-
-	if err := a.addFileOutputs(buildOutput); err != nil {
-		return errors.Wrap(err, "error in File section")
-	}
-
-	return nil
-}
-
-func (a *App) addDockerBuildOutputs(buildOutput *cfg.Output) error {
-	for _, di := range buildOutput.DockerImage {
-		a.Outputs = append(a.Outputs, &DockerArtifact{
-			ImageIDFile: path.Join(a.Path, di.IDFile),
-			Tag:         di.RegistryUpload.Tag,
-			Repository:  di.RegistryUpload.Repository,
-			Registry:    di.RegistryUpload.Registry,
-		})
-	}
-
-	return nil
-}
-
-func (a *App) addFileOutputs(buildOutput *cfg.Output) error {
-	for _, f := range buildOutput.File {
-		filePath := f.Path
-		if !f.S3Upload.IsEmpty() {
-			url := "s3://" + f.S3Upload.Bucket + "/" + f.S3Upload.DestFile
-
-			src := path.Join(a.Path, filePath)
-
-			a.Outputs = append(a.Outputs, &FileArtifact{
-				RelPath:   path.Join(a.RelPath, filePath),
-				Path:      src,
-				DestFile:  f.S3Upload.DestFile,
-				UploadURL: url,
-				uploadJob: &scheduler.S3Job{
-					DestURL:  url,
-					FilePath: src,
-				},
-			})
-		}
-
-		if !f.FileCopy.IsEmpty() {
-			src := path.Join(a.Path, filePath)
-
-			a.Outputs = append(a.Outputs, &FileArtifact{
-				RelPath:   path.Join(a.RelPath, filePath),
-				Path:      src,
-				DestFile:  f.FileCopy.Path,
-				UploadURL: f.FileCopy.Path,
-				uploadJob: &scheduler.FileCopyJob{
-					Src: src,
-					Dst: f.FileCopy.Path,
-				},
-			})
-		}
-	}
-
-	return nil
-}
-
-func (a *App) addCfgsToBuildInputs(appCfg *cfg.App) {
-	buildInput := cfg.Input{}
-	buildInput.Files.Paths = append(buildInput.Files.Paths, AppCfgFile)
-
-	a.UnresolvedInputs = append(a.UnresolvedInputs, &buildInput)
+	cfg *cfg.App
 }
 
 // NewApp reads the configuration file and returns a new App
 func NewApp(appCfg *cfg.App, repositoryRootPath string) (*App, error) {
-	var buildCommand string
-	var buildTask *cfg.Task
-
 	appDir := path.Dir(appCfg.FilePath())
 
 	appRelPath, err := filepath.Rel(repositoryRootPath, appDir)
@@ -122,34 +36,18 @@ func NewApp(appCfg *cfg.App, repositoryRootPath string) (*App, error) {
 	}
 
 	if len(appCfg.Tasks) == 1 {
-		buildTask = appCfg.Tasks[0]
-
-		if buildTask.Name != "build" {
-			return nil, fmt.Errorf("%s: has a task defined with name %q, only 1 task definition with name 'build' is currently allowed", appCfg.Name, buildTask.Name)
+		if appCfg.Tasks[0].Name != "build" {
+			return nil, fmt.Errorf("%s: has a task defined with name %q, only 1 task definition with name 'build' is currently allowed", appCfg.Name, appCfg.Tasks[0].Name)
 		}
-
-		buildCommand = buildTask.Command
 	}
 
 	app := App{
+		cfg:                appCfg,
 		Path:               appDir,
 		RelPath:            appRelPath,
 		Name:               appCfg.Name,
-		BuildCmd:           strings.TrimSpace(buildCommand),
 		repositoryRootPath: repositoryRootPath,
 	}
-
-	if buildTask == nil {
-		return &app, nil
-	}
-
-	err = app.addBuildOutput(&buildTask.Output)
-	if err != nil {
-		return nil, errors.Wrapf(err, "%s: processing Task.Output section failed", app.Name)
-	}
-
-	app.UnresolvedInputs = []*cfg.Input{&buildTask.Input}
-	app.addCfgsToBuildInputs(appCfg)
 
 	return &app, nil
 }
@@ -159,207 +57,21 @@ func (a *App) String() string {
 	return a.Name
 }
 
-func (a *App) pathsToUniqFiles(workingDir string, paths []string) ([]*File, error) {
-	dedupMap := make(map[string]struct{}, len(paths))
-	res := make([]*File, 0, len(paths))
+func (a *App) Task() *Task {
+	result := make([]*Task, 0, len(a.cfg.Tasks))
 
-	for _, path := range paths {
-		if _, exist := dedupMap[path]; exist {
-			log.Debugf("%s: removed duplicate Build Input '%s'", a.Name, path)
-			continue
-		}
-		dedupMap[path] = struct{}{}
-
-		relPath, err := filepath.Rel(workingDir, path)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO: should resolving the relative path be done in
-		// Newfile() instead?
-		res = append(res, NewFile(workingDir, relPath))
+	for _, taskCfg := range a.cfg.Tasks {
+		task := NewTask(taskCfg, a.Name, a.repositoryRootPath, a.Path)
+		result = append(result, task)
 	}
 
-	return res, nil
-}
-
-func (a *App) resolveGlobFileInputs() ([]string, error) {
-	var res []string
-
-	for _, bi := range a.UnresolvedInputs {
-		for _, globPath := range bi.Files.Paths {
-			if !filepath.IsAbs(globPath) {
-				globPath = filepath.Join(a.Path, globPath)
-			}
-
-			resolver := glob.NewResolver(globPath)
-			paths, err := resolver.Resolve()
-			if err != nil {
-				return nil, errors.Wrap(err, globPath)
-			}
-
-			if len(paths) == 0 {
-				return nil, fmt.Errorf("'%s' matched 0 files", globPath)
-			}
-
-			res = append(res, paths...)
-		}
+	// TODO: return a []*Task and remove this check when the db and
+	// commands are able to handle multiple tasks.
+	if len(result) != 1 {
+		panic(fmt.Sprintf("%s: found %d tasks, expected 1", a.Name, len(result)))
 	}
 
-	return res, nil
-}
-
-func (a *App) resolveGitFileInputs() ([]string, error) {
-	var res []string
-
-	for _, bi := range a.UnresolvedInputs {
-		if len(bi.GitFiles.Paths) == 0 {
-			continue
-		}
-
-		resolver := gitpath.NewResolver(a.Path, bi.GitFiles.Paths...)
-		paths, err := resolver.Resolve()
-		if err != nil {
-			return nil, err
-		}
-
-		if len(paths) == 0 {
-			return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(paths, ", "))
-		}
-		res = append(res, paths...)
-	}
-
-	return res, nil
-}
-
-func (a *App) resolveGoSrcInputs() ([]string, error) {
-	var res []string
-
-	for _, bi := range a.UnresolvedInputs {
-		if len(bi.GolangSources.Paths) == 0 {
-			continue
-		}
-
-		absGoSourcePaths := make([]string, 0, len(bi.GolangSources.Paths))
-		for _, relGosrcpath := range bi.GolangSources.Paths {
-			absPath := path.Join(a.Path, relGosrcpath)
-			absGoSourcePaths = append(absGoSourcePaths, absPath)
-		}
-
-		resolver := gosource.NewResolver(log.Debugf, bi.GolangSourcesInputs().Environment, absGoSourcePaths...)
-		paths, err := resolver.Resolve()
-		if err != nil {
-			return nil, err
-		}
-
-		if len(paths) == 0 {
-			return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(paths, ", "))
-		}
-
-		res = append(res, paths...)
-	}
-
-	return res, nil
-}
-
-func (a *App) resolveBuildInputPaths() ([]string, error) {
-	globPaths, err := a.resolveGlobFileInputs()
-	if err != nil {
-		return nil, errors.Wrapf(err, "resolving File BuildInputs failed")
-	}
-
-	gitPaths, err := a.resolveGitFileInputs()
-	if err != nil {
-		return nil, errors.Wrapf(err, "resolving GitFile BuildInputs failed")
-	}
-
-	goSrcPaths, err := a.resolveGoSrcInputs()
-	if err != nil {
-		return nil, errors.Wrapf(err, "resolving GoLangSources BuildInputs failed")
-	}
-
-	paths := make([]string, 0, len(globPaths)+len(gitPaths)+len(goSrcPaths))
-	paths = append(paths, globPaths...)
-	paths = append(paths, gitPaths...)
-	paths = append(paths, goSrcPaths...)
-
-	return paths, nil
-}
-
-// HasBuildInputs returns true if BuildInputs are defined for the app
-func (a *App) HasBuildInputs() bool {
-	for _, bi := range a.UnresolvedInputs {
-		if len(bi.Files.Paths) != 0 {
-			return true
-		}
-
-		if len(bi.GitFiles.Paths) != 0 {
-			return true
-		}
-
-		if len(bi.GolangSources.Paths) != 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
-// BuildInputs resolves all build inputs of the app.
-// The BuildInputs are deduplicates before they are returned.
-// If one more resolved path does not match a file an error is generated.
-// If not build inputs are defined, an empty slice and no error is returned.
-// If the function is called the first time, the BuildInputPaths are resolved
-// and stored. On following calls the stored BuildInputs are returned.
-func (a *App) BuildInputs() ([]*File, error) {
-	if a.buildInputs != nil {
-		return a.buildInputs, nil
-	}
-
-	paths, err := a.resolveBuildInputPaths()
-	if err != nil {
-		return nil, err
-	}
-
-	a.buildInputs, err = a.pathsToUniqFiles(a.repositoryRootPath, paths)
-	if err != nil {
-		return nil, err
-	}
-
-	return a.buildInputs, nil
-}
-
-// TotalInputDigest returns the total input digest that is calculated over all
-// input sources. The calculation is only done on the 1. call on following calls
-// the stored digest is returned
-func (a *App) TotalInputDigest() (digest.Digest, error) {
-	if a.totalInputDigest != nil {
-		return *a.totalInputDigest, nil
-	}
-
-	buildInputs, err := a.BuildInputs()
-	if err != nil {
-		return digest.Digest{}, err
-	}
-
-	digests := make([]*digest.Digest, 0, len(buildInputs))
-	for _, bi := range buildInputs {
-		d, err := bi.Digest()
-		if err != nil {
-			return digest.Digest{}, errors.Wrapf(err, "calculating input digest of %q failed", bi)
-		}
-
-		digests = append(digests, &d)
-	}
-
-	totalDigest, err := sha384.Sum(digests)
-	if err != nil {
-		return digest.Digest{}, errors.Wrap(err, "calculating total input digest")
-	}
-
-	a.totalInputDigest = totalDigest
-
-	return *a.totalInputDigest, nil
+	return result[0]
 }
 
 // SortAppsByName sorts the apps in the slice by Name

--- a/build.go
+++ b/build.go
@@ -42,21 +42,21 @@ func (b BuildStatus) String() string {
 // storage if a build for this input digest already exist.
 // If the function returns BuildStatusExist the returned build pointer is valid
 // otherwise it is nil.
-func GetBuildStatus(storer storage.Storer, app *App) (BuildStatus, *storage.BuildWithDuration, error) {
-	if len(app.BuildCmd) == 0 {
+func GetBuildStatus(storer storage.Storer, task *Task) (BuildStatus, *storage.BuildWithDuration, error) {
+	if len(task.Command) == 0 {
 		return BuildStatusBuildCommandUndefined, nil, nil
 	}
 
-	if !app.HasBuildInputs() {
+	if !task.HasInputs() {
 		return BuildStatusInputsUndefined, nil, nil
 	}
 
-	d, err := app.TotalInputDigest()
+	d, err := task.TotalInputDigest()
 	if err != nil {
 		return -1, nil, errors.Wrap(err, "calculating total input digest failed")
 	}
 
-	build, err := storer.GetLatestBuildByDigest(app.Name, d.String())
+	build, err := storer.GetLatestBuildByDigest(task.AppName, d.String())
 	if err != nil {
 		if err == storage.ErrNotExist {
 			return BuildStatusPending, nil, nil

--- a/build/build.go
+++ b/build/build.go
@@ -15,7 +15,7 @@ type Result struct {
 	Output   string
 }
 
-// Job describes abuild job
+// Job describes a build job
 type Job struct {
 	Application string
 	Directory   string

--- a/cfg/inputdef.go
+++ b/cfg/inputdef.go
@@ -7,7 +7,8 @@ type InputDef interface {
 }
 
 // TODO: make FileInputs, GitFileInputs, GolangSources pointers and get rid of this function?
-func inputsIsEmpty(in InputDef) bool {
+// InputsAreEmpty returns true if no inputs are defined
+func InputsAreEmpty(in InputDef) bool {
 	return len(in.FileInputs().Paths) == 0 &&
 		len(in.GitFileInputs().Paths) == 0 &&
 		len(in.GolangSourcesInputs().Paths) == 0 &&

--- a/cfg/inputinclude.go
+++ b/cfg/inputinclude.go
@@ -30,7 +30,7 @@ func (in *InputInclude) Validate() error {
 		return err
 	}
 
-	if inputsIsEmpty(in) {
+	if InputsAreEmpty(in) {
 		return nil
 	}
 

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -128,10 +128,12 @@ func ls(cmd *cobra.Command, args []string) {
 		var build *storage.BuildWithDuration
 		var buildStatus baur.BuildStatus
 
+		task := app.Task()
+
 		if storageQueryNeeded {
 			var err error
 
-			buildStatus, build, err = baur.GetBuildStatus(storageClt, app)
+			buildStatus, build, err = baur.GetBuildStatus(storageClt, task)
 			if err != nil {
 				log.Fatalf("gathering informations for %s failed: %s", app, err)
 			}

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -47,10 +47,11 @@ func lsInputs(cmd *cobra.Command, args []string) {
 
 	rep := MustFindRepository()
 	app := mustArgToApp(rep, args[0])
+	task := app.Task()
 	writeHeaders := !lsInputsConfig.quiet && !lsInputsConfig.csv
 
-	if !app.HasBuildInputs() {
-		log.Fatalf("No build inputs are configured in %s of %s", baur.AppCfgFile, app.Name)
+	if !task.HasInputs() {
+		log.Fatalf("No inputs are configured in %s of %s", baur.AppCfgFile, app.Name)
 	}
 
 	if writeHeaders {
@@ -67,7 +68,7 @@ func lsInputs(cmd *cobra.Command, args []string) {
 		formatter = table.New(headers, os.Stdout)
 	}
 
-	inputs, err := app.BuildInputs()
+	inputs, err := task.Inputs()
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -95,7 +96,7 @@ func lsInputs(cmd *cobra.Command, args []string) {
 	}
 
 	if lsInputsConfig.showDigest && !lsInputsConfig.quiet && !lsInputsConfig.csv {
-		totalDigest, err := app.TotalInputDigest()
+		totalDigest, err := task.TotalInputDigest()
 		if err != nil {
 			log.Fatalln("calculating total input digest failed:", err)
 		}

--- a/task.go
+++ b/task.go
@@ -1,0 +1,305 @@
+package baur
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/simplesurance/baur/cfg"
+	"github.com/simplesurance/baur/digest"
+	"github.com/simplesurance/baur/digest/sha384"
+	"github.com/simplesurance/baur/fs"
+	"github.com/simplesurance/baur/log"
+	"github.com/simplesurance/baur/resolve/gitpath"
+	"github.com/simplesurance/baur/resolve/glob"
+	"github.com/simplesurance/baur/resolve/gosource"
+	"github.com/simplesurance/baur/upload/scheduler"
+)
+
+// Task is a an execution step belonging to an app.
+// A task has a set of Inputs that produce a set of outputs by executing it's
+// Command.
+type Task struct {
+	RepositoryRoot string
+	Directory      string
+
+	AppName string
+
+	Name             string
+	Command          string
+	UnresolvedInputs *cfg.Input
+	resolvedInputs   []*File
+	totalInputDigest *digest.Digest
+	Outputs          *cfg.Output
+}
+
+// NewTask returns a new Task.
+func NewTask(cfg *cfg.Task, appName, repositoryRootdir, workingDir string) *Task {
+	return &Task{
+		RepositoryRoot:   repositoryRootdir,
+		Directory:        workingDir,
+		Outputs:          &cfg.Output,
+		Command:          cfg.Command,
+		Name:             cfg.Name,
+		AppName:          appName,
+		UnresolvedInputs: &cfg.Input,
+	}
+}
+
+// ID returns <APP-NAME>.<TASK-NAME>
+func (t *Task) ID() string {
+	return fmt.Sprintf("%s.%s", t.AppName, t.Name)
+}
+
+// String returns ID()
+func (t *Task) String() string {
+	return t.ID()
+}
+
+// HasInputs returns true if Inputs are defined for the app
+func (t *Task) HasInputs() bool {
+	return !cfg.InputsAreEmpty(t.UnresolvedInputs)
+}
+
+// TotalInputDigest returns the total input digest that is calculated over all
+// input sources. The calculation is only done on the 1. call on following calls
+// the stored digest is returned.
+func (t *Task) TotalInputDigest() (digest.Digest, error) {
+	if t.totalInputDigest != nil {
+		return *t.totalInputDigest, nil
+	}
+
+	buildInputs, err := t.Inputs()
+	if err != nil {
+		return digest.Digest{}, err
+	}
+
+	digests := make([]*digest.Digest, 0, len(buildInputs))
+	for _, bi := range buildInputs {
+		d, err := bi.Digest()
+		if err != nil {
+			return digest.Digest{}, fmt.Errorf("calculating input digest of %q failed: %w", bi, err)
+		}
+
+		digests = append(digests, &d)
+	}
+
+	totalDigest, err := sha384.Sum(digests)
+	if err != nil {
+		return digest.Digest{}, fmt.Errorf("calculating total input digest: %w", err)
+	}
+
+	t.totalInputDigest = totalDigest
+
+	return *t.totalInputDigest, nil
+}
+
+// Inputs resolves and returns all inputs of the task.
+// The Inputs are deduplicated before they are returned.
+// If one more resolved path does not match a file an error is generated.
+// If not build inputs are defined, an empty slice and no error is returned.
+// If the function is called the first time, the BuildInputPaths are resolved
+// and stored. On following calls the stored BuildInputs are returned.
+func (t *Task) Inputs() ([]*File, error) {
+	if t.resolvedInputs != nil {
+		return t.resolvedInputs, nil
+	}
+
+	paths, err := t.resolveBuildInputPaths()
+	if err != nil {
+		return nil, err
+	}
+
+	t.resolvedInputs, err = t.pathsToUniqFiles(t.RepositoryRoot, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.resolvedInputs, nil
+}
+
+func (t *Task) resolveBuildInputPaths() ([]string, error) {
+	globPaths, err := t.resolveGlobFileInputs()
+	if err != nil {
+		return nil, fmt.Errorf("resolving File BuildInputs failed: %w", err)
+	}
+
+	gitPaths, err := t.resolveGitFileInputs()
+	if err != nil {
+		return nil, fmt.Errorf("resolving GitFile BuildInputs failed: %w", err)
+	}
+
+	goSrcPaths, err := t.resolveGoSrcInputs()
+	if err != nil {
+		return nil, fmt.Errorf("resolving GoLangSources BuildInputs failed: %w", err)
+	}
+
+	paths := make([]string, 0, len(globPaths)+len(gitPaths)+len(goSrcPaths)+1)
+	paths = append(paths, globPaths...)
+	paths = append(paths, gitPaths...)
+	paths = append(paths, goSrcPaths...)
+
+	// Add the .app.toml file of the app to the inputs
+	paths = append(paths, path.Join(t.Directory, AppCfgFile))
+
+	return paths, nil
+}
+
+func (t *Task) resolveGlobFileInputs() ([]string, error) {
+	var res []string
+
+	for _, globPath := range t.UnresolvedInputs.Files.Paths {
+		if !filepath.IsAbs(globPath) {
+			globPath = filepath.Join(t.Directory, globPath)
+		}
+
+		resolver := glob.NewResolver(globPath)
+		paths, err := resolver.Resolve()
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", globPath, err)
+		}
+
+		if len(paths) == 0 {
+			return nil, fmt.Errorf("'%s' matched 0 files", globPath)
+		}
+
+		res = append(res, paths...)
+	}
+
+	return res, nil
+}
+
+func (t *Task) resolveGitFileInputs() ([]string, error) {
+	var res []string
+
+	if len(t.UnresolvedInputs.GitFiles.Paths) == 0 {
+		return res, nil
+	}
+
+	resolver := gitpath.NewResolver(t.Directory, t.UnresolvedInputs.GitFiles.Paths...)
+	paths, err := resolver.Resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(paths, ", "))
+	}
+
+	res = append(res, paths...)
+
+	return res, nil
+}
+
+func (t *Task) resolveGoSrcInputs() ([]string, error) {
+	var res []string
+
+	if len(t.UnresolvedInputs.GolangSources.Paths) == 0 {
+		return res, nil
+	}
+
+	absGoSourcePaths := fs.AbsPaths(t.Directory, t.UnresolvedInputs.GolangSources.Paths)
+
+	// TODO use a logger instance
+	resolver := gosource.NewResolver(log.Debugf, t.UnresolvedInputs.GolangSources.Environment, absGoSourcePaths...)
+	paths, err := resolver.Resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(paths, ", "))
+	}
+
+	res = append(res, paths...)
+
+	return res, nil
+}
+
+func (t *Task) pathsToUniqFiles(workingDir string, paths []string) ([]*File, error) {
+	dedupMap := make(map[string]struct{}, len(paths))
+	res := make([]*File, 0, len(paths))
+
+	for _, path := range paths {
+		if _, exist := dedupMap[path]; exist {
+			// TODO use a logger instance
+			log.Debugf("%s: removed duplicate Build Input '%s'", t.ID(), path)
+			continue
+		}
+		dedupMap[path] = struct{}{}
+
+		relPath, err := filepath.Rel(workingDir, path)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: should resolving the relative path be done in
+		// Newfile() instead?
+		res = append(res, NewFile(workingDir, relPath))
+	}
+
+	return res, nil
+}
+
+// TODO: rename this function when the db and commands support multiple tasks.
+// BuildOutputs returns a list of outputs that the task.Command is expected to produce.
+func (t *Task) BuildOutputs() ([]BuildOutput, error) {
+	result := make([]BuildOutput, 0, len(t.Outputs.DockerImage)+len(t.Outputs.File))
+
+	taskRelDir, err := filepath.Rel(t.Directory, t.RepositoryRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, di := range t.Outputs.DockerImage {
+		result = append(result, &DockerArtifact{
+			ImageIDFile: path.Join(t.Directory, di.IDFile),
+			Tag:         di.RegistryUpload.Tag,
+			Repository:  di.RegistryUpload.Repository,
+			Registry:    di.RegistryUpload.Registry,
+		})
+	}
+
+	for _, f := range t.Outputs.File {
+		filePath := f.Path
+		absFilePath := path.Join(t.Directory, filePath)
+
+		if !f.S3Upload.IsEmpty() {
+			url := "s3://" + f.S3Upload.Bucket + "/" + f.S3Upload.DestFile
+
+			result = append(result, &FileArtifact{
+				RelPath:   path.Join(taskRelDir, filePath),
+				Path:      absFilePath,
+				DestFile:  f.S3Upload.DestFile,
+				UploadURL: url,
+				uploadJob: &scheduler.S3Job{
+					DestURL:  url,
+					FilePath: absFilePath,
+				},
+			})
+		}
+
+		if !f.FileCopy.IsEmpty() {
+			result = append(result, &FileArtifact{
+				RelPath:   path.Join(taskRelDir, filePath),
+				Path:      absFilePath,
+				DestFile:  f.FileCopy.Path,
+				UploadURL: f.FileCopy.Path,
+				uploadJob: &scheduler.FileCopyJob{
+					Src: absFilePath,
+					Dst: f.FileCopy.Path,
+				},
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func SortTasksByID(tasks []*Task) {
+	sort.Slice(tasks, func(i int, j int) bool {
+		return tasks[i].ID() < tasks[i].ID()
+	})
+}


### PR DESCRIPTION
        introduce Task type
        
        Task represents the section with the same name in the .app.cfg file.
        The fields and method relating to Inputs, Outputs and building an App are moved
        to Task.
        
        In the future baur will support to define multiple tasks per app.
        Currently only one task name with the name "build" is supported.
