### PR TITLE
Improve input string handling

### DIFF
--- a/input.go
+++ b/input.go
@@ -5,4 +5,16 @@ import "github.com/simplesurance/baur/v1/internal/digest"
 // Input represents an input
 type Input interface {
 	Digest() (*digest.Digest, error)
+	String() string
+}
+
+// InputAddStrIfNotEmpty returns a new slice that contains in and str as an
+// InputString object, if str is not an empty string.
+// If it is, in is returned.
+func InputAddStrIfNotEmpty(in []Input, str string) []Input {
+	if str == "" {
+		return in
+	}
+
+	return append(in, NewInputString(str))
 }

--- a/inputs.go
+++ b/inputs.go
@@ -9,36 +9,18 @@ import (
 
 // Inputs are resolved Inputs of a task.
 type Inputs struct {
-	files       []*Inputfile
-	inputString *InputString
-	digest      *digest.Digest
+	inputs []Input
+	digest *digest.Digest
 }
 
-// NewInputs returns a new Inputs
-func NewInputs(files []*Inputfile) *Inputs {
-	return &Inputs{files: files}
+// NewInputs returns an new Inputs
+func NewInputs(in []Input) *Inputs {
+	return &Inputs{inputs: in}
 }
 
-// SetInputFiles sets the input files
-func (in *Inputs) SetInputFiles(files []*Inputfile) {
-	in.files = files
-	in.digest = nil
-}
-
-// GetInputFiles gets the input files
-func (in *Inputs) GetInputFiles() []*Inputfile {
-	return in.files
-}
-
-// SetInputString sets a string value as an *InputString
-func (in *Inputs) SetInputString(inputStr string) {
-	in.inputString = NewInputString(inputStr)
-	in.digest = nil
-}
-
-// GetInputString returns an *InputString set via SetInputString
-func (in *Inputs) GetInputString() *InputString {
-	return in.inputString
+// Inputs returns all stored Inputs
+func (in *Inputs) Inputs() []Input {
+	return in.inputs
 }
 
 // Digest returns a summarized digest over all Inputs.
@@ -48,24 +30,15 @@ func (in *Inputs) Digest() (*digest.Digest, error) {
 		return in.digest, nil
 	}
 
-	digests := make([]*digest.Digest, len(in.files))
+	digests := make([]*digest.Digest, len(in.inputs))
 
-	for i, file := range in.files {
-		fdigest, err := file.Digest()
+	for i, input := range in.inputs {
+		fdigest, err := input.Digest()
 		if err != nil {
-			return nil, fmt.Errorf("calculating digest for %q failed: %w", file.Path(), err)
+			return nil, fmt.Errorf("calculating digest for %q failed: %w", input, err)
 		}
 
 		digests[i] = fdigest
-	}
-
-	if in.inputString != nil && in.inputString.Exists() {
-		idigest, err := in.inputString.Digest()
-		if err != nil {
-			return nil, fmt.Errorf("calculating digest for input string %q failed: %w", in.inputString.Value, err)
-		}
-
-		digests = append(digests, idigest)
 	}
 
 	totalDigest, err := sha384.Sum(digests)

--- a/inputstring.go
+++ b/inputstring.go
@@ -29,12 +29,7 @@ func (i *InputString) Digest() (*digest.Digest, error) {
 	return i.calcDigest()
 }
 
-// Exists returns whether an input string has been set
-func (i *InputString) Exists() bool {
-	return i.Value != ""
-}
-
-// String returns it's full string representation
+// String returns it's string representation
 func (i *InputString) String() string {
 	return fmt.Sprintf("string:%s", i.Value)
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -62,7 +62,7 @@ type csvStatus struct {
 }
 
 // baurCSVStatus runs "baur status --csv" and returns the result.
-func baurCSVStatus(t *testing.T, inputStr, altInputStr string) []*csvStatus {
+func baurCSVStatus(t *testing.T, inputStr, lookupInputStr string) []*csvStatus {
 	t.Helper()
 
 	stdoutBuf, _ := interceptCmdOutput()
@@ -70,7 +70,7 @@ func baurCSVStatus(t *testing.T, inputStr, altInputStr string) []*csvStatus {
 	statusCmd := newStatusCmd()
 	statusCmd.csv = true
 	statusCmd.inputStr = inputStr
-	statusCmd.altInputStr = altInputStr
+	statusCmd.lookupInputStr = lookupInputStr
 
 	statusCmd.Command.Run(&statusCmd.Command, nil)
 
@@ -206,13 +206,13 @@ func TestRunningPendingTasksWithInputStringChangesStatus(t *testing.T) {
 	assertStatusTasks(t, r, statusOut, baur.TaskStatusRunExist, commit)
 }
 
-// TestAltInputStringReturnsRunExistsStatusWhenInputStringRunExists creates a new baur repository with a
+// TestLookupInputStringReturnsRunExistsStatusWhenInputStringRunExists creates a new baur repository with a
 // simple app then runs:
 // - "baur run with an input string of feature-x"
 // - "baur status with an input string of feature-x", ensures all apps are listed and have status run exist
 // - "baur status with an input string of feature-y", ensures all apps are listed and have status pending,
-// - "baur status with an input string of feature-y and alt input string of feature-x", ensures all apps are listed and have status run exist
-func TestAltInputStringReturnsRunExistsStatusWhenInputStringRunExists(t *testing.T) {
+// - "baur status with an input string of feature-y and lookup input string of feature-x", ensures all apps are listed and have status run exist
+func TestLookupInputStringReturnsRunExistsStatusWhenInputStringRunExists(t *testing.T) {
 	initTest(t)
 
 	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -62,7 +62,7 @@ type csvStatus struct {
 }
 
 // baurCSVStatus runs "baur status --csv" and returns the result.
-func baurCSVStatus(t *testing.T, inputStr string, altInputStr string) []*csvStatus {
+func baurCSVStatus(t *testing.T, inputStr, altInputStr string) []*csvStatus {
 	t.Helper()
 
 	stdoutBuf, _ := interceptCmdOutput()
@@ -93,12 +93,14 @@ func baurCSVStatus(t *testing.T, inputStr string, altInputStr string) []*csvStat
 
 func assertStatusTasks(t *testing.T, r *repotest.Repo, statusOut []*csvStatus, expectedStatus baur.TaskStatus, commit string) {
 	var taskIds []string
+
 	for _, task := range statusOut {
 		taskIds = append(taskIds, task.taskID)
 
 		assert.Equal(t, expectedStatus.String(), task.status)
 		assert.Equal(t, commit, task.commit)
 	}
+
 	assert.ElementsMatch(t, taskIds, r.TaskIDs(), "baur status is missing some tasks")
 }
 

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -66,10 +66,10 @@ type runCmd struct {
 	cobra.Command
 
 	// Cmdline parameters
-	skipUpload  bool
-	force       bool
-	inputStr    string
-	altInputStr string
+	skipUpload     bool
+	force          bool
+	inputStr       string
+	lookupInputStr string
 
 	// other fields
 	storage      storage.Storer
@@ -99,7 +99,7 @@ func newRunCmd() *runCmd {
 		"enforce running tasks independent of their status")
 	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
 		"include a string as an input")
-	cmd.Flags().StringVar(&cmd.altInputStr, "alt-input-str", "",
+	cmd.Flags().StringVar(&cmd.lookupInputStr, "lookup-input-str", "",
 		"if a run can not be found, try to find a run with this value as input-string")
 
 	return &cmd
@@ -310,7 +310,7 @@ func (c *runCmd) filterPendingTasks(tasks []*baur.Task) ([]*pendingTask, error) 
 	const sep = " => "
 
 	taskIDColLen := maxTaskIDLen(tasks) + len(sep)
-	statusEvaluator := baur.NewTaskStatusEvaluator(c.repoRootPath, c.storage, baur.NewInputResolver(), c.inputStr, c.altInputStr)
+	statusEvaluator := baur.NewTaskStatusEvaluator(c.repoRootPath, c.storage, baur.NewInputResolver(), c.inputStr, c.lookupInputStr)
 
 	stdout.Printf("Evaluating status of tasks:\n\n")
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -35,13 +35,13 @@ func init() {
 type statusCmd struct {
 	cobra.Command
 
-	csv         bool
-	quiet       bool
-	absPaths    bool
-	inputStr    string
-	altInputStr string
-	buildStatus flag.TaskStatus
-	fields      *flag.Fields
+	csv            bool
+	quiet          bool
+	absPaths       bool
+	inputStr       string
+	lookupInputStr string
+	buildStatus    flag.TaskStatus
+	fields         *flag.Fields
 }
 
 func newStatusCmd() *statusCmd {
@@ -81,7 +81,7 @@ func newStatusCmd() *statusCmd {
 	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
 		"include a string as input")
 
-	cmd.Flags().StringVar(&cmd.altInputStr, "alt-input-str", "",
+	cmd.Flags().StringVar(&cmd.lookupInputStr, "lookup-input-str", "",
 		"if a run can not be found, try to find a run with this value as input-string")
 
 	return &cmd
@@ -147,7 +147,7 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 
 	showProgress := len(tasks) >= 5 && !c.quiet && !c.csv
 
-	statusMgr := baur.NewTaskStatusEvaluator(repo.Path, storageClt, baur.NewInputResolver(), c.inputStr, c.altInputStr)
+	statusMgr := baur.NewTaskStatusEvaluator(repo.Path, storageClt, baur.NewInputResolver(), c.inputStr, c.lookupInputStr)
 
 	baur.SortTasksByID(tasks)
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -79,7 +79,7 @@ func newStatusCmd() *statusCmd {
 		cmd.fields.Usage(term.Highlight))
 
 	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
-		"include a string as an input")
+		"include a string as input")
 
 	cmd.Flags().StringVar(&cmd.altInputStr, "alt-input-str", "",
 		"if a run can not be found, try to find a run with this value as input-string")

--- a/storage.go
+++ b/storage.go
@@ -72,28 +72,17 @@ func StoreRun(
 }
 
 func InputsToStorageInputs(inputs *Inputs) ([]*storage.Input, error) {
-	result := make([]*storage.Input, 0, len(inputs.GetInputFiles()))
+	result := make([]*storage.Input, 0, len(inputs.Inputs()))
 
-	for _, file := range inputs.GetInputFiles() {
+	for _, in := range inputs.Inputs() {
 		// TODO: rename storage.Input.URI to Name?
-		digest, err := file.Digest()
+		digest, err := in.Digest()
 		if err != nil {
-			return nil, fmt.Errorf("calculating digest of %q failed: %w", file.Path(), err)
+			return nil, fmt.Errorf("calculating digest of %q failed: %w", in, err)
 		}
 
 		result = append(result, &storage.Input{
-			URI:    file.RepoRelPath(),
-			Digest: digest.String(),
-		})
-	}
-
-	if inputs.GetInputString().Exists() {
-		digest, err := inputs.GetInputString().Digest()
-		if err != nil {
-			return nil, fmt.Errorf("calculating digest for input string %q failed: %w", inputs.GetInputString().Value, err)
-		}
-		result = append(result, &storage.Input{
-			URI:    inputs.GetInputString().String(),
+			URI:    in.String(),
 			Digest: digest.String(),
 		})
 	}

--- a/taskstatusevaluator.go
+++ b/taskstatusevaluator.go
@@ -41,36 +41,42 @@ func NewTaskStatusEvaluator(
 // If TaskStatusInputsUndefined is returned, the returned Inputs slice and TaskRunWithID are nil.
 // If TaskStatusExecutionPending is returned, the returned TaskRunWithID is nil.
 func (t *TaskStatusEvaluator) Status(ctx context.Context, task *Task) (TaskStatus, *Inputs, *storage.TaskRunWithID, error) {
+	var taskStatus TaskStatus
+	var run *storage.TaskRunWithID
+
 	if !task.HasInputs() {
 		return TaskStatusInputsUndefined, nil, nil, nil
 	}
 
-	inputs, err := t.inputResolver.Resolve(ctx, t.repositoryDir, task)
+	inputFiles, err := t.inputResolver.Resolve(ctx, t.repositoryDir, task)
 	if err != nil {
 		return TaskStatusUndefined, nil, nil, fmt.Errorf("resolving inputs failed: %w", err)
 	}
 
-	var taskStatus TaskStatus
-	var run *storage.TaskRunWithID
+	inputs := NewInputs(InputAddStrIfNotEmpty(inputFiles, t.inputStr))
 
-	inputs.SetInputString(t.inputStr)
 	taskStatus, run, err = t.getTaskStatus(ctx, inputs, task)
-
 	if err != nil {
 		return TaskStatusUndefined, nil, nil, err
 	}
 
-	if taskStatus == TaskStatusExecutionPending && t.altInputStr != "" {
-		inputs.SetInputString(t.altInputStr)
-		taskStatus, run, err = t.getTaskStatus(ctx, inputs, task)
-
-		inputs.SetInputString(t.inputStr)
+	if t.altInputStr == "" || taskStatus != TaskStatusExecutionPending {
+		return taskStatus, inputs, run, err
 	}
 
+	inputsWaltInputStr := NewInputs(append(inputFiles, NewInputString(t.altInputStr)))
+	taskStatus, run, err = t.getTaskStatus(ctx, inputsWaltInputStr, task)
+	if err != nil {
+		return TaskStatusUndefined, nil, nil, err
+	}
+
+	// inputs instead of inputsWaltInputStr must be returned, if the task
+	// must be run it should be recorded with the inputStr not with the
+	// altInputStr
 	return taskStatus, inputs, run, err
 }
 
-func (t *TaskStatusEvaluator) getTaskStatus(ctx context.Context, inputs Input, task *Task) (TaskStatus, *storage.TaskRunWithID, error) {
+func (t *TaskStatusEvaluator) getTaskStatus(ctx context.Context, inputs *Inputs, task *Task) (TaskStatus, *storage.TaskRunWithID, error) {
 	totalInputDigest, err := inputs.Digest()
 	if err != nil {
 		return TaskStatusUndefined, nil, fmt.Errorf("calculating total input digest failed: %w", err)

--- a/taskstatusevaluator.go
+++ b/taskstatusevaluator.go
@@ -14,8 +14,8 @@ type TaskStatusEvaluator struct {
 	inputResolver *InputResolver
 	store         storage.Storer
 
-	inputStr    string
-	altInputStr string
+	inputStr       string
+	lookupInputStr string
 }
 
 // NewTaskStatusEvaluator returns a new TaskSNewTaskStatusEvaluator.
@@ -24,14 +24,14 @@ func NewTaskStatusEvaluator(
 	store storage.Storer,
 	inputResolver *InputResolver,
 	inputStr string,
-	altInputStr string,
+	lookupInputStr string,
 ) *TaskStatusEvaluator {
 	return &TaskStatusEvaluator{
-		repositoryDir: repositoryDir,
-		inputResolver: inputResolver,
-		store:         store,
-		inputStr:      inputStr,
-		altInputStr:   altInputStr,
+		repositoryDir:  repositoryDir,
+		inputResolver:  inputResolver,
+		store:          store,
+		inputStr:       inputStr,
+		lookupInputStr: lookupInputStr,
 	}
 }
 
@@ -60,20 +60,20 @@ func (t *TaskStatusEvaluator) Status(ctx context.Context, task *Task) (TaskStatu
 		return TaskStatusUndefined, nil, nil, err
 	}
 
-	if t.altInputStr == "" || taskStatus != TaskStatusExecutionPending {
+	if t.lookupInputStr == "" || taskStatus != TaskStatusExecutionPending {
 		return taskStatus, inputs, run, err
 	}
 
-	inputsWaltInputStr := NewInputs(append(inputFiles, NewInputString(t.altInputStr)))
-	taskStatus, run, err = t.getTaskStatus(ctx, inputsWaltInputStr, task)
+	inputsLookupStr := NewInputs(append(inputFiles, NewInputString(t.lookupInputStr)))
+	taskStatus, run, err = t.getTaskStatus(ctx, inputsLookupStr, task)
 	if err != nil {
 		return TaskStatusUndefined, nil, nil, err
 	}
 
-	// inputs instead of inputsWaltInputStr must be returned, if the task
+	// inputs instead of inputsLookupInputStr must be returned, if the task
 	// must be run it should be recorded with the inputStr not with the
 	// altInputStr
-	return taskStatus, inputs, run, err
+	return taskStatus, inputsLookupStr, run, err
 }
 
 func (t *TaskStatusEvaluator) getTaskStatus(ctx context.Context, inputs *Inputs, task *Task) (TaskStatus, *storage.TaskRunWithID, error) {


### PR DESCRIPTION
```
        command: rename --alt-input-str parameter to --lookup-input-str
        
        The name makes it more clear that the input str is only used for lookups.
        Fields and variable names are also adapted to the new name
        
-------------------------------------------------------------------------------
        simplify handling input Strings
        
        Use the introduced Input interface to store Inputfiles and the inputString in
        the same slice.
        This simplifies the usage, conditional handling for the inputString can be
        removed in many places.
        
        InputString are now only added to Inputs if the string is not empty.
        Previously InputString with an empty String value were added which made it
        necessary to check later again if the String was empty or not.
        
        In some places inputs.GetInputString().Exists() was called without checking if
        GetInputString() returned nil.
        This could have caused a nil pointer dereference. This is fixed by this change.
        
        The commit also applies some minor cosmetic improvements.
```

Follow-up PR for: https://github.com/simplesurance/baur/pull/185