### PR TITLE
use os independent filepath functions

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,7 +1,6 @@
 package baur
 
 import (
-	"path"
 	"path/filepath"
 	"sort"
 
@@ -23,7 +22,7 @@ type App struct {
 
 // NewApp reads the configuration file and returns a new App
 func NewApp(appCfg *cfg.App, repositoryRootPath string) (*App, error) {
-	appDir := path.Dir(appCfg.FilePath())
+	appDir := filepath.Dir(appCfg.FilePath())
 
 	appRelPath, err := filepath.Rel(repositoryRootPath, appDir)
 	if err != nil {

--- a/inputresolver.go
+++ b/inputresolver.go
@@ -3,7 +3,6 @@ package baur
 import (
 	"context"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -54,7 +53,7 @@ func (i *InputResolver) Resolve(ctx context.Context, repositoryDir string, task 
 
 	// Add the .app.toml file of the app to the inputs
 	// TODO: add the files that were included in the .app.toml and it's includes
-	allInputsPaths = append(allInputsPaths, path.Join(task.Directory, AppCfgFile))
+	allInputsPaths = append(allInputsPaths, filepath.Join(task.Directory, AppCfgFile))
 
 	uniqInputs, err := i.pathsToUniqInputs(repositoryDir, allInputsPaths)
 	if err != nil {

--- a/internal/command/init_app.go
+++ b/internal/command/init_app.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -42,12 +42,12 @@ func initApp(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		appName = args[0]
 	} else {
-		appName = path.Base(cwd)
+		appName = filepath.Base(cwd)
 	}
 
 	appCfg := cfg.ExampleApp(appName)
 
-	err = appCfg.ToFile(path.Join(cwd, baur.AppCfgFile), cfg.ToFileOptCommented())
+	err = appCfg.ToFile(filepath.Join(cwd, baur.AppCfgFile), cfg.ToFileOptCommented())
 	if err != nil {
 		if os.IsExist(err) {
 			log.Fatalf("%s already exist\n", baur.AppCfgFile)

--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -54,11 +54,11 @@ func getBashCompletionDir() string {
 
 	var xdgHome string
 	if xdgHome, exist = os.LookupEnv("XDG_DATA_HOME"); exist {
-		return path.Join(xdgHome, "bash-completion/completions")
+		return filepath.Join(xdgHome, "bash-completion/completions")
 	}
 
 	if home, exist := os.LookupEnv("HOME"); exist {
-		return path.Join(home, ".local/share/bash-completion/completions")
+		return filepath.Join(home, ".local/share/bash-completion/completions")
 	}
 
 	return "~/.local/share/bash-completion/completions"
@@ -89,7 +89,7 @@ func bashComp(cmd *cobra.Command, args []string) {
 
 	mustCreatebashComplDir(complDir)
 
-	complFile := path.Join(complDir, "baur")
+	complFile := filepath.Join(complDir, "baur")
 	f, err := os.Create(complFile)
 	exitOnErrf(err, "creating %q' failed", complFile)
 

--- a/internal/command/init_repo.go
+++ b/internal/command/init_repo.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -43,7 +43,7 @@ func initRepo(cmd *cobra.Command, args []string) {
 	}
 
 	repoCfg := cfg.ExampleRepository()
-	repoCfgPath := path.Join(repoDir, baur.RepositoryCfgFile)
+	repoCfgPath := filepath.Join(repoDir, baur.RepositoryCfgFile)
 
 	err = repoCfg.ToFile(repoCfgPath)
 	if err != nil {

--- a/internal/fs/fileglob_test.go
+++ b/internal/fs/fileglob_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -182,7 +181,7 @@ func Test_Resolve(t *testing.T) {
 
 		createFiles(t, tempdir, tc.files)
 
-		resolvedFiles, err := FileGlob(path.Join(tempdir, tc.fileSrcGlobPath))
+		resolvedFiles, err := FileGlob(filepath.Join(tempdir, tc.fileSrcGlobPath))
 		if err != nil {
 			t.Fatal("resolving glob path:", err)
 		}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -95,7 +94,7 @@ func FindFileInParentDirs(startPath, filename string) (string, error) {
 	searchDir := startPath
 
 	for {
-		p := path.Join(searchDir, filename)
+		p := filepath.Join(searchDir, filename)
 
 		_, err := os.Stat(p)
 		if err == nil {
@@ -116,7 +115,7 @@ func FindFileInParentDirs(startPath, filename string) (string, error) {
 			return "", os.ErrNotExist
 		}
 
-		searchDir = path.Join(searchDir, "..")
+		searchDir = filepath.Join(searchDir, "..")
 	}
 }
 
@@ -128,7 +127,7 @@ func FindFilesInSubDir(searchDir, filename string, maxdepth int) ([]string, erro
 	glob := ""
 
 	for i := 0; i <= maxdepth; i++ {
-		globPath := path.Join(searchDir, glob, filename)
+		globPath := filepath.Join(searchDir, glob, filename)
 
 		matches, err := filepath.Glob(globPath)
 		if err != nil {
@@ -156,7 +155,7 @@ func PathsJoin(rootPath string, relPaths []string) []string {
 	absPaths := make([]string, 0, len(relPaths))
 
 	for _, d := range relPaths {
-		abs := path.Clean(path.Join(rootPath, d))
+		abs := filepath.Clean(filepath.Join(rootPath, d))
 		absPaths = append(absPaths, abs)
 	}
 

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/simplesurance/baur/v1"
@@ -22,13 +22,13 @@ func (r *Repo) CreateAppWithoutTasks(t *testing.T) *cfg.App {
 		Name: appName,
 	}
 
-	appDir := path.Join(r.Dir, appName)
+	appDir := filepath.Join(r.Dir, appName)
 
 	if err := os.Mkdir(appDir, 0775); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := app.ToFile(path.Join(appDir, baur.AppCfgFile)); err != nil {
+	if err := app.ToFile(filepath.Join(appDir, baur.AppCfgFile)); err != nil {
 		t.Fatalf("writing app cfg file failed: %s", err)
 	}
 
@@ -81,20 +81,20 @@ func (r *Repo) CreateSimpleApp(t *testing.T) *cfg.App {
 		},
 	}
 
-	appDir := path.Join(r.Dir, appName)
+	appDir := filepath.Join(r.Dir, appName)
 
 	if err := os.Mkdir(appDir, 0775); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := app.ToFile(path.Join(appDir, baur.AppCfgFile)); err != nil {
+	if err := app.ToFile(filepath.Join(appDir, baur.AppCfgFile)); err != nil {
 		t.Fatalf("writing app cfg file failed: %s", err)
 	}
 
 	r.AppCfgs = append(r.AppCfgs, &app)
 
-	buildFilePath := path.Join(path.Join(appDir, "build.sh"))
-	checkFilePath := path.Join(path.Join(appDir, "check.sh"))
+	buildFilePath := filepath.Join(filepath.Join(appDir, "build.sh"))
+	checkFilePath := filepath.Join(filepath.Join(appDir, "check.sh"))
 
 	fstest.WriteToFile(t, []byte(`
 #!/bin/sh
@@ -106,7 +106,7 @@ cat output_content.txt > output
 
 	fstest.Chmod(t, buildFilePath, os.ModePerm)
 
-	fstest.WriteToFile(t, []byte("1"), path.Join(appDir, "output_content.txt"))
+	fstest.WriteToFile(t, []byte("1"), filepath.Join(appDir, "output_content.txt"))
 
 	fstest.WriteToFile(t, []byte(`
 #!/bin/sh
@@ -197,7 +197,7 @@ func CreateBaurRepository(t *testing.T, opts ...Opt) *Repo {
 		t.Cleanup(func() { os.RemoveAll(tempDir) })
 	}
 
-	artifactDir := path.Join(tempDir, "filecopy-artifacts")
+	artifactDir := filepath.Join(tempDir, "filecopy-artifacts")
 
 	t.Logf("creating baur repository in %s", tempDir)
 
@@ -218,7 +218,7 @@ func CreateBaurRepository(t *testing.T, opts ...Opt) *Repo {
 		},
 	}
 
-	if err := cfgR.ToFile(path.Join(tempDir, baur.RepositoryCfgFile)); err != nil {
+	if err := cfgR.ToFile(filepath.Join(tempDir, baur.RepositoryCfgFile)); err != nil {
 		t.Fatalf("could not write repository cfg file: %s", err)
 	}
 

--- a/internal/upload/filecopy/filecopy.go
+++ b/internal/upload/filecopy/filecopy.go
@@ -3,7 +3,7 @@ package filecopy
 import (
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -63,7 +63,7 @@ func copyFile(src, dst string) error {
 // If the destination path exist and is not a regular file an error is returned.
 // If it exist and is a file, the file is overwritten if it's not the same.
 func (c *Client) Upload(src string, dst string) (string, error) {
-	destDir := path.Dir(dst)
+	destDir := filepath.Dir(dst)
 
 	isDir, err := fs.IsDir(destDir)
 	if err != nil {

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	stdexec "os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -34,7 +34,7 @@ func CommandIsInstalled() bool {
 
 // If '.git/' exist, if it does not
 func IsGitDir(dir string) (bool, error) {
-	err := fs.DirsExist(path.Join(dir, ".git"))
+	err := fs.DirsExist(filepath.Join(dir, ".git"))
 	if err == nil {
 		return true, nil
 	}

--- a/loader.go
+++ b/loader.go
@@ -2,7 +2,6 @@ package baur
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -283,7 +282,7 @@ func (a *Loader) fromCfg(appCfg *cfg.App) (*App, error) {
 // IsAppDirectory returns true and the path to the app config file if the
 // directory contains an app config file.
 func IsAppDirectory(dir string) (string, bool) {
-	cfgPath := path.Join(dir, AppCfgFile)
+	cfgPath := filepath.Join(dir, AppCfgFile)
 	isFile, _ := fs.IsFile(cfgPath)
 
 	return cfgPath, isFile

--- a/repository.go
+++ b/repository.go
@@ -2,7 +2,7 @@ package baur
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -52,7 +52,7 @@ func NewRepository(cfgPath string) (*Repository, error) {
 		return nil, errors.Wrapf(err,
 			"validating repository config %q failed", cfgPath)
 	}
-	repoPath := path.Dir(cfgPath)
+	repoPath := filepath.Dir(cfgPath)
 
 	r := Repository{
 		Cfg:         repoCfg,


### PR DESCRIPTION
Use the functions from the "filepath" package instead of from the "path" package.
The functions in "filepath" are OS-independent, the functions in "path" are for
generic paths.

This closes #187. 