### PR TITLE
golangci-lint: change local prefixes to v1 and fix imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,4 +20,4 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/simplesurance/baur
+    local-prefixes: github.com/simplesurance/baur/v1

--- a/cfg/upgrade/v4/v4.go
+++ b/cfg/upgrade/v4/v4.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cfgv0 "github.com/simplesurance/baur/cfg"
+
 	"github.com/simplesurance/baur/v1/cfg"
 )
 

--- a/cfgupgrade.go
+++ b/cfgupgrade.go
@@ -7,6 +7,7 @@ import (
 
 	baur_old "github.com/simplesurance/baur"
 	cfg_old "github.com/simplesurance/baur/cfg"
+
 	v4 "github.com/simplesurance/baur/v1/cfg/upgrade/v4"
 	"github.com/simplesurance/baur/v1/internal/fs"
 	"github.com/simplesurance/baur/v1/internal/log"


### PR DESCRIPTION
- a '/v1' suffix was added to the import path of baur, adapt the goimports
  local-prefix accordingly.

- fix the formatting of the import statements accordingly