### PR TITLE
cfg: support resolving $ROOT and $APPNAME variables in command field

### DIFF
--- a/app.go
+++ b/app.go
@@ -197,12 +197,16 @@ func NewApp(repository *Repository, cfgPath string) (*App, error) {
 		return nil, errors.Wrapf(err, "%s: resolving repository relative application path failed", appCfg.Name)
 	}
 
+	cmd := strings.TrimSpace(appCfg.Build.Command)
+	cmd = replaceROOTvar(cmd, repository)
+	cmd = replaceAppNameVar(cmd, appCfg.Name)
+
 	app := App{
 		Repository: repository,
 		Path:       path.Dir(cfgPath),
 		RelPath:    appRelPath,
 		Name:       appCfg.Name,
-		BuildCmd:   strings.TrimSpace(appCfg.Build.Command),
+		BuildCmd:   cmd,
 	}
 
 	err = app.addBuildOutput(&appCfg.Build.Output)

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -17,7 +17,7 @@ type App struct {
 
 // Build the build section
 type Build struct {
-	Command  string      `toml:"command" commented:"false" comment:"Command to build the application"`
+	Command  string      `toml:"command" commented:"false" comment:"Command to build the application, valid variables: $ROOT, $APPNAME"`
 	Includes []string    `toml:"includes" comment:"Repository relative paths to baur include files that the build inherits.\n Valid variables: $ROOT"`
 	Input    BuildInput  `comment:"Specification of build inputs like source files, Makefiles, etc"`
 	Output   BuildOutput `comment:"Specification of build outputs produced by the [Build.command]"`
@@ -32,7 +32,7 @@ type BuildInput struct {
 
 // GolangSources specifies inputs for Golang Applications
 type GolangSources struct {
-	Environment []string `toml:"environment" comment:"Environment to use when discovering Golang source files\n This can be environment variables understood by the Golang tools, like GOPATH, GOFLAGS, etc.\n If empty the default Go environment is used.\n Valid variables: $ROOT " commented:"true"`
+	Environment []string `toml:"environment" comment:"Environment to use when discovering Golang source files\n This can be environment variables understood by the Golang tools, like GOPATH, GOFLAGS, etc.\n If empty the default Go environment is used.\n Valid variables: $ROOT" commented:"true"`
 	Paths       []string `toml:"paths" comment:"Paths to directories containing Golang source files.\n All source files including imported packages are discovered,\n files from Go's stdlib package and testfiles are ignored." commented:"true"`
 }
 

--- a/cfg/repository.go
+++ b/cfg/repository.go
@@ -14,7 +14,7 @@ const (
 	// configVersion identifies the format of the configuration files,
 	// whenever an incompatible change is made, this number has to be
 	// increased
-	configVersion int = 3
+	configVersion int = 4
 )
 
 // Repository contains the repository configuration.


### PR DESCRIPTION
The $ROOT and $APPNAME variables can be specified in the Command field of the
.app.toml files and are resolved before execution.

The config version is incremented to 4.

This closes #152 