### PR TITLE
Refactor resolving inputs

### DIFF
--- a/build.go
+++ b/build.go
@@ -14,7 +14,6 @@ const (
 	BuildStatusUndefined
 	BuildStatusInputsUndefined
 	// TODO: is BuildStatusBuildCommandUndefined used/needed?
-	BuildStatusBuildCommandUndefined
 	BuildStatusExist
 	BuildStatusPending
 )
@@ -29,8 +28,6 @@ func (t BuildStatus) String() string {
 		return "Exist"
 	case BuildStatusPending:
 		return "Pending"
-	case BuildStatusBuildCommandUndefined:
-		return "Command Undefined"
 	default:
 		panic(fmt.Sprintf("incompatible TaskStatus value: %d", t))
 	}
@@ -41,10 +38,6 @@ func (t BuildStatus) String() string {
 // If the function returns BuildStatusExist the returned build pointer is valid
 // otherwise it is nil.
 func TaskRunStatus(task *Task, repositoryDir string, store storage.Storer) (BuildStatus, *storage.BuildWithDuration, error) {
-	if task.Command == "" {
-		return BuildStatusBuildCommandUndefined, nil, nil
-	}
-
 	if !task.HasInputs() {
 		return BuildStatusInputsUndefined, nil, nil
 	}
@@ -60,10 +53,6 @@ func TaskRunStatus(task *Task, repositoryDir string, store storage.Storer) (Buil
 }
 
 func TaskRunStatusInputs(task *Task, inputs *Inputs, store storage.Storer) (BuildStatus, *storage.BuildWithDuration, error) {
-	if task.Command == "" {
-		return BuildStatusBuildCommandUndefined, nil, nil
-	}
-
 	if !task.HasInputs() {
 		return BuildStatusInputsUndefined, nil, nil
 	}
@@ -80,7 +69,7 @@ func taskStatusFromDB(appName string, inputs *Inputs, store storage.Storer) (Bui
 	existingBuild, err := store.GetLatestBuildByDigest(appName, digest.String())
 	if err != nil {
 		if err == storage.ErrNotExist {
-			return BuildStatusExist, nil, nil
+			return BuildStatusPending, nil, nil
 		}
 
 		return BuildStatusUndefined, nil, err

--- a/file.go
+++ b/file.go
@@ -37,7 +37,7 @@ func (f *File) Digest() (digest.Digest, error) {
 		return digest.Digest{}, err
 	}
 
-	err = sha.AddFile(filepath.Join(f.absPath))
+	err = sha.AddFile(f.absPath)
 	if err != nil {
 		return digest.Digest{}, err
 	}

--- a/inputresolver.go
+++ b/inputresolver.go
@@ -1,0 +1,162 @@
+package baur
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/simplesurance/baur/cfg"
+	"github.com/simplesurance/baur/log"
+	"github.com/simplesurance/baur/resolve/gitpath"
+	"github.com/simplesurance/baur/resolve/glob"
+	"github.com/simplesurance/baur/resolve/gosource"
+)
+
+type InputResolver struct {
+	gitGlobPathResolver *gitpath.Resolver
+	globPathResolver    *glob.Resolver
+	goSourceResolver    *gosource.Resolver
+}
+
+func NewInputResolver() *InputResolver {
+	return &InputResolver{
+		gitGlobPathResolver: &gitpath.Resolver{},
+		globPathResolver:    &glob.Resolver{},
+		goSourceResolver:    gosource.NewResolver(log.Debugf),
+	}
+}
+
+// Resolves the input definition of the task to concrete Files.
+// If an input definition does not resolve to >= paths, an error is returned.
+// The resolved Files are deduplicated.
+func (i *InputResolver) Resolve(repositoryDir string, task *Task) (*Inputs, error) {
+	goSourcePaths, err := i.resolveGoSrcInputs(task.Directory, &task.UnresolvedInputs.GolangSources)
+	if err != nil {
+		return nil, fmt.Errorf("resolving golang source inputs failed: %w", err)
+	}
+
+	gitPaths, err := i.resolveGitGlobPaths(repositoryDir, task.Directory, &task.UnresolvedInputs.GitFiles)
+	if err != nil {
+		return nil, fmt.Errorf("resolving git-file inputs failed: %w", err)
+	}
+
+	globPaths, err := i.resolveGlobPaths(task.Directory, &task.UnresolvedInputs.Files)
+	if err != nil {
+		return nil, fmt.Errorf("resolving glob file inputs failed: %w", err)
+	}
+
+	allInputsPaths := make([]string, 0, len(goSourcePaths)+len(globPaths)+len(gitPaths)+1)
+	allInputsPaths = append(allInputsPaths, gitPaths...)
+	allInputsPaths = append(allInputsPaths, globPaths...)
+	allInputsPaths = append(allInputsPaths, goSourcePaths...)
+
+	// Add the .app.toml file of the app to the inputs
+	// TODO: add the files that were included in the .app.toml and it's includes
+	allInputsPaths = append(allInputsPaths, path.Join(task.Directory, AppCfgFile))
+
+	uniqFiles, err := i.pathsToUniqFiles(repositoryDir, allInputsPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Inputs{Files: uniqFiles}, nil
+}
+
+func (i *InputResolver) resolveGitGlobPaths(repositoryRootDir, appDir string, inputs *cfg.GitFileInputs) ([]string, error) {
+	if len(inputs.Paths) == 0 {
+		return nil, nil
+	}
+
+	gitPaths, err := i.gitGlobPathResolver.Resolve(appDir, inputs.Paths...)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(gitPaths) == 0 {
+		return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(inputs.Paths, ", "))
+	}
+
+	return gitPaths, err
+}
+
+func (i *InputResolver) resolveGlobPaths(appDir string, inputs *cfg.FileInputs) ([]string, error) {
+	if len(inputs.Paths) == 0 {
+		return nil, nil
+	}
+
+	// slice will have at least the same sice then inputs.Path, every globPath must resolve to >1 path
+	result := make([]string, 0, len(inputs.Paths))
+
+	for _, path := range inputs.Paths {
+		var absGlobPath string
+
+		if filepath.IsAbs(path) {
+			absGlobPath = path
+		} else {
+			absGlobPath = filepath.Join(appDir, path)
+		}
+
+		resolvedPaths, err := i.globPathResolver.Resolve(absGlobPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(resolvedPaths) == 0 {
+			return nil, fmt.Errorf("'%s' matched 0 files", path)
+		}
+
+		result = append(result, resolvedPaths...)
+	}
+
+	return result, nil
+}
+
+func (i *InputResolver) resolveGoSrcInputs(appDir string, inputs *cfg.GolangSources) ([]string, error) {
+	if len(inputs.Paths) == 0 && len(inputs.Environment) == 0 {
+		return nil, nil
+	}
+
+	absGoSourceDirs := make([]string, len(inputs.Paths))
+	for i, path := range inputs.Paths {
+		if filepath.IsAbs(path) {
+			absGoSourceDirs[i] = path
+			continue
+		}
+
+		absGoSourceDirs[i] = filepath.Join(appDir, path)
+	}
+
+	return i.goSourceResolver.Resolve(inputs.Environment, absGoSourceDirs...)
+}
+
+func (i *InputResolver) pathsToUniqFiles(repositoryRoot string, pathSlice ...[]string) ([]*File, error) {
+	var pathsCount int
+
+	for _, paths := range pathSlice {
+		pathsCount += len(paths)
+	}
+
+	res := make([]*File, 0, pathsCount)
+	dedupMap := make(map[string]struct{}, pathsCount)
+
+	for _, paths := range pathSlice {
+		for _, path := range paths {
+			if _, exist := dedupMap[path]; exist {
+				log.Debugf("removed duplicate input %q", path)
+				continue
+			}
+
+			dedupMap[path] = struct{}{}
+
+			relPath, err := filepath.Rel(repositoryRoot, path)
+			if err != nil {
+				return nil, err
+			}
+
+			res = append(res, NewFile(repositoryRoot, relPath))
+		}
+	}
+
+	return res, nil
+}

--- a/inputs.go
+++ b/inputs.go
@@ -1,0 +1,42 @@
+package baur
+
+import (
+	"fmt"
+
+	"github.com/simplesurance/baur/digest"
+	"github.com/simplesurance/baur/digest/sha384"
+)
+
+// Inputs are resolved Inputs of a task.
+type Inputs struct {
+	Files  []*File
+	digest *digest.Digest
+}
+
+// Digest returns a summarized digest over all Files.
+// On the first call the digest is calculated, on subsequent calls the stored digest is returned.
+func (in *Inputs) Digest() (digest.Digest, error) {
+	if in.digest != nil {
+		return *in.digest, nil
+	}
+
+	digests := make([]*digest.Digest, len(in.Files))
+
+	for i, file := range in.Files {
+		fdigest, err := file.Digest()
+		if err != nil {
+			return digest.Digest{}, fmt.Errorf("calculating digest for %q failed: %w", file.Path(), err)
+		}
+
+		digests[i] = &fdigest
+	}
+
+	totalDigest, err := sha384.Sum(digests)
+	if err != nil {
+		return digest.Digest{}, err
+	}
+
+	in.digest = totalDigest
+
+	return *in.digest, nil
+}

--- a/internal/command/build.go
+++ b/internal/command/build.go
@@ -518,6 +518,8 @@ func buildRun(cmd *cobra.Command, args []string) {
 		<-uploadWatchFin
 	}
 
-	term.PrintSep()
+	if len(buildJobs) > 0 {
+		term.PrintSep()
+	}
 	fmt.Printf("finished in %ss\n", durationToStrSeconds(time.Since(startTs)))
 }

--- a/internal/command/build.go
+++ b/internal/command/build.go
@@ -360,7 +360,7 @@ func pendingBuilds(storer storage.Storer, apps []*baur.App, repositoryRootDir st
 				appNameColLen, app.Name, appColSep, coloredBuildStatus(status))
 		}
 
-		if status == baur.BuildStatusInputsUndefined || status == baur.BuildStatusBuildCommandUndefined {
+		if status == baur.BuildStatusInputsUndefined {
 			continue
 		}
 

--- a/internal/command/flag/buildstatus.go
+++ b/internal/command/flag/buildstatus.go
@@ -10,18 +10,16 @@ import (
 
 // Valid commandline values
 const (
-	buildStatusExist                 = "exist"
-	buildStatusPending               = "pending"
-	buildStatusInputUndefined        = "inputs-undefined"
-	buildStatusBuildCommandUndefined = "build-command-undefined"
+	buildStatusExist          = "exist"
+	buildStatusPending        = "pending"
+	buildStatusInputUndefined = "inputs-undefined"
 )
 
 // BuildStatusFormatDescription is the format description for the flag
 const BuildStatusFormatDescription string = "one of " +
 	buildStatusExist + ", " +
 	buildStatusPending + ", " +
-	buildStatusInputUndefined + ", " +
-	buildStatusBuildCommandUndefined
+	buildStatusInputUndefined
 
 // BuildStatus is a commandline parameter to specify build status filters
 type BuildStatus struct {
@@ -45,8 +43,6 @@ func (b *BuildStatus) Set(val string) error {
 		b.Status = baur.BuildStatusPending
 	case buildStatusInputUndefined:
 		b.Status = baur.BuildStatusPending
-	case buildStatusBuildCommandUndefined:
-		b.Status = baur.BuildStatusBuildCommandUndefined
 	default:
 		return errors.New("status must be " + BuildStatusFormatDescription)
 	}
@@ -65,13 +61,12 @@ func (b *BuildStatus) Usage(highlightFn func(a ...interface{}) string) string {
 	return strings.TrimSpace(fmt.Sprintf(`
 Only show applications with this build status
 Format: %s
-where %s is one of: %s, %s, %s, %s`,
+where %s is one of: %s, %s, %s`,
 		highlightFn(b.Type()),
 		highlightFn("STATUS"),
 		highlightFn(buildStatusExist),
 		highlightFn(buildStatusPending),
 		highlightFn(buildStatusInputUndefined),
-		highlightFn(buildStatusBuildCommandUndefined),
 	))
 }
 

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -159,8 +159,6 @@ func coloredBuildStatus(status baur.BuildStatus) string {
 	switch status {
 	case baur.BuildStatusInputsUndefined:
 		return yellowHighlight(status.String())
-	case baur.BuildStatusBuildCommandUndefined:
-		return yellowHighlight(status.String())
 	case baur.BuildStatusExist:
 		return greenHighlight(status.String())
 	case baur.BuildStatusPending:

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -126,14 +126,14 @@ func ls(cmd *cobra.Command, args []string) {
 	for i, app := range apps {
 		var row []interface{}
 		var build *storage.BuildWithDuration
-		var buildStatus baur.BuildStatus
+		var taskStatus baur.BuildStatus
 
 		task := app.Task()
 
 		if storageQueryNeeded {
 			var err error
 
-			buildStatus, build, err = baur.GetBuildStatus(storageClt, task)
+			taskStatus, build, err = baur.TaskRunStatus(task, repo.Path, storageClt)
 			if err != nil {
 				log.Fatalf("gathering informations for %s failed: %s", app, err)
 			}
@@ -150,11 +150,11 @@ func ls(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		if lsAppsConfig.buildStatus.IsSet() && buildStatus != lsAppsConfig.buildStatus.Status {
+		if lsAppsConfig.buildStatus.IsSet() && taskStatus != lsAppsConfig.buildStatus.Status {
 			continue
 		}
 
-		row = assembleRow(app, build, buildStatus)
+		row = assembleRow(app, build, taskStatus)
 
 		if err := formatter.WriteRow(row); err != nil {
 			log.Fatalln(err)

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -68,16 +68,18 @@ func lsInputs(cmd *cobra.Command, args []string) {
 		formatter = table.New(headers, os.Stdout)
 	}
 
-	inputs, err := task.Inputs()
+	inputResolver := baur.NewInputResolver()
+
+	inputs, err := inputResolver.Resolve(rep.Path, task)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	sort.Slice(inputs, func(i, j int) bool {
-		return inputs[i].RepoRelPath() < inputs[j].RepoRelPath()
+		return inputs.Files[i].RepoRelPath() < inputs.Files[j].RepoRelPath()
 	})
 
-	for _, input := range inputs {
+	for _, input := range inputs.Files {
 		if !lsInputsConfig.showDigest || lsInputsConfig.quiet {
 			mustWriteRow(formatter, []interface{}{input})
 			continue
@@ -96,7 +98,7 @@ func lsInputs(cmd *cobra.Command, args []string) {
 	}
 
 	if lsInputsConfig.showDigest && !lsInputsConfig.quiet && !lsInputsConfig.csv {
-		totalDigest, err := task.TotalInputDigest()
+		totalDigest, err := inputs.Digest()
 		if err != nil {
 			log.Fatalln("calculating total input digest failed:", err)
 		}

--- a/resolve/gitpath/gitpaths.go
+++ b/resolve/gitpath/gitpaths.go
@@ -10,25 +10,18 @@ import (
 
 // Resolver resolves one or more git glob paths in a git repository by running
 // git ls-files.
-// Glob path only resolve to files that are tracked in the repository.
-type Resolver struct {
-	workingDir string
-	globs      []string
-}
+// Glob paths are only resolved to files that are tracked in the repository.
+type Resolver struct{}
 
-// NewResolver returns a resolver that resolves the passed git glob paths to absolute
-// paths
-func NewResolver(workingDir string, globs ...string) *Resolver {
-	return &Resolver{
-		workingDir: workingDir,
-		globs:      globs,
+// Resolve resolves the glob paths to absolute file paths by calling git ls-files.
+// workingDir must be a directory that is part of a Git repository.
+// If a resolved file does not exist an error is returned.
+func (r *Resolver) Resolve(workingDir string, globs ...string) ([]string, error) {
+	if len(globs) == 0 {
+		return []string{}, nil
 	}
-}
 
-// Resolve the glob paths to absolute file paths by calling
-// git ls-files
-func (r *Resolver) Resolve() ([]string, error) {
-	out, err := git.LsFiles(r.workingDir, r.globs...)
+	out, err := git.LsFiles(workingDir, globs...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +30,7 @@ func (r *Resolver) Resolve() ([]string, error) {
 	res := make([]string, 0, len(relPaths))
 
 	for _, relPath := range relPaths {
-		absPath := filepath.Join(r.workingDir, relPath)
+		absPath := filepath.Join(workingDir, relPath)
 
 		isFile, err := fs.IsFile(absPath)
 		if err != nil {

--- a/resolve/glob/glob_test.go
+++ b/resolve/glob/glob_test.go
@@ -185,8 +185,7 @@ func Test_Resolve(t *testing.T) {
 
 		createFiles(t, tempdir, tc.files)
 
-		fs := NewResolver(path.Join(tempdir, tc.fileSrcGlobPath))
-		resolvedFiles, err := fs.Resolve()
+		resolvedFiles, err := (&Resolver{}).Resolve(path.Join(tempdir, tc.fileSrcGlobPath))
 		if err != nil {
 			t.Fatal("resolving glob path:", err)
 		}

--- a/resolve/gosource/gosource_test.go
+++ b/resolve/gosource/gosource_test.go
@@ -72,11 +72,9 @@ func TestResolveWithGoPath(t *testing.T) {
 
 	resolver := NewResolver(
 		nil,
-		[]string{"GOPATH=" + tmpdir},
-		projectPath,
 	)
 
-	resolvedFiles, err := resolver.Resolve()
+	resolvedFiles, err := resolver.Resolve([]string{"GOPATH=" + tmpdir}, projectPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,8 +97,8 @@ func TestResolveWithGoMod(t *testing.T) {
 	_, projectPath, filepaths, cleanupFn := createGoProject(t, "baur-test/", true)
 	defer cleanupFn()
 
-	resolver := NewResolver(nil, nil, projectPath)
-	resolvedFiles, err := resolver.Resolve()
+	resolver := NewResolver(nil)
+	resolvedFiles, err := resolver.Resolve(nil, projectPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/resolve/resolver.go
+++ b/resolve/resolver.go
@@ -1,7 +1,0 @@
-package resolve
-
-// Resolver specifies an interface to resolve abstract file specifications like
-// glob paths or go packages to file paths
-type Resolver interface {
-	Resolve() ([]string, error)
-}

--- a/task.go
+++ b/task.go
@@ -5,16 +5,8 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/simplesurance/baur/cfg"
-	"github.com/simplesurance/baur/digest"
-	"github.com/simplesurance/baur/digest/sha384"
-	"github.com/simplesurance/baur/fs"
-	"github.com/simplesurance/baur/log"
-	"github.com/simplesurance/baur/resolve/gitpath"
-	"github.com/simplesurance/baur/resolve/glob"
-	"github.com/simplesurance/baur/resolve/gosource"
 	"github.com/simplesurance/baur/upload/scheduler"
 )
 
@@ -30,8 +22,6 @@ type Task struct {
 	Name             string
 	Command          string
 	UnresolvedInputs *cfg.Input
-	resolvedInputs   []*File
-	totalInputDigest *digest.Digest
 	Outputs          *cfg.Output
 }
 
@@ -61,186 +51,6 @@ func (t *Task) String() string {
 // HasInputs returns true if Inputs are defined for the app
 func (t *Task) HasInputs() bool {
 	return !cfg.InputsAreEmpty(t.UnresolvedInputs)
-}
-
-// TotalInputDigest returns the total input digest that is calculated over all
-// input sources. The calculation is only done on the 1. call on following calls
-// the stored digest is returned.
-func (t *Task) TotalInputDigest() (digest.Digest, error) {
-	if t.totalInputDigest != nil {
-		return *t.totalInputDigest, nil
-	}
-
-	buildInputs, err := t.Inputs()
-	if err != nil {
-		return digest.Digest{}, err
-	}
-
-	digests := make([]*digest.Digest, 0, len(buildInputs))
-	for _, bi := range buildInputs {
-		d, err := bi.Digest()
-		if err != nil {
-			return digest.Digest{}, fmt.Errorf("calculating input digest of %q failed: %w", bi, err)
-		}
-
-		digests = append(digests, &d)
-	}
-
-	totalDigest, err := sha384.Sum(digests)
-	if err != nil {
-		return digest.Digest{}, fmt.Errorf("calculating total input digest: %w", err)
-	}
-
-	t.totalInputDigest = totalDigest
-
-	return *t.totalInputDigest, nil
-}
-
-// Inputs resolves and returns all inputs of the task.
-// The Inputs are deduplicated before they are returned.
-// If one more resolved path does not match a file an error is generated.
-// If not build inputs are defined, an empty slice and no error is returned.
-// If the function is called the first time, the BuildInputPaths are resolved
-// and stored. On following calls the stored BuildInputs are returned.
-func (t *Task) Inputs() ([]*File, error) {
-	if t.resolvedInputs != nil {
-		return t.resolvedInputs, nil
-	}
-
-	paths, err := t.resolveBuildInputPaths()
-	if err != nil {
-		return nil, err
-	}
-
-	t.resolvedInputs, err = t.pathsToUniqFiles(t.RepositoryRoot, paths)
-	if err != nil {
-		return nil, err
-	}
-
-	return t.resolvedInputs, nil
-}
-
-func (t *Task) resolveBuildInputPaths() ([]string, error) {
-	globPaths, err := t.resolveGlobFileInputs()
-	if err != nil {
-		return nil, fmt.Errorf("resolving File BuildInputs failed: %w", err)
-	}
-
-	gitPaths, err := t.resolveGitFileInputs()
-	if err != nil {
-		return nil, fmt.Errorf("resolving GitFile BuildInputs failed: %w", err)
-	}
-
-	goSrcPaths, err := t.resolveGoSrcInputs()
-	if err != nil {
-		return nil, fmt.Errorf("resolving GoLangSources BuildInputs failed: %w", err)
-	}
-
-	paths := make([]string, 0, len(globPaths)+len(gitPaths)+len(goSrcPaths)+1)
-	paths = append(paths, globPaths...)
-	paths = append(paths, gitPaths...)
-	paths = append(paths, goSrcPaths...)
-
-	// Add the .app.toml file of the app to the inputs
-	paths = append(paths, path.Join(t.Directory, AppCfgFile))
-
-	return paths, nil
-}
-
-func (t *Task) resolveGlobFileInputs() ([]string, error) {
-	var res []string
-
-	for _, globPath := range t.UnresolvedInputs.Files.Paths {
-		if !filepath.IsAbs(globPath) {
-			globPath = filepath.Join(t.Directory, globPath)
-		}
-
-		resolver := glob.NewResolver(globPath)
-		paths, err := resolver.Resolve()
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", globPath, err)
-		}
-
-		if len(paths) == 0 {
-			return nil, fmt.Errorf("'%s' matched 0 files", globPath)
-		}
-
-		res = append(res, paths...)
-	}
-
-	return res, nil
-}
-
-func (t *Task) resolveGitFileInputs() ([]string, error) {
-	var res []string
-
-	if len(t.UnresolvedInputs.GitFiles.Paths) == 0 {
-		return res, nil
-	}
-
-	resolver := gitpath.NewResolver(t.Directory, t.UnresolvedInputs.GitFiles.Paths...)
-	paths, err := resolver.Resolve()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(paths) == 0 {
-		return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(paths, ", "))
-	}
-
-	res = append(res, paths...)
-
-	return res, nil
-}
-
-func (t *Task) resolveGoSrcInputs() ([]string, error) {
-	var res []string
-
-	if len(t.UnresolvedInputs.GolangSources.Paths) == 0 {
-		return res, nil
-	}
-
-	absGoSourcePaths := fs.AbsPaths(t.Directory, t.UnresolvedInputs.GolangSources.Paths)
-
-	// TODO use a logger instance
-	resolver := gosource.NewResolver(log.Debugf, t.UnresolvedInputs.GolangSources.Environment, absGoSourcePaths...)
-	paths, err := resolver.Resolve()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(paths) == 0 {
-		return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(paths, ", "))
-	}
-
-	res = append(res, paths...)
-
-	return res, nil
-}
-
-func (t *Task) pathsToUniqFiles(workingDir string, paths []string) ([]*File, error) {
-	dedupMap := make(map[string]struct{}, len(paths))
-	res := make([]*File, 0, len(paths))
-
-	for _, path := range paths {
-		if _, exist := dedupMap[path]; exist {
-			// TODO use a logger instance
-			log.Debugf("%s: removed duplicate Build Input '%s'", t.ID(), path)
-			continue
-		}
-		dedupMap[path] = struct{}{}
-
-		relPath, err := filepath.Rel(workingDir, path)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO: should resolving the relative path be done in
-		// Newfile() instead?
-		res = append(res, NewFile(workingDir, relPath))
-	}
-
-	return res, nil
 }
 
 // TODO: rename this function when the db and commands support multiple tasks.


### PR DESCRIPTION
```
        build: do not print 2 consecutive separator lines when no app needs to be build
        
-------------------------------------------------------------------------------
        remove BuildStatusBuildCommandUndefined
        
        Task definitions in the config file must have a Command defined otherwise the
        validation fails.
        Remove the BuildStatusBuildCommandUndefined, it's not needed anymore.
        
-------------------------------------------------------------------------------
        refactor resolving inputs of a task
        
        - Resolving inputs of a task is moved from the Task struct to an InputResolver
          struct
        - Inputs struct is introduced that has a caching method to calculate the total
          input digest
        - "baur build" will now always query the status of a build from the db, also
          when "--force" or "--skip-uploads" is passed
        
-------------------------------------------------------------------------------
        resolve: refactor resolvers
        
        The configuration parameters for resolvers are moved from their structs to the
        Resolve() methods.
        This allows to use the same resolver object for resolving different paths.
        The Resolver interface is removed. The Resolve functions do not have the same
        signature anymore. Also the interface can be defined in the package that uses
        the resolvers.

```