### PR TITLE
Compile and run on Windows

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,7 +1,6 @@
 package baur
 
 import (
-	"path"
 	"path/filepath"
 	"sort"
 
@@ -23,7 +22,7 @@ type App struct {
 
 // NewApp reads the configuration file and returns a new App
 func NewApp(appCfg *cfg.App, repositoryRootPath string) (*App, error) {
-	appDir := path.Dir(appCfg.FilePath())
+	appDir := filepath.Dir(appCfg.FilePath())
 
 	appRelPath, err := filepath.Rel(repositoryRootPath, appDir)
 	if err != nil {

--- a/cfg/task.go
+++ b/cfg/task.go
@@ -7,7 +7,7 @@ import (
 // Task is a task section
 type Task struct {
 	Name     string   `toml:"name" comment:"Identifies the task, currently the name must be 'build'."`
-	Command  string   `toml:"command" comment:"Command to execute. The command is run via the sh shell."`
+	Command  string   `toml:"command" comment:"Command to execute. The command is run via the sh shell on Unix or cmd shell on Windows."`
 	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory.\n Valid variables: $ROOT."`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
 	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"syscall"
 )
@@ -54,8 +55,12 @@ func Command(name string, arg ...string) *Cmd {
 	}
 }
 
-// ShellCommand executes a command in sh shell.
+// ShellCommand executes a command in sh shell on Unix or cmd shell on Windows.
 func ShellCommand(cmd string) *Cmd {
+	if runtime.GOOS == "windows" {
+		return Command("cmd", "/C", cmd)
+	}
+
 	return Command("sh", "-c", cmd)
 }
 

--- a/internal/upload/filecopy/filecopy.go
+++ b/internal/upload/filecopy/filecopy.go
@@ -3,7 +3,7 @@ package filecopy
 import (
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -63,7 +63,7 @@ func copyFile(src, dst string) error {
 // If the destination path exist and is not a regular file an error is returned.
 // If it exist and is a file, the file is overwritten if it's not the same.
 func (c *Client) Upload(src string, dst string) (string, error) {
-	destDir := path.Dir(dst)
+	destDir := filepath.Dir(dst)
 
 	isDir, err := fs.IsDir(destDir)
 	if err != nil {

--- a/repository.go
+++ b/repository.go
@@ -2,7 +2,7 @@ package baur
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -52,7 +52,7 @@ func NewRepository(cfgPath string) (*Repository, error) {
 		return nil, errors.Wrapf(err,
 			"validating repository config %q failed", cfgPath)
 	}
-	repoPath := path.Dir(cfgPath)
+	repoPath := filepath.Dir(cfgPath)
 
 	r := Repository{
 		Cfg:         repoCfg,

--- a/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
@@ -11,7 +11,6 @@ import (
 	"time"
 	"unsafe"
 
-	winio "github.com/Microsoft/go-winio"
 	"golang.org/x/sys/windows"
 )
 
@@ -103,13 +102,13 @@ func mkdirall(path string, applyACL bool, sddl string) error {
 // and Local System.
 func mkdirWithACL(name string, sddl string) error {
 	sa := windows.SecurityAttributes{Length: 0}
-	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	sd, err := windows.SecurityDescriptorFromString(sddl)
 	if err != nil {
 		return &os.PathError{Op: "mkdir", Path: name, Err: err}
 	}
 	sa.Length = uint32(unsafe.Sizeof(sa))
 	sa.InheritHandle = 1
-	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+	sa.SecurityDescriptor = sd
 
 	namep, err := windows.UTF16PtrFromString(name)
 	if err != nil {

--- a/vendor/github.com/simplesurance/baur/app.go
+++ b/vendor/github.com/simplesurance/baur/app.go
@@ -191,7 +191,7 @@ func NewApp(repository *Repository, cfgPath string) (*App, error) {
 			cfgPath)
 	}
 
-	appAbsPath := path.Dir(cfgPath)
+	appAbsPath := filepath.Dir(cfgPath)
 	appRelPath, err := filepath.Rel(repository.Path, appAbsPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s: resolving repository relative application path failed", appCfg.Name)
@@ -203,7 +203,7 @@ func NewApp(repository *Repository, cfgPath string) (*App, error) {
 
 	app := App{
 		Repository: repository,
-		Path:       path.Dir(cfgPath),
+		Path:       filepath.Dir(cfgPath),
 		RelPath:    appRelPath,
 		Name:       appCfg.Name,
 		BuildCmd:   cmd,

--- a/vendor/github.com/simplesurance/baur/repository.go
+++ b/vendor/github.com/simplesurance/baur/repository.go
@@ -63,7 +63,7 @@ func NewRepository(cfgPath string) (*Repository, error) {
 
 	r := Repository{
 		CfgPath:       cfgPath,
-		Path:          path.Dir(cfgPath),
+		Path:          filepath.Dir(cfgPath),
 		AppSearchDirs: fs.PathsJoin(path.Dir(cfgPath), cfg.Discover.Dirs),
 		SearchDepth:   cfg.Discover.SearchDepth,
 		PSQLURL:       cfg.Database.PGSQLURL,


### PR DESCRIPTION
This will allow Baur to compile and run on Windows.

- I chose _cmd_ as the Windows command shell as it is the base shell for Windows. If users would like to use PowerShell instead they can invoke PowerShell from the cmd shell.
- Usages of `path` have been replaced with `filepath`. From the Go documentation [Package filepath implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths.](https://golang.org/pkg/path/filepath/)
- `filesys_windows.go` has been updated to use the newer SecurityAttributes struct, see [Move to upstream Sddl/SecurityAttribute functions](https://github.com/microsoft/go-winio/pull/165).

I feel like these changes can be made independently from actually building a Windows binary at this time.
I plan on making the required changes to the `Makefile` to produce the Windows binary and updating the CI process to run the test cases in due time.