### PR TITLE
cfg: change GolangSources field to be a slice

### DIFF
--- a/cfg/app.go
+++ b/cfg/app.go
@@ -37,9 +37,11 @@ func ExampleApp(name string) *App {
 					GitFiles: GitFileInputs{
 						Paths: []string{"Makefile"},
 					},
-					GolangSources: GolangSources{
-						Queries:     []string{"./..."},
-						Environment: []string{"GOFLAGS=-mod=vendor", "GO111MODULE=on"},
+					GolangSources: []GolangSources{
+						{
+							Queries:     []string{"./..."},
+							Environment: []string{"GOFLAGS=-mod=vendor", "GO111MODULE=on"},
+						},
 					},
 				},
 				Output: Output{

--- a/cfg/golangsources.go
+++ b/cfg/golangsources.go
@@ -19,20 +19,6 @@ func (g *GolangSources) IsEmpty() bool {
 		!g.Tests
 }
 
-// Merge merges the two GolangSources structs
-func (g *GolangSources) Merge(other *GolangSources) {
-	// TODO: merging this section is currently buggy,
-	// https://github.com/simplesurance/baur/issues/169 must be fixed
-
-	g.Queries = append(g.Queries, other.Queries...)
-	g.Environment = append(g.Environment, other.Environment...)
-	g.BuildFlags = append(g.BuildFlags, other.BuildFlags...)
-
-	if other.Tests {
-		g.Tests = other.Tests
-	}
-}
-
 func (g *GolangSources) Resolve(resolvers resolver.Resolver) error {
 	for i, env := range g.Environment {
 		var err error

--- a/cfg/include.go
+++ b/cfg/include.go
@@ -107,9 +107,11 @@ func ExampleInclude(id string) *Include {
 				GitFiles: GitFileInputs{
 					Paths: []string{"Makefile"},
 				},
-				GolangSources: GolangSources{
-					Queries:     []string{"."},
-					Environment: []string{"GOFLAGS=-mod=vendor", "GO111MODULE=on"},
+				GolangSources: []GolangSources{
+					{
+						Queries:     []string{"."},
+						Environment: []string{"GOFLAGS=-mod=vendor", "GO111MODULE=on"},
+					},
 				},
 			},
 		},

--- a/cfg/includedb_test.go
+++ b/cfg/includedb_test.go
@@ -49,10 +49,12 @@ func inputInclude() InputIncludes {
 				Paths: []string{"*.c", "*.h"},
 			},
 
-			GolangSources: GolangSources{
-				Environment: []string{"GOPATH=."},
-				Queries:     []string{"."},
-				BuildFlags:  []string{},
+			GolangSources: []GolangSources{
+				{
+					Environment: []string{"GOPATH=."},
+					Queries:     []string{"."},
+					BuildFlags:  []string{},
+				},
 			},
 		},
 	}
@@ -370,9 +372,13 @@ func TestTaskInclude(t *testing.T) {
 							GitFiles: GitFileInputs{
 								Paths: []string{"*.txt", "*.d"},
 							},
-							GolangSources: GolangSources{
-								Environment: []string{"A=B"},
-								Queries:     []string{"."},
+							GolangSources: []GolangSources{
+								{
+									Environment: []string{"A=B"},
+									Queries:     []string{"."},
+									BuildFlags:  []string{},
+									Tests:       false,
+								},
 							},
 						},
 						{
@@ -383,9 +389,13 @@ func TestTaskInclude(t *testing.T) {
 							GitFiles: GitFileInputs{
 								Paths: []string{"*.txt", "hellofile"},
 							},
-							GolangSources: GolangSources{
-								Environment: []string{"C=D"},
-								Queries:     []string{"cmd/"},
+							GolangSources: []GolangSources{
+								{
+									Environment: []string{"C=D"},
+									Queries:     []string{"cmd/"},
+									BuildFlags:  []string{},
+									Tests:       true,
+								},
 							},
 						},
 					},
@@ -475,13 +485,8 @@ func TestTaskInclude(t *testing.T) {
 					assert.Contains(t, loadedTask.Input.GitFileInputs().Paths, path, "GitFileInput missing")
 				}
 
-				// related bug: https://github.com/simplesurance/baur/issues/169
-				for _, env := range loadedTask.Input.GolangSources.Environment {
-					assert.Contains(t, loadedTask.Input.GolangSourcesInputs().Environment, env, "GolangSources env missing")
-				}
-
-				for _, query := range loadedTask.Input.GolangSources.Queries {
-					assert.Contains(t, loadedTask.Input.GolangSourcesInputs().Queries, query, "GolangSources query missing")
+				for _, gs := range inputIncl.GolangSources {
+					assert.Contains(t, loadedTask.Input.GolangSources, gs)
 				}
 			}
 

--- a/cfg/input.go
+++ b/cfg/input.go
@@ -1,12 +1,14 @@
 package cfg
 
-import "github.com/simplesurance/baur/v1/cfg/resolver"
+import (
+	"github.com/simplesurance/baur/v1/cfg/resolver"
+)
 
 // Input contains information about task inputs
 type Input struct {
-	Files         FileInputs    `comment:"Inputs specified by file glob paths"`
-	GitFiles      GitFileInputs `comment:"Inputs specified by path, matching only Git tracked files"`
-	GolangSources GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
+	Files         FileInputs      `comment:"Inputs specified by file glob paths"`
+	GitFiles      GitFileInputs   `comment:"Inputs specified by path, matching only Git tracked files"`
+	GolangSources []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
 }
 
 func (in *Input) FileInputs() *FileInputs {
@@ -17,15 +19,15 @@ func (in *Input) GitFileInputs() *GitFileInputs {
 	return &in.GitFiles
 }
 
-func (in *Input) GolangSourcesInputs() *GolangSources {
-	return &in.GolangSources
+func (in *Input) GolangSourcesInputs() []GolangSources {
+	return in.GolangSources
 }
 
 // Merge appends the information in other to in.
 func (in *Input) Merge(other InputDef) {
 	in.Files.Merge(other.FileInputs())
 	in.GitFiles.Merge(other.GitFileInputs())
-	in.GolangSources.Merge(other.GolangSourcesInputs())
+	in.GolangSources = append(in.GolangSources, other.GolangSourcesInputs()...)
 }
 
 func (in *Input) Resolve(resolvers resolver.Resolver) error {
@@ -37,8 +39,12 @@ func (in *Input) Resolve(resolvers resolver.Resolver) error {
 		return FieldErrorWrap(err, "Gitfiles")
 	}
 
-	if err := in.GolangSources.Resolve(resolvers); err != nil {
-		return FieldErrorWrap(err, "GoLangSources")
+	for i, gs := range in.GolangSources {
+		if err := gs.Resolve(resolvers); err != nil {
+			return FieldErrorWrap(err, "GoLangSources")
+		}
+
+		in.GolangSources[i] = gs
 	}
 
 	return nil
@@ -50,8 +56,10 @@ func InputValidate(i InputDef) error {
 		return FieldErrorWrap(err, "Files")
 	}
 
-	if err := i.GolangSourcesInputs().Validate(); err != nil {
-		return FieldErrorWrap(err, "GolangSources")
+	for _, gs := range i.GolangSourcesInputs() {
+		if err := gs.Validate(); err != nil {
+			return FieldErrorWrap(err, "GolangSources")
+		}
 	}
 
 	// TODO: add validation for gitfiles section

--- a/cfg/inputdef.go
+++ b/cfg/inputdef.go
@@ -3,12 +3,12 @@ package cfg
 type InputDef interface {
 	FileInputs() *FileInputs
 	GitFileInputs() *GitFileInputs
-	GolangSourcesInputs() *GolangSources
+	GolangSourcesInputs() []GolangSources
 }
 
 // InputsAreEmpty returns true if no inputs are defined
 func InputsAreEmpty(in InputDef) bool {
 	return len(in.FileInputs().Paths) == 0 &&
 		len(in.GitFileInputs().Paths) == 0 &&
-		in.GolangSourcesInputs().IsEmpty()
+		len(in.GolangSourcesInputs()) == 0
 }

--- a/cfg/inputinclude.go
+++ b/cfg/inputinclude.go
@@ -4,9 +4,9 @@ package cfg
 type InputInclude struct {
 	IncludeID string `toml:"include_id" comment:"identifier of the include"`
 
-	Files         FileInputs    `comment:"Inputs specified by file glob paths"`
-	GitFiles      GitFileInputs `comment:"Inputs specified by path, matching only Git tracked files"`
-	GolangSources GolangSources `comment:"Inputs specified by directories containing Golang applications"`
+	Files         FileInputs      `comment:"Inputs specified by file glob paths"`
+	GitFiles      GitFileInputs   `comment:"Inputs specified by path, matching only Git tracked files"`
+	GolangSources []GolangSources `comment:"Inputs specified by directories containing Golang applications"`
 }
 
 func (in *InputInclude) FileInputs() *FileInputs {
@@ -17,8 +17,8 @@ func (in *InputInclude) GitFileInputs() *GitFileInputs {
 	return &in.GitFiles
 }
 
-func (in *InputInclude) GolangSourcesInputs() *GolangSources {
-	return &in.GolangSources
+func (in *InputInclude) GolangSourcesInputs() []GolangSources {
+	return in.GolangSources
 }
 
 // Validate checks if the stored information is valid.

--- a/cfg/taskdef.go
+++ b/cfg/taskdef.go
@@ -20,9 +20,7 @@ func TaskMerge(task TaskDef, workingDir string, resolver resolver.Resolver, incl
 	for _, includeSpec := range *task.GetIncludes() {
 		inputInclude, err := includeDB.LoadInputInclude(resolver, workingDir, includeSpec)
 		if err == nil {
-			task.GetInput().Files.Merge(&inputInclude.Files)
-			task.GetInput().GitFiles.Merge(&inputInclude.GitFiles)
-			task.GetInput().GolangSources.Merge(&inputInclude.GolangSources)
+			task.GetInput().Merge(inputInclude)
 
 			continue
 		}

--- a/cfg/upgrade/v4/v4.go
+++ b/cfg/upgrade/v4/v4.go
@@ -30,7 +30,7 @@ func UpgradeIncludeConfig(old *cfgv0.Include) *cfg.Include {
 		len(old.BuildInput.GolangSources.Environment) > 0 ||
 		len(old.BuildInput.GolangSources.Paths) > 0 {
 
-		include.Input = append(include.Input, &cfg.InputInclude{
+		in := &cfg.InputInclude{
 			IncludeID: NewIncludeID,
 			Files: cfg.FileInputs{
 				Paths: old.BuildInput.Files.Paths,
@@ -39,12 +39,19 @@ func UpgradeIncludeConfig(old *cfgv0.Include) *cfg.Include {
 			GitFiles: cfg.GitFileInputs{
 				Paths: old.BuildInput.GitFiles.Paths,
 			},
-			GolangSources: cfg.GolangSources{
-				Environment: old.BuildInput.GolangSources.Environment,
-				Queries:     golangSourcesPathsToQuery(old.BuildInput.GolangSources.Paths),
-				Tests:       false,
-			},
-		})
+		}
+
+		if len(old.BuildInput.GolangSources.Environment) > 0 || len(old.BuildInput.GolangSources.Paths) > 0 {
+			in.GolangSources = []cfg.GolangSources{
+				{
+					Environment: old.BuildInput.GolangSources.Environment,
+					Queries:     golangSourcesPathsToQuery(old.BuildInput.GolangSources.Paths),
+					Tests:       false,
+				},
+			}
+		}
+
+		include.Input = append(include.Input, in)
 	}
 
 	if len(old.BuildOutput.DockerImage) > 0 ||
@@ -105,9 +112,16 @@ func UpgradeAppConfig(old *cfgv0.App) *cfg.App {
 
 	task.Input.Files.Paths = old.Build.Input.Files.Paths
 	task.Input.GitFiles.Paths = old.Build.Input.GitFiles.Paths
-	task.Input.GolangSources.Environment = old.Build.Input.GolangSources.Environment
-	task.Input.GolangSources.Queries = golangSourcesPathsToQuery(old.Build.Input.GolangSources.Paths)
-	task.Input.GolangSources.Tests = false
+
+	if len(old.Build.Input.GolangSources.Environment) > 0 || len(old.Build.Input.GolangSources.Paths) > 0 {
+		task.Input.GolangSources = []cfg.GolangSources{
+			{
+				Environment: old.Build.Input.GolangSources.Environment,
+				Queries:     golangSourcesPathsToQuery(old.Build.Input.GolangSources.Paths),
+				Tests:       false,
+			},
+		}
+	}
 
 	//TODO: dedup code for converting outputs, same code is used used in UpgradeIncludeConfig
 	for _, di := range old.Build.Output.DockerImage {

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -129,6 +129,8 @@ func (c *showCmd) showApp(arg string) {
 				mustWriteRow(formatter, "", "", "Type:", term.Highlight("GolangSources"))
 				mustWriteStringSliceRows(formatter, "Queries:", 2, gs.Queries)
 				mustWriteStringSliceRows(formatter, "Environment:", 2, gs.Environment)
+				mustWriteStringSliceRows(formatter, "BuildFlags:", 2, gs.BuildFlags)
+				mustWriteRow(formatter, "", "", "Tests:", term.Highlight(gs.Tests))
 
 				if i+1 < len(task.UnresolvedInputs.GolangSources) {
 					mustWriteRow(formatter, "", "", "", "")

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -124,14 +124,15 @@ func (c *showCmd) showApp(arg string) {
 				mustWriteStringSliceRows(formatter, "Paths:", 2, task.UnresolvedInputs.GitFiles.Paths)
 			}
 
-			if len(task.UnresolvedInputs.GolangSources.Queries) > 0 {
-				if len(task.UnresolvedInputs.GitFiles.Paths) > 0 {
+			for i, gs := range task.UnresolvedInputs.GolangSources {
+				mustWriteRow(formatter, "", "", "", "")
+				mustWriteRow(formatter, "", "", "Type:", term.Highlight("GolangSources"))
+				mustWriteStringSliceRows(formatter, "Queries:", 2, gs.Queries)
+				mustWriteStringSliceRows(formatter, "Environment:", 2, gs.Environment)
+
+				if i+1 < len(task.UnresolvedInputs.GolangSources) {
 					mustWriteRow(formatter, "", "", "", "")
 				}
-
-				mustWriteRow(formatter, "", "", "Type:", term.Highlight("GolangSources"))
-				mustWriteStringSliceRows(formatter, "Query:", 2, task.UnresolvedInputs.GolangSources.Queries)
-				mustWriteStringSliceRows(formatter, "Environment:", 2, task.UnresolvedInputs.GolangSources.Environment)
 			}
 		}
 


### PR DESCRIPTION
```
        show: print Gosource BuildFlags and Tests fields
        
        The "baur show" command was now displaying the new BuildFlags and Tests of
        GolangGolangSources inputs, show them.
        
-------------------------------------------------------------------------------
        cfg: convert the GolangSources field in the app config to a slice
        
        The GolangSources field consisted of multiple field and app configs only had a
        single GolangSources element.
        
        When includes that contained GolangSources definitions were merged with the app
        config, the values of the includes were appended to the single GolangSources
        definition.
        This could cause that golangsources were evaluated for a path with wrong
        Environment, BuildFlags or Tests settings.
        
        Convert the GolangSources to a slice.
        This allows to keep the settings from GolangSources from includes and also
        allows to specify multiple GolangSources definitions with different settings in
        the .app.toml file.
        

```