### PR TITLE
Support filtering by task names, add `baur status` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
 
   static_analysis:
     docker:
-      - image: golangci/golangci-lint:v1.23.3
+      - image: golangci/golangci-lint:v1.23.8
 
     working_directory: ~/baur
     steps:

--- a/internal/command/flag/buildstatus.go
+++ b/internal/command/flag/buildstatus.go
@@ -10,67 +10,68 @@ import (
 
 // Valid commandline values
 const (
-	buildStatusExist          = "exist"
-	buildStatusPending        = "pending"
-	buildStatusInputUndefined = "inputs-undefined"
+	taskStatusExist          = "exist"
+	taskStatusPending        = "pending"
+	taskStatusInputUndefined = "inputs-undefined"
 )
 
-// BuildStatusFormatDescription is the format description for the flag
-const BuildStatusFormatDescription string = "one of " +
-	buildStatusExist + ", " +
-	buildStatusPending + ", " +
-	buildStatusInputUndefined
+// TaskStatusFormatDescription is the format description for the flag
+const TaskStatusFormatDescription string = "one of " +
+	taskStatusExist + ", " +
+	taskStatusPending + ", " +
+	taskStatusInputUndefined
 
-// BuildStatus is a commandline parameter to specify build status filters
-type BuildStatus struct {
+// TaskStatus is a commandline parameter to specify build status filters
+type TaskStatus struct {
 	Status baur.BuildStatus
 	isSet  bool
 }
 
 // String returns the default value in the usage output
-func (b *BuildStatus) String() string {
+func (b *TaskStatus) String() string {
 	return ""
 }
 
 // Set parses the passed string and sets the SortFlagValue
-func (b *BuildStatus) Set(val string) error {
+func (b *TaskStatus) Set(val string) error {
 	b.isSet = true
 
 	switch strings.ToLower(val) {
-	case buildStatusExist:
+	case taskStatusExist:
 		b.Status = baur.BuildStatusExist
-	case buildStatusPending:
+	case taskStatusPending:
 		b.Status = baur.BuildStatusPending
-	case buildStatusInputUndefined:
-		b.Status = baur.BuildStatusPending
+	case taskStatusInputUndefined:
+		b.Status = baur.BuildStatusInputsUndefined
+
 	default:
-		return errors.New("status must be " + BuildStatusFormatDescription)
+		return errors.New("status must be " + TaskStatusFormatDescription)
 	}
 
 	return nil
 }
 
 // Type returns the format description of the flag
-func (b *BuildStatus) Type() string {
+func (b *TaskStatus) Type() string {
 	return "<STATUS>"
 }
 
 // Usage returns a usage description, important parts are passed through
 // highlightFn
-func (b *BuildStatus) Usage(highlightFn func(a ...interface{}) string) string {
+func (b *TaskStatus) Usage(highlightFn func(a ...interface{}) string) string {
 	return strings.TrimSpace(fmt.Sprintf(`
-Only show applications with this build status
+Only show tasks with this status
 Format: %s
 where %s is one of: %s, %s, %s`,
 		highlightFn(b.Type()),
 		highlightFn("STATUS"),
-		highlightFn(buildStatusExist),
-		highlightFn(buildStatusPending),
-		highlightFn(buildStatusInputUndefined),
+		highlightFn(taskStatusExist),
+		highlightFn(taskStatusPending),
+		highlightFn(taskStatusInputUndefined),
 	))
 }
 
 // IsSet returns true if the flag parsed a commandline value (Set() was called)
-func (b *BuildStatus) IsSet() bool {
+func (b *TaskStatus) IsSet() bool {
 	return b.isSet
 }

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -122,15 +122,15 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 
 	repoState := git.NewRepositoryState(repo.Path)
 
-	appLoader, err := baur.NewAppLoader(repo.Cfg, repoState.CommitID, log.StdLogger)
+	appLoader, err := baur.NewLoader(repo.Cfg, repoState.CommitID, log.StdLogger)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	if len(args) == 0 {
-		apps, err = appLoader.All()
+		apps, err = appLoader.AllApps()
 	} else {
-		apps, err = appLoader.Load(args...)
+		apps, err = appLoader.LoadApps(args...)
 	}
 
 	if err != nil {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/fatih/color"
@@ -127,12 +128,7 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 		log.Fatalln(err)
 	}
 
-	if len(args) == 0 {
-		apps, err = appLoader.AllApps()
-	} else {
-		apps, err = appLoader.LoadApps(args...)
-	}
-
+	apps, err = appLoader.LoadApps(args...)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -174,4 +170,36 @@ func bytesToMib(bytes int) string {
 
 func durationToStrSeconds(duration time.Duration) string {
 	return fmt.Sprintf("%.3f", duration.Seconds())
+}
+
+var errorPrefix = color.New(color.FgRed).Sprint("ERROR: ")
+
+func exitOnErrf(err error, format string, v ...interface{}) {
+	if err == nil {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, errorPrefix+format, v...)
+
+	os.Exit(1)
+}
+
+func exitOnErr(err error, msg ...interface{}) {
+	if err == nil {
+		return
+	}
+
+	if len(msg) != 0 {
+		msg[0] = fmt.Sprintf("%s%s", errorPrefix, msg[0])
+		fmt.Fprintln(os.Stderr, msg...)
+	}
+
+	os.Exit(1)
+}
+
+func mustTaskRepoRelPath(repositoryDir string, task *baur.Task) string {
+	path, err := filepath.Rel(repositoryDir, task.Directory)
+	exitOnErr(err)
+
+	return path
 }

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -12,149 +12,99 @@ import (
 	"github.com/simplesurance/baur/format/table"
 	"github.com/simplesurance/baur/internal/command/flag"
 	"github.com/simplesurance/baur/log"
-	"github.com/simplesurance/baur/storage"
 )
 
 const (
-	lsAppNameHeader        = "Name"
-	lsAppNameParam         = "name"
-	lsAppPathHeader        = "Path"
-	lsAppPathParam         = "path"
-	lsAppBuildStatusHeader = "Build Status"
-	lsAppBuildStatusParam  = "build-status"
-	lsAppBuildIDHeader     = "Build ID"
-	lsAppBuildIDParam      = "build-id"
-	lsAppGitCommitHeader   = "Git Commit"
-	lsAppGitCommitParam    = "git-commit"
+	lsAppNameHeader = "Name"
+	lsAppNameParam  = "name"
+	lsAppPathHeader = "Path"
+	lsAppPathParam  = "path"
 )
 
-type lsAppsConf struct {
-	csv         bool
-	quiet       bool
-	absPaths    bool
-	buildStatus flag.BuildStatus
-	fields      *flag.Fields
-}
-
-var lsAppsCmd = &cobra.Command{
-	Use:   "apps [<APP-NAME>|<PATH>]...",
-	Short: "list applications and their status",
-	Run:   ls,
-	Args:  cobra.ArbitraryArgs,
-}
-
-var lsAppsConfig lsAppsConf
-
 func init() {
-	lsAppsCmd.Flags().BoolVar(&lsAppsConfig.csv, "csv", false,
+	lsCmd.AddCommand(&newLsAppsCmd().Command)
+}
+
+type lsAppsCmd struct {
+	cobra.Command
+
+	csv      bool
+	quiet    bool
+	absPaths bool
+	fields   *flag.Fields
+}
+
+func newLsAppsCmd() *lsAppsCmd {
+	cmd := lsAppsCmd{
+		Command: cobra.Command{
+			Use:   "apps [<APP-NAME>|<PATH>]...",
+			Short: "list applications",
+			Args:  cobra.ArbitraryArgs,
+		},
+
+		fields: flag.NewFields([]string{
+			lsAppNameParam,
+			lsAppPathParam,
+		}),
+	}
+
+	cmd.Run = cmd.run
+
+	cmd.Flags().BoolVar(&cmd.csv, "csv", false,
 		"List applications in RFC4180 CSV format")
 
-	lsAppsCmd.Flags().BoolVarP(&lsAppsConfig.quiet, "quiet", "q", false,
+	cmd.Flags().BoolVarP(&cmd.quiet, "quiet", "q", false,
 		"Suppress printing a header and progress dots")
 
-	lsAppsCmd.Flags().BoolVar(&lsAppsConfig.absPaths, "abs-path", false,
+	cmd.Flags().BoolVar(&cmd.absPaths, "abs-path", false,
 		"Show absolute instead of relative paths")
 
-	lsAppsCmd.Flags().VarP(&lsAppsConfig.buildStatus, "build-status", "s",
-		lsAppsConfig.buildStatus.Usage(highlight))
+	cmd.Flags().VarP(cmd.fields, "fields", "f",
+		cmd.fields.Usage(highlight))
 
-	lsAppsConfig.fields = flag.NewFields([]string{
-		lsAppNameParam,
-		lsAppPathParam,
-		lsAppBuildIDParam,
-		lsAppBuildStatusParam,
-		lsAppGitCommitParam,
-	})
-	lsAppsCmd.Flags().VarP(lsAppsConfig.fields, "fields", "f",
-		lsAppsConfig.fields.Usage(highlight))
+	return &cmd
 
-	lsCmd.AddCommand(lsAppsCmd)
 }
 
-func createHeader() []string {
+func (c *lsAppsCmd) createHeader() []string {
 	var headers []string
 
-	for _, f := range lsAppsConfig.fields.Fields {
+	for _, f := range c.fields.Fields {
 		switch f {
 		case lsAppNameParam:
 			headers = append(headers, lsAppNameHeader)
 		case lsAppPathParam:
 			headers = append(headers, lsAppPathHeader)
-		case lsAppBuildStatusParam:
-			headers = append(headers, lsAppBuildStatusHeader)
-		case lsAppBuildIDParam:
-			headers = append(headers, lsAppBuildIDHeader)
-		case lsAppGitCommitParam:
-			headers = append(headers, lsAppGitCommitHeader)
+
 		default:
 			panic(fmt.Sprintf("unsupported value '%v' in fields parameter", f))
-
 		}
 	}
 
 	return headers
 }
 
-func ls(cmd *cobra.Command, args []string) {
+func (c *lsAppsCmd) run(cmd *cobra.Command, args []string) {
 	var headers []string
 	var formatter format.Formatter
-	var storageClt storage.Storer
 
 	repo := MustFindRepository()
 	apps := mustArgToApps(repo, args)
-	writeHeaders := !lsAppsConfig.quiet && !lsAppsConfig.csv
-	storageQueryNeeded := storageQueryIsNeeded()
 
-	if storageQueryNeeded {
-		storageClt = MustGetPostgresClt(repo)
+	if !c.quiet && !c.csv {
+		headers = c.createHeader()
 	}
 
-	if writeHeaders {
-		headers = createHeader()
-	}
-
-	if lsAppsConfig.csv {
+	if c.csv {
 		formatter = csv.New(headers, os.Stdout)
 	} else {
 		formatter = table.New(headers, os.Stdout)
 	}
 
-	showProgress := len(apps) >= 5 && !lsAppsConfig.quiet && !lsAppsConfig.csv
-
 	baur.SortAppsByName(apps)
 
-	for i, app := range apps {
-		var row []interface{}
-		var build *storage.BuildWithDuration
-		var taskStatus baur.BuildStatus
-
-		task := app.Task()
-
-		if storageQueryNeeded {
-			var err error
-
-			taskStatus, build, err = baur.TaskRunStatus(task, repo.Path, storageClt)
-			if err != nil {
-				log.Fatalf("gathering informations for %s failed: %s", app, err)
-			}
-
-			// querying the build status for all applications can
-			// take some time, output progress dots to let the user
-			// know that something is happening
-			if showProgress {
-				fmt.Printf(".")
-
-				if i+1 == len(apps) {
-					fmt.Printf("\n\n")
-				}
-			}
-		}
-
-		if lsAppsConfig.buildStatus.IsSet() && taskStatus != lsAppsConfig.buildStatus.Status {
-			continue
-		}
-
-		row = assembleRow(app, build, taskStatus)
+	for _, app := range apps {
+		row := c.assembleRow(app)
 
 		if err := formatter.WriteRow(row); err != nil {
 			log.Fatalln(err)
@@ -166,52 +116,19 @@ func ls(cmd *cobra.Command, args []string) {
 	}
 }
 
-func storageQueryIsNeeded() bool {
-	for _, f := range lsAppsConfig.fields.Fields {
-		switch f {
-		case lsAppBuildStatusParam:
-			return true
-		case lsAppBuildIDParam:
-			return true
-		case lsAppGitCommitParam:
-			return true
-		}
-	}
+func (c *lsAppsCmd) assembleRow(app *baur.App) []interface{} {
+	row := make([]interface{}, 0, 2)
 
-	return false
-}
-
-func assembleRow(app *baur.App, build *storage.BuildWithDuration, buildStatus baur.BuildStatus) []interface{} {
-	var row []interface{}
-
-	for _, f := range lsAppsConfig.fields.Fields {
+	for _, f := range c.fields.Fields {
 		switch f {
 		case lsAppNameParam:
 			row = append(row, app.Name)
 
 		case lsAppPathParam:
-			if lsAppsConfig.absPaths {
+			if c.absPaths {
 				row = append(row, app.Path)
 			} else {
 				row = append(row, app.RelPath)
-			}
-
-		case lsAppBuildStatusParam:
-			row = append(row, buildStatus)
-
-		case lsAppBuildIDParam:
-			if buildStatus == baur.BuildStatusExist {
-				row = append(row, fmt.Sprint(build.ID))
-			} else {
-				// no build exist, we don't have a build id
-				row = append(row, "")
-			}
-
-		case lsAppGitCommitParam:
-			if buildStatus == baur.BuildStatusExist {
-				row = append(row, fmt.Sprint(build.VCSState.CommitID))
-			} else {
-				row = append(row, "")
 			}
 		}
 	}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime/pprof"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/baur/exec"
@@ -21,6 +22,7 @@ var rootCmd = &cobra.Command{
 
 var verboseFlag bool
 var cpuProfilingFlag bool
+var noColorFlag bool
 
 var defCPUProfFile = filepath.Join(os.TempDir(), "baur-cpu.prof")
 
@@ -28,6 +30,10 @@ func initSb(_ *cobra.Command, _ []string) {
 	if verboseFlag {
 		log.StdLogger.EnableDebug(verboseFlag)
 		exec.DefaultDebugfFn = log.StdLogger.Debugf
+	}
+
+	if noColorFlag {
+		color.NoColor = true
 	}
 
 	if cpuProfilingFlag {
@@ -52,6 +58,7 @@ func Execute() {
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&cpuProfilingFlag, "cpu-prof", false,
 		fmt.Sprintf("enable cpu profiling, result is written to %q", defCPUProfFile))
+	rootCmd.PersistentFlags().BoolVar(&noColorFlag, "no-color", false, "disable color output")
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalln(err)

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -1,0 +1,235 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simplesurance/baur"
+	"github.com/simplesurance/baur/format"
+	"github.com/simplesurance/baur/format/csv"
+	"github.com/simplesurance/baur/format/table"
+	"github.com/simplesurance/baur/git"
+	"github.com/simplesurance/baur/internal/command/flag"
+	"github.com/simplesurance/baur/log"
+	"github.com/simplesurance/baur/storage"
+)
+
+const (
+	statusNameHeader      = "Task ID"
+	statusNameParam       = "task-id"
+	statusPathHeader      = "Path"
+	statusPathParam       = "path"
+	statusStatusHeader    = "Status"
+	statusStatusParam     = "status"
+	statusRunIDHeader     = "Run ID"
+	statusRunIDParam      = "run-id"
+	statusGitCommitHeader = "Git Commit"
+	statusGitCommitParam  = "git-commit"
+)
+
+func init() {
+	rootCmd.AddCommand(&newStatusCmd().Command)
+}
+
+type statusCmd struct {
+	cobra.Command
+
+	csv         bool
+	quiet       bool
+	absPaths    bool
+	buildStatus flag.TaskStatus
+	fields      *flag.Fields
+}
+
+func newStatusCmd() *statusCmd {
+	cmd := statusCmd{
+		Command: cobra.Command{
+			Use:   "status [<SPEC>|<PATH>]...",
+			Short: "list status of tasks",
+			Args:  cobra.ArbitraryArgs,
+		},
+
+		fields: flag.NewFields([]string{
+			statusNameParam,
+			statusPathParam,
+			statusRunIDParam,
+			statusStatusParam,
+			statusGitCommitParam,
+		}),
+	}
+	cmd.Run = cmd.run
+
+	cmd.Flags().BoolVar(&cmd.csv, "csv", false,
+		"List applications in RFC4180 CSV format")
+
+	cmd.Flags().BoolVarP(&cmd.quiet, "quiet", "q", false,
+		"Suppress printing a header and progress dots")
+
+	cmd.Flags().BoolVar(&cmd.absPaths, "abs-path", false,
+		"Show absolute instead of relative paths")
+
+	// TODO: refactor buildStatus struct
+	cmd.Flags().VarP(&cmd.buildStatus, "status", "s",
+		cmd.buildStatus.Usage(highlight))
+
+	cmd.Flags().VarP(cmd.fields, "fields", "f",
+		cmd.fields.Usage(highlight))
+
+	return &cmd
+}
+
+func (c *statusCmd) statusCreateHeader() []string {
+	var headers []string
+
+	for _, f := range c.fields.Fields {
+		switch f {
+		case statusNameParam:
+			headers = append(headers, statusNameHeader)
+		case statusPathParam:
+			headers = append(headers, statusPathHeader)
+		case statusStatusParam:
+			headers = append(headers, statusStatusHeader)
+		case statusRunIDParam:
+			headers = append(headers, statusRunIDHeader)
+		case statusGitCommitParam:
+			headers = append(headers, statusGitCommitHeader)
+
+		default:
+			panic(fmt.Sprintf("unsupported value '%v' in fields parameter", f))
+		}
+	}
+
+	return headers
+}
+
+func (c *statusCmd) run(cmd *cobra.Command, args []string) {
+	var headers []string
+	var formatter format.Formatter
+	var storageClt storage.Storer
+
+	repo := MustFindRepository()
+
+	loader, err := baur.NewLoader(
+		repo.Cfg,
+		git.NewRepositoryState(repo.Path).CommitID,
+		log.StdLogger,
+	)
+	exitOnErr(err)
+
+	tasks, err := loader.LoadTasks(args...)
+	exitOnErr(err)
+
+	writeHeaders := !c.quiet && !c.csv
+	storageQueryNeeded := c.storageQueryIsNeeded()
+
+	if storageQueryNeeded {
+		storageClt = MustGetPostgresClt(repo)
+	}
+
+	if writeHeaders {
+		headers = c.statusCreateHeader()
+	}
+
+	if c.csv {
+		formatter = csv.New(headers, os.Stdout)
+	} else {
+		formatter = table.New(headers, os.Stdout)
+	}
+
+	showProgress := len(tasks) >= 5 && !c.quiet && !c.csv
+
+	baur.SortTasksByID(tasks)
+
+	for i, task := range tasks {
+		var row []interface{}
+		var build *storage.BuildWithDuration
+		var taskStatus baur.BuildStatus
+
+		if storageQueryNeeded {
+			var err error
+
+			taskStatus, build, err = baur.TaskRunStatus(task, repo.Path, storageClt)
+			exitOnErrf(err, "gathering informations for %s failed: %s", task, err)
+
+			// querying the build status for all applications can
+			// take some time, output progress dots to let the user
+			// know that something is happening
+			if showProgress {
+				fmt.Printf(".")
+
+				if i+1 == len(tasks) {
+					fmt.Printf("\n\n")
+				}
+			}
+		}
+
+		if c.buildStatus.IsSet() && taskStatus != c.buildStatus.Status {
+			continue
+		}
+
+		row = c.statusAssembleRow(repo.Path, task, build, taskStatus)
+
+		if err := formatter.WriteRow(row); err != nil {
+			log.Fatalln(err)
+		}
+	}
+
+	if err := formatter.Flush(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func (c *statusCmd) storageQueryIsNeeded() bool {
+	for _, f := range c.fields.Fields {
+		switch f {
+		case statusStatusParam:
+			return true
+		case statusRunIDParam:
+			return true
+		case statusGitCommitParam:
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *statusCmd) statusAssembleRow(repositoryDir string, task *baur.Task, build *storage.BuildWithDuration, buildStatus baur.BuildStatus) []interface{} {
+	var row []interface{}
+
+	for _, f := range c.fields.Fields {
+		switch f {
+		case statusNameParam:
+			row = append(row, task.ID())
+
+		case statusPathParam:
+			if c.absPaths {
+				row = append(row, task.Directory)
+			} else {
+				row = append(row, mustTaskRepoRelPath(repositoryDir, task))
+			}
+
+		case statusStatusParam:
+			row = append(row, buildStatus)
+
+		case statusRunIDParam:
+			if buildStatus == baur.BuildStatusExist {
+				row = append(row, fmt.Sprint(build.ID))
+			} else {
+				// no build exist, we don't have a build id
+				row = append(row, "")
+			}
+
+		case statusGitCommitParam:
+			if buildStatus == baur.BuildStatusExist {
+				row = append(row, fmt.Sprint(build.VCSState.CommitID))
+			} else {
+				row = append(row, "")
+			}
+		}
+	}
+
+	return row
+}

--- a/loader.go
+++ b/loader.go
@@ -68,16 +68,21 @@ func splitSpecifiers(specifiers []string) (names, cfgPaths []string, star bool) 
 }
 
 // LoadTasks loads the tasks of apps that match the passed specifier.
-// Specifier format is <APP-SPEC>[.<TASK-SPEC>]
+// Specifier format is <APP-SPEC>[.<TASK-SPEC>].
 // <APP-SPEC> is:
 //   - <APP-NAME> or
 //   - '*'
 // <TASK-SPEC> is:
 //   - Task Name or
 //   - '*'
+// If no specifier is passed all tasks of all apps are returned.
 // If multiple specifiers match the same task, it's only returned 1x in the returned slice.
 func (a *Loader) LoadTasks(specifier ...string) ([]*Task, error) {
 	var result []*Task
+
+	if len(specifier) == 0 {
+		specifier = []string{"*"}
+	}
 
 	for _, spec := range specifier {
 		spl := strings.Split(spec, ".")
@@ -113,12 +118,13 @@ func (a *Loader) LoadTasks(specifier ...string) ([]*Task, error) {
 // - application directory path
 // - <APP-NAME>
 // - '*'
+// If no specifier is passed all apps are returned.
 // If multiple specifiers match the same app, it's only returned 1x in the returned slice.
 func (a *Loader) LoadApps(specifier ...string) ([]*App, error) {
 	names, cfgPaths, star := splitSpecifiers(specifier)
 
-	if star {
-		return a.AllApps()
+	if star || len(specifier) == 0 {
+		return a.allApps()
 	}
 
 	result := make([]*App, 0, len(specifier))
@@ -193,8 +199,7 @@ func (a *Loader) AppNames(names ...string) ([]*App, error) {
 	return result, nil
 }
 
-// AllApps loads all apps in the repository.
-func (a *Loader) AllApps() ([]*App, error) {
+func (a *Loader) allApps() ([]*App, error) {
 	a.logger.Debugf("loader: loading all apps")
 
 	result := make([]*App, 0, len(a.appConfigPaths))


### PR DESCRIPTION
```
        baur: add global parameter to disable colored output
        
-------------------------------------------------------------------------------
        circleci: update golangci-lint to 1.23.8
        
-------------------------------------------------------------------------------
        baur: introduce status command
        
        - "baur status" shows the run status of tasks, same what "baur ls apps" did so
          far but for tasks
        - "baur ls apps" only shows static informations about apps now
        - loader: when passing no args to LoadApps() or LoadTasks() it has the same
          effect then passing '*'. This makes it easier to use from the command package.
        
-------------------------------------------------------------------------------
        apploader: add methods to load tasks
        
        - rename AppLoader to Loader
        - add method LoadTasks(), to load tasks that match a '<APP-SPEC>.<TASK-SPEC>'
          specification
        

```