### PR TITLE
Commands: harmonize command code, small changes to represent tasks instead of builds

### DIFF
--- a/format/csv/csv.go
+++ b/format/csv/csv.go
@@ -32,7 +32,7 @@ func (f *Formatter) writeHeader(headers []string) error {
 }
 
 // WriteRow writes a row to the csvwriter buffer
-func (f *Formatter) WriteRow(row []interface{}) error {
+func (f *Formatter) WriteRow(row ...interface{}) error {
 	var str []string
 
 	for _, col := range row {

--- a/format/format.go
+++ b/format/format.go
@@ -3,6 +3,6 @@ package format
 
 // Formatter is an interface for formatters
 type Formatter interface {
-	WriteRow(Row []interface{}) error
+	WriteRow(Row ...interface{}) error
 	Flush() error
 }

--- a/format/table/table.go
+++ b/format/table/table.go
@@ -38,7 +38,7 @@ func (f *Formatter) writeHeader(headers []string) error {
 }
 
 // WriteRow writes a row to the tabwriter buffer
-func (f *Formatter) WriteRow(row []interface{}) error {
+func (f *Formatter) WriteRow(row ...interface{}) error {
 	var rowStr string
 
 	for i, col := range row {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -41,7 +41,7 @@ func mustFindRepository() *baur.Repository {
 				baur.RepositoryCfgFile)
 		}
 
-		log.Fatalln("locating baur repository failed:", err)
+		exitOnErr(err, "locating baur repository failed")
 	}
 
 	return repo
@@ -150,14 +150,10 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 	repoState := git.NewRepositoryState(repo.Path)
 
 	appLoader, err := baur.NewLoader(repo.Cfg, repoState.CommitID, log.StdLogger)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	exitOnErr(err)
 
 	apps, err = appLoader.LoadApps(args...)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	exitOnErr(err)
 
 	if len(apps) == 0 {
 		log.Fatalf("could not find any applications\n"+
@@ -172,9 +168,7 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 
 func mustWriteRowVa(fmt format.Formatter, row ...interface{}) {
 	err := fmt.WriteRow(row)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	exitOnErr(err)
 }
 
 var errorPrefix = color.New(color.FgRed).Sprint("ERROR:")

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -166,7 +166,7 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 	return apps
 }
 
-func mustWriteRowVa(fmt format.Formatter, row ...interface{}) {
+func mustWriteRow(fmt format.Formatter, row ...interface{}) {
 	err := fmt.WriteRow(row...)
 	exitOnErr(err)
 }

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -178,11 +178,6 @@ func mustWriteRowVa(fmt format.Formatter, row ...interface{}) {
 	}
 }
 
-// Deprecated: use  mustWriteRowVa
-func mustWriteRow(fmt format.Formatter, row []interface{}) {
-	mustWriteRowVa(fmt, row...)
-}
-
 var errorPrefix = color.New(color.FgRed).Sprint("ERROR:")
 
 func exitOnErrf(err error, format string, v ...interface{}) {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -32,9 +32,8 @@ func findRepository() (*baur.Repository, error) {
 	return baur.NewRepository(path)
 }
 
-// MustFindRepository must find repo
-// TODO: rename to mustFindRepository
-func MustFindRepository() *baur.Repository {
+// mustFindRepository must find repo
+func mustFindRepository() *baur.Repository {
 	repo, err := findRepository()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -203,7 +203,6 @@ func exitOnErr(err error, msg ...interface{}) {
 	fmt.Fprintf(os.Stderr, "%s %s: %s\n", errorPrefix, wholeMsg, err)
 
 	os.Exit(1)
-
 }
 
 func mustTaskRepoRelPath(repositoryDir string, task *baur.Task) string {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -167,7 +167,7 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 }
 
 func mustWriteRowVa(fmt format.Formatter, row ...interface{}) {
-	err := fmt.WriteRow(row)
+	err := fmt.WriteRow(row...)
 	exitOnErr(err)
 }
 

--- a/internal/command/init_app.go
+++ b/internal/command/init_app.go
@@ -35,7 +35,7 @@ var initAppCmd = &cobra.Command{
 
 func initApp(cmd *cobra.Command, args []string) {
 	var appName string
-	MustFindRepository()
+	mustFindRepository()
 
 	cwd, err := os.Getwd()
 	exitOnErr(err)

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -87,7 +87,7 @@ func (c *lsAppsCmd) run(cmd *cobra.Command, args []string) {
 	var headers []string
 	var formatter format.Formatter
 
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 	apps := mustArgToApps(repo, args)
 
 	if !c.quiet && !c.csv {

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -105,8 +105,7 @@ func (c *lsAppsCmd) run(cmd *cobra.Command, args []string) {
 	for _, app := range apps {
 		row := c.assembleRow(app)
 
-		err := formatter.WriteRow(row)
-		exitOnErr(err)
+		mustWriteRowVa(formatter, row...)
 	}
 
 	err := formatter.Flush()

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -105,7 +105,7 @@ func (c *lsAppsCmd) run(cmd *cobra.Command, args []string) {
 	for _, app := range apps {
 		row := c.assembleRow(app)
 
-		mustWriteRowVa(formatter, row...)
+		mustWriteRow(formatter, row...)
 	}
 
 	err := formatter.Flush()

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -52,7 +52,7 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 	var formatter format.Formatter
 	var headers []string
 
-	rep := MustFindRepository()
+	rep := mustFindRepository()
 	task := mustArgToTask(rep, args[0])
 	writeHeaders := !c.quiet && !c.csv
 

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -86,14 +86,14 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 
 	for _, input := range inputs.Files {
 		if !c.showDigest || c.quiet {
-			mustWriteRowVa(formatter, input)
+			mustWriteRow(formatter, input)
 			continue
 		}
 
 		digest, err := input.Digest()
 		exitOnErrf(err, "%s: calculating digest failed", input)
 
-		mustWriteRowVa(formatter, input, digest.String())
+		mustWriteRow(formatter, input, digest.String())
 	}
 
 	err = formatter.Flush()

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -21,7 +21,7 @@ type lsInputsConf struct {
 
 var lsInputsCmd = &cobra.Command{
 	Use:   "inputs <APP-NAME>.<TASK-NAME>]",
-	Short: "list resolved build inputs of an application",
+	Short: "list resolved task inputs of an application",
 	Run:   lsInputs,
 	Args:  cobra.ExactArgs(1),
 }
@@ -84,7 +84,7 @@ func lsInputs(cmd *cobra.Command, args []string) {
 		}
 
 		digest, err := input.Digest()
-		exitOnErr(err, "calculating digest failed")
+		exitOnErrf(err, "%s: calculating digest failed", input)
 
 		mustWriteRowVa(formatter, input, digest.String())
 	}

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -20,7 +20,7 @@ type lsInputsConf struct {
 }
 
 var lsInputsCmd = &cobra.Command{
-	Use:   "inputs [<APP-NAME>.<TASK-NAME>]",
+	Use:   "inputs <APP-NAME>.<TASK-NAME>]",
 	Short: "list resolved build inputs of an application",
 	Run:   lsInputs,
 	Args:  cobra.ExactArgs(1),
@@ -79,14 +79,14 @@ func lsInputs(cmd *cobra.Command, args []string) {
 
 	for _, input := range inputs.Files {
 		if !lsInputsConfig.showDigest || lsInputsConfig.quiet {
-			mustWriteRow(formatter, []interface{}{input})
+			mustWriteRowVa(formatter, input)
 			continue
 		}
 
 		digest, err := input.Digest()
 		exitOnErr(err, "calculating digest failed")
 
-		mustWriteRow(formatter, []interface{}{input, digest.String()})
+		mustWriteRowVa(formatter, input, digest.String())
 	}
 
 	err = formatter.Flush()

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -76,11 +76,11 @@ func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
 	for _, o := range outputs {
 		for _, upload := range o.Uploads {
 			if c.quiet {
-				mustWriteRow(formatter, []interface{}{upload.URI})
+				mustWriteRowVa(formatter, upload.URI)
 				continue
 			}
 
-			mustWriteRow(formatter, []interface{}{
+			mustWriteRowVa(formatter,
 				upload.URI,
 				o.Digest,
 				term.FormatSize(o.SizeBytes, term.FormatBaseWithoutUnitName(c.csv)),
@@ -90,7 +90,7 @@ func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
 				),
 				o.Type,
 				upload.Method,
-			})
+			)
 		}
 	}
 

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -74,32 +73,17 @@ func lsOutputs(cmd *cobra.Command, args []string) {
 				continue
 			}
 
-			if lsOutputsConf.csv {
-				mustWriteRow(formatter, []interface{}{
-					upload.URI,
-					o.Digest,
-					o.SizeBytes,
-					fmt.Sprintf("%.3f",
-						upload.UploadStopTimestamp.Sub(upload.UploadStartTimestamp).Seconds(),
-					),
-					o.Type,
-					upload.Method,
-				})
-
-				continue
-			}
-
 			mustWriteRow(formatter, []interface{}{
 				upload.URI,
 				o.Digest,
-				term.FormatSize(o.SizeBytes),
+				term.FormatSize(o.SizeBytes, term.FormatBaseWithoutUnitName(lsOutputsConf.csv)),
 				term.FormatDuration(
 					upload.UploadStopTimestamp.Sub(upload.UploadStartTimestamp),
+					term.FormatBaseWithoutUnitName(lsOutputsConf.csv),
 				),
 				o.Type,
 				upload.Method,
 			})
-
 		}
 	}
 

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -46,7 +46,7 @@ func newLsOutputsCmd() *lsOutputsCmd {
 }
 
 func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 	pgClient := mustNewCompatibleStorage(repo)
 
 	taskRunID, err := strconv.Atoi(args[0])

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -76,11 +76,11 @@ func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
 	for _, o := range outputs {
 		for _, upload := range o.Uploads {
 			if c.quiet {
-				mustWriteRowVa(formatter, upload.URI)
+				mustWriteRow(formatter, upload.URI)
 				continue
 			}
 
-			mustWriteRowVa(formatter,
+			mustWriteRow(formatter,
 				upload.URI,
 				o.Digest,
 				term.FormatSize(o.SizeBytes, term.FormatBaseWithoutUnitName(c.csv)),

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -113,7 +113,7 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 
 	c.app, c.task = parseSpec(args[0])
 
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 	psql := mustNewCompatibleStorage(repo)
 
 	var formatter format.Formatter

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -100,7 +100,7 @@ func parseSpec(s string) (app, task string) {
 	}
 
 	// is never executed because of the default case
-	return "", ""
+	panic("default case not run")
 }
 
 func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -181,6 +181,7 @@ func (c *lsRunsCmd) printTaskRun(formatter format.Formatter, taskRun *storage.Ta
 		taskRun.StartTimestamp.Format(flag.DateTimeFormatTz),
 		term.FormatDuration(
 			taskRun.StopTimestamp.Sub(taskRun.StartTimestamp),
+			term.FormatBaseWithoutUnitName(c.csv),
 		),
 		taskRun.TotalInputDigest,
 	)

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -156,7 +156,7 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 }
 
 func printHeader(formatter format.Formatter) {
-	mustWriteRowVa(
+	mustWriteRow(
 		formatter,
 		"Id",
 		"App",
@@ -170,10 +170,10 @@ func printHeader(formatter format.Formatter) {
 
 func (c *lsRunsCmd) printTaskRun(formatter format.Formatter, taskRun *storage.TaskRunWithID) {
 	if c.quiet {
-		mustWriteRowVa(formatter, taskRun.ID)
+		mustWriteRow(formatter, taskRun.ID)
 	}
 
-	mustWriteRowVa(formatter,
+	mustWriteRow(formatter,
 		strconv.Itoa(taskRun.ID),
 		taskRun.ApplicationName,
 		taskRun.TaskName,

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -148,7 +148,7 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 			log.Fatalf("no matching task runs exist")
 		}
 
-		log.Fatalln(err)
+		exitOnErr(err)
 	}
 
 	exitOnErr(formatter.Flush())

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -139,7 +139,8 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 		filters,
 		sorters,
 		func(taskRun *storage.TaskRunWithID) error {
-			return c.printTaskRun(formatter, taskRun)
+			c.printTaskRun(formatter, taskRun)
+			return nil
 		},
 	)
 
@@ -155,7 +156,8 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 }
 
 func printHeader(formatter format.Formatter) {
-	exitOnErr(formatter.WriteRow([]interface{}{
+	mustWriteRowVa(
+		formatter,
 		"Id",
 		"App",
 		"Task",
@@ -163,15 +165,15 @@ func printHeader(formatter format.Formatter) {
 		"Start Time",
 		"Duration (s)",
 		"Input Digest",
-	}))
+	)
 }
 
-func (c *lsRunsCmd) printTaskRun(formatter format.Formatter, taskRun *storage.TaskRunWithID) error {
+func (c *lsRunsCmd) printTaskRun(formatter format.Formatter, taskRun *storage.TaskRunWithID) {
 	if c.quiet {
-		return formatter.WriteRow([]interface{}{taskRun.ID})
+		mustWriteRowVa(formatter, taskRun.ID)
 	}
 
-	return formatter.WriteRow([]interface{}{
+	mustWriteRowVa(formatter,
 		strconv.Itoa(taskRun.ID),
 		taskRun.ApplicationName,
 		taskRun.TaskName,
@@ -181,7 +183,7 @@ func (c *lsRunsCmd) printTaskRun(formatter format.Formatter, taskRun *storage.Ta
 			taskRun.StopTimestamp.Sub(taskRun.StartTimestamp),
 		),
 		taskRun.TotalInputDigest,
-	})
+	)
 }
 
 func (c *lsRunsCmd) getFilters() []*storage.Filter {

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -163,7 +163,7 @@ func printHeader(formatter format.Formatter) {
 		"Task",
 		"Result",
 		"Start Time",
-		"Duration (s)",
+		"Duration",
 		"Input Digest",
 	)
 }

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -18,11 +18,11 @@ import (
 )
 
 const lsRunsLongHelp = `
-List  recorded task runs.
+List recorded task runs.
 
 Arguments:
-	'*' can be passed as <APP-NAME> and <TASK-NAME> argument to match
-	all Apps and Tasks.
+	'*' can be passed as <APP-NAME> or <TASK-NAME> argument to match
+	all Apps or Tasks.
 `
 
 const lsRunsExample = `
@@ -30,7 +30,7 @@ baur ls runs -s duration-desc calc               list task runs of the calc
 						 application, sorted by
 						 run duration
 baur ls runs --csv --after=2018.09.27-11:30 '*'  list all task runs in csv format that
-						 started after 2018.09.27 11:30`
+						 were started after 2018.09.27 11:30`
 
 func init() {
 	lsCmd.AddCommand(&newLsRunsCmd().Command)
@@ -53,7 +53,7 @@ func newLsRunsCmd() *lsRunsCmd {
 	cmd := lsRunsCmd{
 		Command: cobra.Command{
 			Use:     "runs <APP-NAME>[.<TASK-NAME>]",
-			Short:   "list record task runs",
+			Short:   "list recorded task runs",
 			Long:    strings.TrimSpace(lsRunsLongHelp),
 			Example: strings.TrimSpace(lsRunsExample),
 			Args:    cobra.ExactArgs(1),

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -18,7 +18,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:              "baur",
-	Short:            "baur manages builds and artifacts in mono repositories.",
+	Short:            "baur is a task runner for mono repositories.",
 	PersistentPreRun: initSb,
 }
 

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -58,7 +58,7 @@ func initSb(_ *cobra.Command, _ []string) {
 // Execute parses commandline flags and execute their actions
 func Execute() {
 	if err := version.LoadPackageVars(); err != nil {
-		log.Errorln("setting version failed", err)
+		stderr.Printf("setting version failed: %s\n", err)
 	}
 	rootCmd.Version = version.CurSemVer.String()
 

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -134,7 +134,7 @@ func dockerClient() *docker.Client {
 func (c *runCmd) run(cmd *cobra.Command, args []string) {
 	startTime := time.Now()
 
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 	c.repoRootPath = repo.Path
 
 	c.storage = mustNewCompatibleStorage(repo)

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -64,7 +64,7 @@ func (c *showCmd) run(cmd *cobra.Command, args []string) {
 }
 
 func (c *showCmd) showApp(arg string) {
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 	app := mustArgToApp(repo, arg)
 
 	tasks := app.Tasks()
@@ -193,7 +193,7 @@ func vcsStr(v *storage.TaskRun) string {
 }
 
 func (c *showCmd) showBuild(taskRunID int) {
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 	storageClt := mustNewCompatibleStorage(repo)
 
 	taskRun, err := storageClt.TaskRun(ctx, taskRunID)

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -72,22 +72,22 @@ func (c *showCmd) showApp(arg string) {
 
 	formatter := table.New(nil, stdout)
 
-	mustWriteRowVa(formatter, "Application Name:", term.Highlight(app.Name), "", "")
-	mustWriteRowVa(formatter, "Path:", term.Highlight(app.RelPath), "")
+	mustWriteRow(formatter, "Application Name:", term.Highlight(app.Name), "", "")
+	mustWriteRow(formatter, "Path:", term.Highlight(app.RelPath), "")
 
-	mustWriteRowVa(formatter, "", "", "", "")
+	mustWriteRow(formatter, "", "", "", "")
 	for taskIdx, task := range tasks {
-		mustWriteRowVa(formatter, term.Underline("Task"))
-		mustWriteRowVa(formatter, "", "Name:", term.Highlight(task.Name), "", "")
-		mustWriteRowVa(formatter, "", "Command:", term.Highlight(task.Command), "", "")
+		mustWriteRow(formatter, term.Underline("Task"))
+		mustWriteRow(formatter, "", "Name:", term.Highlight(task.Name), "", "")
+		mustWriteRow(formatter, "", "Command:", term.Highlight(task.Command), "", "")
 
 		if task.HasInputs() {
-			mustWriteRowVa(formatter, "", "", "", "")
-			mustWriteRowVa(formatter, "", term.Underline("Inputs:"), "", "")
+			mustWriteRow(formatter, "", "", "", "")
+			mustWriteRow(formatter, "", term.Underline("Inputs:"), "", "")
 
 			if len(task.UnresolvedInputs.Files.Paths) > 0 {
-				mustWriteRowVa(formatter, "", "", "Type:", term.Highlight("File"))
-				mustWriteRowVa(
+				mustWriteRow(formatter, "", "", "Type:", term.Highlight("File"))
+				mustWriteRow(
 					formatter,
 					"",
 					"",
@@ -98,11 +98,11 @@ func (c *showCmd) showApp(arg string) {
 
 			if len(task.UnresolvedInputs.GitFiles.Paths) > 0 {
 				if len(task.UnresolvedInputs.Files.Paths) > 0 {
-					mustWriteRowVa(formatter, "", "", "", "")
+					mustWriteRow(formatter, "", "", "", "")
 				}
 
-				mustWriteRowVa(formatter, "", "", "Type:", term.Highlight("GitFile"))
-				mustWriteRowVa(
+				mustWriteRow(formatter, "", "", "Type:", term.Highlight("GitFile"))
+				mustWriteRow(
 					formatter,
 					"",
 					"",
@@ -113,18 +113,18 @@ func (c *showCmd) showApp(arg string) {
 
 			if len(task.UnresolvedInputs.GolangSources.Paths) > 0 {
 				if len(task.UnresolvedInputs.GitFiles.Paths) > 0 {
-					mustWriteRowVa(formatter, "", "", "", "")
+					mustWriteRow(formatter, "", "", "", "")
 				}
 
-				mustWriteRowVa(formatter, "", "", "Type:", term.Highlight("GolangSources"))
-				mustWriteRowVa(
+				mustWriteRow(formatter, "", "", "Type:", term.Highlight("GolangSources"))
+				mustWriteRow(
 					formatter,
 					"",
 					"",
 					"Paths:",
 					term.Highlight(strings.Join(task.UnresolvedInputs.GolangSources.Paths, ", ")),
 				)
-				mustWriteRowVa(
+				mustWriteRow(
 					formatter,
 					"",
 					"",
@@ -134,45 +134,45 @@ func (c *showCmd) showApp(arg string) {
 		}
 
 		if task.HasOutputs() {
-			mustWriteRowVa(formatter, "", term.Underline("Outputs:"), "", "")
+			mustWriteRow(formatter, "", term.Underline("Outputs:"), "", "")
 		}
 
 		for i, di := range task.Outputs.DockerImage {
-			mustWriteRowVa(formatter, "", "", "Type:", term.Highlight("Docker Image"))
-			mustWriteRowVa(formatter, "", "", "IDFile:", term.Highlight(di.IDFile))
-			mustWriteRowVa(formatter, "", "", "Registry:", term.Highlight(di.RegistryUpload.Registry))
-			mustWriteRowVa(formatter, "", "", "Repository:", term.Highlight(di.RegistryUpload.Repository))
-			mustWriteRowVa(formatter, "", "", "Tag:", term.Highlight(di.RegistryUpload.Tag))
+			mustWriteRow(formatter, "", "", "Type:", term.Highlight("Docker Image"))
+			mustWriteRow(formatter, "", "", "IDFile:", term.Highlight(di.IDFile))
+			mustWriteRow(formatter, "", "", "Registry:", term.Highlight(di.RegistryUpload.Registry))
+			mustWriteRow(formatter, "", "", "Repository:", term.Highlight(di.RegistryUpload.Repository))
+			mustWriteRow(formatter, "", "", "Tag:", term.Highlight(di.RegistryUpload.Tag))
 
 			if i+1 < len(task.Outputs.DockerImage) {
-				mustWriteRowVa(formatter, "", "", "", "")
+				mustWriteRow(formatter, "", "", "", "")
 			}
 		}
 
 		for i, file := range task.Outputs.File {
 			if len(task.Outputs.DockerImage) > 0 {
-				mustWriteRowVa(formatter, "", "", "", "")
+				mustWriteRow(formatter, "", "", "", "")
 			}
 
-			mustWriteRowVa(formatter, "", "", "Type:", term.Highlight("File"))
-			mustWriteRowVa(formatter, "", "", "Path:", term.Highlight(file.Path))
+			mustWriteRow(formatter, "", "", "Type:", term.Highlight("File"))
+			mustWriteRow(formatter, "", "", "Path:", term.Highlight(file.Path))
 
 			if !file.FileCopy.IsEmpty() {
-				mustWriteRowVa(formatter, "", "", "Filecopy Destination:", term.Highlight(file.FileCopy.Path))
+				mustWriteRow(formatter, "", "", "Filecopy Destination:", term.Highlight(file.FileCopy.Path))
 			}
 
 			if !file.S3Upload.IsEmpty() {
-				mustWriteRowVa(formatter, "", "", "S3 Bucket:", term.Highlight(file.S3Upload.Bucket))
-				mustWriteRowVa(formatter, "", "", "S3 Destfile:", term.Highlight(file.S3Upload.DestFile))
+				mustWriteRow(formatter, "", "", "S3 Bucket:", term.Highlight(file.S3Upload.Bucket))
+				mustWriteRow(formatter, "", "", "S3 Destfile:", term.Highlight(file.S3Upload.DestFile))
 			}
 
 			if i+1 < len(task.Outputs.File) {
-				mustWriteRowVa(formatter, "", "", "", "")
+				mustWriteRow(formatter, "", "", "", "")
 			}
 		}
 
 		if taskIdx+1 < len(tasks) {
-			mustWriteRowVa(formatter, "", "", "", "")
+			mustWriteRow(formatter, "", "", "", "")
 		}
 	}
 
@@ -212,18 +212,18 @@ func (c *showCmd) showBuild(taskRunID int) {
 
 	formatter := table.New(nil, stdout)
 
-	mustWriteRowVa(formatter, "Run-ID:", term.Highlight(taskRun.ID))
-	mustWriteRowVa(formatter, "Application:", term.Highlight(taskRun.ApplicationName))
-	mustWriteRowVa(formatter, "Task:", term.Highlight(taskRun.TaskName))
+	mustWriteRow(formatter, "Run-ID:", term.Highlight(taskRun.ID))
+	mustWriteRow(formatter, "Application:", term.Highlight(taskRun.ApplicationName))
+	mustWriteRow(formatter, "Task:", term.Highlight(taskRun.TaskName))
 
 	if taskRun.Result == storage.ResultSuccess {
-		mustWriteRowVa(formatter, "Result", term.GreenHighlight(taskRun.Result))
+		mustWriteRow(formatter, "Result", term.GreenHighlight(taskRun.Result))
 	} else {
-		mustWriteRowVa(formatter, "Result", term.RedHighlight(taskRun.Result))
+		mustWriteRow(formatter, "Result", term.RedHighlight(taskRun.Result))
 	}
 
-	mustWriteRowVa(formatter, "Started At:", term.Highlight(taskRun.StartTimestamp))
-	mustWriteRowVa(
+	mustWriteRow(formatter, "Started At:", term.Highlight(taskRun.StartTimestamp))
+	mustWriteRow(
 		formatter,
 		"Build Duration:",
 		term.Highlight(
@@ -233,33 +233,33 @@ func (c *showCmd) showBuild(taskRunID int) {
 		),
 	)
 
-	mustWriteRowVa(formatter, "Git Commit:", term.Highlight(vcsStr(&taskRun.TaskRun)))
+	mustWriteRow(formatter, "Git Commit:", term.Highlight(vcsStr(&taskRun.TaskRun)))
 
-	mustWriteRowVa(formatter, "Total Input Digest:", term.Highlight(taskRun.TotalInputDigest))
-	mustWriteRowVa(formatter, "Output Count:", term.Highlight(len(outputs)))
+	mustWriteRow(formatter, "Total Input Digest:", term.Highlight(taskRun.TotalInputDigest))
+	mustWriteRow(formatter, "Output Count:", term.Highlight(len(outputs)))
 
 	if len(outputs) > 0 {
-		mustWriteRowVa(formatter)
-		mustWriteRowVa(formatter, term.Underline("Outputs:"))
+		mustWriteRow(formatter)
+		mustWriteRow(formatter, term.Underline("Outputs:"))
 	}
 
 	for i, o := range outputs {
-		mustWriteRowVa(formatter, "", "Local Path:", term.Highlight(o.Name))
-		mustWriteRowVa(formatter, "", "Digest:", term.Highlight(o.Digest))
-		mustWriteRowVa(
+		mustWriteRow(formatter, "", "Local Path:", term.Highlight(o.Name))
+		mustWriteRow(formatter, "", "Digest:", term.Highlight(o.Digest))
+		mustWriteRow(
 			formatter,
 			"",
 			"Size:",
 			term.Highlight(term.FormatSize(o.SizeBytes)),
 		)
-		mustWriteRowVa(formatter, "", "Type:", term.Highlight(o.Type))
+		mustWriteRow(formatter, "", "Type:", term.Highlight(o.Type))
 
-		mustWriteRowVa(formatter)
-		mustWriteRowVa(formatter, "", term.Underline("Uploads:"))
+		mustWriteRow(formatter)
+		mustWriteRow(formatter, "", term.Underline("Uploads:"))
 
 		for uploadIdx, upload := range o.Uploads {
-			mustWriteRowVa(formatter, "", "", "URI:", term.Highlight(upload.URI))
-			mustWriteRowVa(
+			mustWriteRow(formatter, "", "", "URI:", term.Highlight(upload.URI))
+			mustWriteRow(
 				formatter,
 				"",
 				"",
@@ -269,18 +269,18 @@ func (c *showCmd) showBuild(taskRunID int) {
 						upload.UploadStartTimestamp),
 				),
 			)
-			mustWriteRowVa(
+			mustWriteRow(
 				formatter,
 				"", "", "Upload Method:", term.Highlight(upload.Method),
 			)
 
 			if uploadIdx+1 < len(o.Uploads) {
-				mustWriteRowVa(formatter)
+				mustWriteRow(formatter)
 			}
 		}
 
 		if i+1 < len(outputs) {
-			mustWriteRowVa(formatter)
+			mustWriteRow(formatter)
 		}
 	}
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -109,7 +109,7 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 	var formatter format.Formatter
 	var storageClt storage.Storer
 
-	repo := MustFindRepository()
+	repo := mustFindRepository()
 
 	loader, err := baur.NewLoader(
 		repo.Cfg,

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -173,8 +173,7 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 
 		row = c.statusAssembleRow(repo.Path, task, taskRun, taskStatus)
 
-		err := formatter.WriteRow(row)
-		exitOnErr(err)
+		mustWriteRow(formatter, row...)
 	}
 
 	err = formatter.Flush()

--- a/internal/command/term/format.go
+++ b/internal/command/term/format.go
@@ -5,7 +5,34 @@ import (
 	"time"
 )
 
-func FormatSize(bytes uint64) string {
+type FormatOption func(*fmtSettings)
+
+type fmtSettings struct {
+	baseUnitWithoutUnitName bool
+}
+
+// FormatBaseWithoutUnitName when enabled the Format functions return the value
+// in it's base unit without unit-name suffix
+func FormatBaseWithoutUnitName(enable bool) FormatOption {
+	return func(o *fmtSettings) {
+		o.baseUnitWithoutUnitName = enable
+	}
+}
+
+func evalOptions(opts []FormatOption) *fmtSettings {
+	var s fmtSettings
+
+	for _, opt := range opts {
+		opt(&s)
+	}
+
+	return &s
+}
+func FormatSize(bytes uint64, opts ...FormatOption) string {
+	if evalOptions(opts).baseUnitWithoutUnitName {
+		return fmt.Sprint(bytes)
+	}
+
 	if bytes < 1024 {
 		return fmt.Sprintf("%d B", bytes)
 	}
@@ -21,7 +48,11 @@ func FormatSize(bytes uint64) string {
 	return fmt.Sprintf("%.3f GiB", float64(bytes)/1024/1024/1024)
 }
 
-func FormatDuration(d time.Duration) string {
+func FormatDuration(d time.Duration, opts ...FormatOption) string {
+	if evalOptions(opts).baseUnitWithoutUnitName {
+		return fmt.Sprintf("%.3f", d.Seconds())
+	}
+
 	if d.Minutes() > 1 {
 		return d.Round(time.Second).String()
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -9,7 +9,6 @@ import (
 )
 
 var errorPrefix = color.New(color.FgRed).Sprint("ERROR: ")
-var warnPrefix = color.New(color.FgYellow).Sprint("WARN: ")
 
 // Logger logs messages
 type Logger struct {
@@ -87,25 +86,6 @@ func (l *Logger) Errorf(format string, v ...interface{}) {
 	l.logger.Printf(errorPrefix+" "+format, v...)
 }
 
-// Warnf logs a message to stderr
-func (l *Logger) Warnf(format string, v ...interface{}) {
-	l.logger.Printf(warnPrefix+format, v...)
-}
-
-// Infoln logs a message to stdout
-/*
-func (l *Logger) Infoln(v ...interface{}) {
-	l.logger.Println(v...)
-}
-*/
-
-// Infof logs a message to stdout
-/*
-func (l *Logger) Infof(format string, v ...interface{}) {
-	l.logger.Printf(format, v...)
-}
-*/
-
 // DebugEnabled returns true if the Stdlogger logs debug messages
 func DebugEnabled() bool {
 	return StdLogger.DebugEnabled()
@@ -142,22 +122,3 @@ func Errorln(v ...interface{}) {
 func Errorf(format string, v ...interface{}) {
 	StdLogger.Errorf(format, v...)
 }
-
-// Warnf logs a message to stderr
-func Warnf(format string, v ...interface{}) {
-	StdLogger.Warnf(format, v...)
-}
-
-// Infoln logs a message to stdout
-/*
-func Infoln(v ...interface{}) {
-	StdLogger.Infoln(v...)
-}
-*/
-
-// Infof logs a message to stdout
-/*
-func Infof(format string, v ...interface{}) {
-	StdLogger.Infof(format, v...)
-}
-*/


### PR DESCRIPTION
This PR:
- ensures all commands represent task and do not use the build terminology anymore,
- harmonizes the command code and make use of the recent improvements in all commands,
- fixes some smaller issues found on the go

See the commit messages for a full list of changes

