### PR TITLE
cfg: fix: git head commit is trying to resolved despite $GITCOMMIT va…

### DIFF
--- a/cfg/resolver/callback.go
+++ b/cfg/resolver/callback.go
@@ -9,6 +9,13 @@ type CallbackReplacement struct {
 }
 
 func (c *CallbackReplacement) Resolve(in string) (string, error) {
+	// only run NewFunc() if necessary to prevent that Resolve() returns an
+	// error because NewFunc() failed, despite the string does not contain
+	// the substring.
+	if !strings.Contains(in, c.Old) {
+		return in, nil
+	}
+
 	new, err := c.NewFunc()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
…r not used

When baur was run in a directory that was not a git repository, baur commands
failed because they could not resolve HEAD to a commit.
This happened when the $GITCOMMIT was no used in a config.

Only run the gitcommit resolve function when a config field contains $GITCOMMIT.

Fixes #161