### PR TITLE
cfg: add Optional field to FileInputs and GitFileInputs sections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             git config --global user.email "circleci-baurtest@example.com"
             git config --global user.name "baur"
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            go test --tags=dbtest -v -test.timeout 1m ./... | tee ${TEST_RESULTS}/go-test.out
+            go test --tags=dbtest -race -v -test.timeout 1m ./... | tee ${TEST_RESULTS}/go-test.out
 
       - store_test_results:
           path: /tmp/test-results

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ clean:
 .PHONY: test
 test:
 	go test -race ./...
+
+.PHONY: dbtest
+dbtest:
+	go test -race -tags=dbtest ./...

--- a/cfg/fileinputs.go
+++ b/cfg/fileinputs.go
@@ -8,7 +8,8 @@ import (
 
 // FileInputs stores glob paths to inputs of a task.
 type FileInputs struct {
-	Paths []string `toml:"paths" comment:"Relative path to source files.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively.\n Valid variables: $ROOT, $APPNAME, $GITCOMMIT."`
+	Paths    []string `toml:"paths" comment:"Relative path to source files.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively.\n Valid variables: $ROOT, $APPNAME, $GITCOMMIT."`
+	Optional bool     `toml:"optional" comment:"If true, baur will not fail if a Path does not resolve to a file."`
 }
 
 // Merge appends the paths in other to f.

--- a/cfg/gitfileinputs.go
+++ b/cfg/gitfileinputs.go
@@ -5,7 +5,8 @@ import "github.com/simplesurance/baur/v1/cfg/resolver"
 // GitFileInputs describes source files that are in the git repository by git
 // pathnames
 type GitFileInputs struct {
-	Paths []string `toml:"paths" comment:"Relative paths to source files.\n Only files tracked by Git that are not in the .gitignore file are matched.\n The same patterns that git ls-files supports can be used.\n Valid variables: $ROOT, $APPNAME."`
+	Paths    []string `toml:"paths" comment:"Relative paths to source files.\n Only files tracked by Git that are not in the .gitignore file are matched.\n The same patterns that git ls-files supports can be used.\n Valid variables: $ROOT, $APPNAME."`
+	Optional bool     `toml:"optional" comment:"If true, baur will not fail if a Path does not resolve to a file."`
 }
 
 // Merge merges two GitFileInputs structs

--- a/inputresolver.go
+++ b/inputresolver.go
@@ -72,12 +72,12 @@ func (i *InputResolver) resolveGitGlobPaths(repositoryRootDir, appDir string, in
 			return nil, nil
 		}
 
-		gitPaths, err := i.gitGlobPathResolver.Resolve(appDir, in.Paths...)
+		gitPaths, err := i.gitGlobPathResolver.Resolve(appDir, !in.Optional, in.Paths...)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(gitPaths) == 0 {
+		if !in.Optional && len(gitPaths) == 0 {
 			return nil, fmt.Errorf("'%s' matched 0 files", strings.Join(in.Paths, ", "))
 		}
 
@@ -106,7 +106,7 @@ func (i *InputResolver) resolveGlobPaths(appDir string, inputs []cfg.FileInputs)
 				return nil, err
 			}
 
-			if len(resolvedPaths) == 0 {
+			if !in.Optional && len(resolvedPaths) == 0 {
 				return nil, fmt.Errorf("'%s' matched 0 files", path)
 			}
 

--- a/inputresolver_test.go
+++ b/inputresolver_test.go
@@ -1,0 +1,224 @@
+package baur
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1/cfg"
+	"github.com/simplesurance/baur/v1/internal/testutils/fstest"
+	"github.com/simplesurance/baur/v1/internal/testutils/gittest"
+)
+
+func TestFilesOptional(t *testing.T) {
+	testcases := []struct {
+		name          string
+		filesToCreate []string
+		task          Task
+		expectError   bool
+	}{
+		{
+			name:          "file_input_optional_missing_2defs",
+			filesToCreate: []string{"file.1"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					Files: []cfg.FileInputs{
+						{
+							Paths:    []string{"*.1"},
+							Optional: false,
+						},
+						{
+							Paths:    []string{"*.2"},
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "gitfile_input_optional_missing_2defs",
+			filesToCreate: []string{"file.1"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					GitFiles: []cfg.GitFileInputs{
+						{
+							Paths:    []string{"*.1"},
+							Optional: false,
+						},
+						{
+							Paths:    []string{"*.2"},
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:          "file_input_optional_missing",
+			filesToCreate: []string{"file.1"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					Files: []cfg.FileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "gitfile_input_optional_missing",
+			filesToCreate: []string{"file.1"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					GitFiles: []cfg.GitFileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:          "file_input_optional_exists",
+			filesToCreate: []string{"file.1", "file.2"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					Files: []cfg.FileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "gitfile_input_optional_exists",
+			filesToCreate: []string{"file.1", "file.2"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					GitFiles: []cfg.GitFileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:          "file_input_exists",
+			filesToCreate: []string{"file.1", "file.2"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					Files: []cfg.FileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "gitfile_input_exists",
+			filesToCreate: []string{"file.1", "file.2"},
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					GitFiles: []cfg.GitFileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: false,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:          "file_input_missing",
+			filesToCreate: []string{"file.1"},
+			expectError:   true,
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					Files: []cfg.FileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "gitfile_input_missing",
+			filesToCreate: []string{"file.1"},
+			expectError:   true,
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					GitFiles: []cfg.GitFileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			r := NewInputResolver()
+
+			for _, f := range tc.filesToCreate {
+				fstest.WriteToFile(t, []byte(f), filepath.Join(tempDir, f))
+			}
+
+			if strings.Contains(tc.name, "git") {
+				gittest.CreateRepository(t, tempDir)
+				gittest.CommitFilesToGit(t, tempDir)
+			}
+
+			tc.task.Directory = tempDir
+
+			result, err := r.Resolve(context.Background(), tempDir, &tc.task)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Empty(t, result)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			t.Logf("result: %+v", result)
+
+			for _, f := range tc.filesToCreate {
+				var found bool
+
+				for _, in := range result {
+					if in.String() == f {
+						found = true
+						break
+					}
+
+				}
+
+				assert.True(t, found, "%s missing in result", f)
+			}
+		})
+	}
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -138,8 +138,7 @@ func TestRunningPendingTasksChangesStatus(t *testing.T) {
 			runInitDb(t)
 
 			if tc.withGitRepository {
-				_, err := exec.Command("git", "init", ".").ExpectSuccess().Run()
-				assert.NoError(t, err)
+				gittest.CreateRepository(t, ".")
 
 				gittest.CommitFilesToGit(t, ".")
 
@@ -177,8 +176,8 @@ func TestRunningPendingTasksWithInputStringChangesStatus(t *testing.T) {
 	runInitDb(t)
 
 	var commit string
-	_, err := exec.Command("git", "init", ".").ExpectSuccess().Run()
-	assert.NoError(t, err)
+
+	gittest.CreateRepository(t, ".")
 
 	gittest.CommitFilesToGit(t, ".")
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -113,6 +113,7 @@ func (c *showCmd) showApp(arg string) {
 
 			for i, f := range task.UnresolvedInputs.Files {
 				mustWriteRow(formatter, "", "", "Type:", term.Highlight("File"))
+				mustWriteRow(formatter, "", "", "Optional:", term.Highlight(f.Optional))
 				mustWriteStringSliceRows(formatter, "Paths:", 2, f.Paths)
 
 				if i+1 < len(task.UnresolvedInputs.Files) {
@@ -126,6 +127,7 @@ func (c *showCmd) showApp(arg string) {
 
 			for i, g := range task.UnresolvedInputs.GitFiles {
 				mustWriteRow(formatter, "", "", "Type:", term.Highlight("GitFile"))
+				mustWriteRow(formatter, "", "", "Optional:", term.Highlight(g.Optional))
 				mustWriteStringSliceRows(formatter, "Paths:", 2, g.Paths)
 
 				if i+1 < len(task.UnresolvedInputs.GitFiles) {

--- a/internal/resolve/gitpath/gitpaths.go
+++ b/internal/resolve/gitpath/gitpaths.go
@@ -16,12 +16,12 @@ type Resolver struct{}
 // Resolve resolves the glob paths to absolute file paths by calling git ls-files.
 // workingDir must be a directory that is part of a Git repository.
 // If a resolved file does not exist an error is returned.
-func (r *Resolver) Resolve(workingDir string, globs ...string) ([]string, error) {
+func (r *Resolver) Resolve(workingDir string, errorUnmatch bool, globs ...string) ([]string, error) {
 	if len(globs) == 0 {
 		return []string{}, nil
 	}
 
-	out, err := git.LsFiles(workingDir, globs...)
+	out, err := git.LsFiles(workingDir, errorUnmatch, globs...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolve/glob/glob.go
+++ b/internal/resolve/glob/glob.go
@@ -17,17 +17,11 @@ type Resolver struct{}
 // - it only returns paths to files, no directory paths,
 // If a globPath doesn't match any files an empty []string is returned and
 // error is nil
-func (r *Resolver) Resolve(globPaths ...string) ([]string, error) {
-	var result []string
-
-	for _, globPath := range globPaths {
-		paths, err := fs.FileGlob(globPath)
-		if err != nil {
-			return nil, fmt.Errorf("resolving %q failed: %w", globPath, err)
-		}
-		result = append(result, paths...)
+func (r *Resolver) Resolve(globPath string) ([]string, error) {
+	paths, err := fs.FileGlob(globPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q failed: %w", globPath, err)
 	}
 
-	return result, nil
-
+	return paths, nil
 }

--- a/internal/testutils/gittest/gittest.go
+++ b/internal/testutils/gittest/gittest.go
@@ -61,3 +61,8 @@ func Clone(t *testing.T, directory, gitURL, commit string) {
 	_, err = exec.Command("git", "checkout", commit).Directory(directory).ExpectSuccess().Run()
 	require.NoError(t, err)
 }
+
+func CreateRepository(t *testing.T, directory string) {
+	_, err := exec.Command("git", "init", ".").Directory(directory).ExpectSuccess().Run()
+	require.NoError(t, err)
+}

--- a/internal/testutils/gittest/gittest.go
+++ b/internal/testutils/gittest/gittest.go
@@ -35,10 +35,16 @@ func CommitFilesToGit(t *testing.T, directory string) []string {
 
 	require.NoError(t, err)
 
-	_, err = exec.Command("git", append([]string{"add"}, files...)...).ExpectSuccess().Run()
+	_, err = exec.Command("git", append([]string{"add"}, files...)...).
+		Directory(directory).
+		ExpectSuccess().
+		Run()
 	require.NoError(t, err)
 
-	_, err = exec.Command("git", "commit", "-a", "-m", "baur commit").ExpectSuccess().Run()
+	_, err = exec.Command("git", "commit", "-a", "-m", "baur commit").
+		Directory(directory).
+		ExpectSuccess().
+		Run()
 	require.NoError(t, err)
 
 	return files

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -81,10 +81,14 @@ func CommitID(dir string) (string, error) {
 }
 
 // LsFiles runs git ls-files in dir, passes args as argument and returns the
-// output
-// If no files match, ErrNotExist is returned
-func LsFiles(dir string, arg ...string) (string, error) {
-	args := append([]string{"-c", "core.quotepath=off", "ls-files", "error-unmatch"}, arg...)
+// output.
+// If no files match and errorUnmatch is true, ErrNotExist is returned
+func LsFiles(dir string, errorUnmatch bool, arg ...string) (string, error) {
+	args := append([]string{"-c", "core.quotepath=off", "ls-files"}, arg...)
+
+	if errorUnmatch {
+		args = append(args, "--error-unmatch")
+	}
 
 	res, err := exec.Command("git", args...).Directory(dir).Run()
 	if err != nil {


### PR DESCRIPTION
```
        cfg: add Optional field to FileInputs and GitFileInputs sections

        Add a new field called "optional" to the FileInputs and GitFileInputs cfg
        sections.
        By default it's value is false.
        If it's set to true, a Path that resolves to 0 files will not generate an error.
        make: add dbtest target

        The target runs all tests, including the one requiring a postgresql server

-------------------------------------------------------------------------------
        ci: run tests with race detector enabled

-------------------------------------------------------------------------------
        test: add function to initialize a new git repository

```