### PR TITLE
cfg: run task commands not via the sh shell

### DIFF
--- a/cfg/app.go
+++ b/cfg/app.go
@@ -29,7 +29,7 @@ func ExampleApp(name string) *App {
 		Tasks: []*Task{
 			&Task{
 				Name:    "build",
-				Command: "make dist",
+				Command: []string{"make", "dist"},
 				Input: Input{
 					Files: []FileInputs{
 						{

--- a/cfg/app_test.go
+++ b/cfg/app_test.go
@@ -55,7 +55,7 @@ func TestEnsureValidateFailsOnDuplicateTaskNames(t *testing.T) {
 			&TaskInclude{
 				IncludeID: taskName,
 				Name:      taskName,
-				Command:   "make",
+				Command:   []string{"make"},
 
 				Input: Input{
 					Files: []FileInputs{{Paths: []string{"*.go"}}},

--- a/cfg/include.go
+++ b/cfg/include.go
@@ -149,7 +149,7 @@ func ExampleInclude(id string) *Include {
 			{
 				IncludeID: id + "_task_cbuild",
 				Name:      "build",
-				Command:   "make",
+				Command:   []string{"make"},
 				Input: Input{
 					GitFiles: []GitFileInputs{
 						{

--- a/cfg/includedb_test.go
+++ b/cfg/includedb_test.go
@@ -98,7 +98,7 @@ func taskInclude() TaskIncludes {
 		&TaskInclude{
 			IncludeID: "build_task",
 			Name:      "build",
-			Command:   "make",
+			Command:   []string{"make"},
 		},
 	}
 }
@@ -117,7 +117,7 @@ func TestLoadTaskIncludeWithIncludesInSameFile(t *testing.T) {
 		&TaskInclude{
 			IncludeID: "build_task",
 			Name:      "build",
-			Command:   "make",
+			Command:   []string{"make"},
 			Includes:  []string{inclFilePath + "#inputs", inclFilePath + "#outputs"},
 		},
 	}
@@ -168,7 +168,7 @@ func TestLoadTaskIncludeWithIncludesInDifferentFiles(t *testing.T) {
 			&TaskInclude{
 				IncludeID: "build_task",
 				Name:      "build",
-				Command:   "make",
+				Command:   []string{"make"},
 				Includes: []string{
 					inputInclFilename + "#" + inputIncl.Input[0].IncludeID,
 					outputInclFilename + "#" + outputIncl.Output[0].IncludeID,
@@ -212,7 +212,7 @@ func TestIncludePathsAreRelativeToCfg(t *testing.T) {
 			&TaskInclude{
 				IncludeID: "build_task",
 				Name:      "build",
-				Command:   "make",
+				Command:   []string{"make"},
 				Includes: []string{
 					filepath.Join(inputInclDirName, inputInclFilename) + "#" + inputIncl.Input[0].IncludeID,
 				},
@@ -250,7 +250,7 @@ func TestAbsIncludePathsFail(t *testing.T) {
 			&TaskInclude{
 				IncludeID: "build_task",
 				Name:      "build",
-				Command:   "make",
+				Command:   []string{"make"},
 				Includes: []string{
 					absInputInclPath + "#" + inputIncl.Input[0].IncludeID,
 				},
@@ -353,7 +353,7 @@ func TestTaskInclude(t *testing.T) {
 				Tasks: Tasks{
 					{
 						Name:    "build",
-						Command: "make",
+						Command: []string{"make"},
 						Includes: []string{
 							"include.toml#input",
 							"include.toml#input2",
@@ -519,7 +519,7 @@ func TestTaskIncludeFailsForNonExistingIncludeFile(t *testing.T) {
 		Tasks: Tasks{
 			{
 				Name:    "build",
-				Command: "make",
+				Command: []string{"make"},
 				Includes: []string{
 					"include.toml#input",
 				},
@@ -549,7 +549,7 @@ func TestTaskIncludeFailsForNonExistingIncludeName(t *testing.T) {
 		Tasks: Tasks{
 			{
 				Name:    "build",
-				Command: "make",
+				Command: []string{"make"},
 				Includes: []string{
 					"include.toml#nonexisting",
 				},
@@ -610,7 +610,7 @@ func TestVarsInIncludeFiles(t *testing.T) {
 		Tasks: Tasks{
 			{
 				Name:    "build",
-				Command: "make",
+				Command: []string{"make"},
 				Includes: []string{
 					inclFilename + "#" + inputInclID,
 					inclFilename + "#" + outputInclID,
@@ -660,7 +660,7 @@ func TestVarsInIncludeFiles(t *testing.T) {
 			{
 				IncludeID: taskInclID,
 				Name:      "check",
-				Command:   "$APPNAME",
+				Command:   []string{"$APPNAME"},
 			},
 		},
 	}
@@ -711,6 +711,6 @@ func TestVarsInIncludeFiles(t *testing.T) {
 		require.Equal(t, variableVal, loadedApp.Tasks[0].Output.File[0].Path)
 
 		require.Equal(t, "check", loadedApp.Tasks[1].Name)
-		require.Equal(t, variableVal, loadedApp.Tasks[1].Command)
+		require.Equal(t, []string{variableVal}, loadedApp.Tasks[1].Command)
 	}
 }

--- a/cfg/taskdef.go
+++ b/cfg/taskdef.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TaskDef interface {
-	GetCommand() string
+	GetCommand() []string
 	GetIncludes() *[]string
 	GetInput() *Input
 	GetName() string

--- a/cfg/taskinclude.go
+++ b/cfg/taskinclude.go
@@ -9,13 +9,13 @@ type TaskInclude struct {
 	IncludeID string `toml:"include_id" comment:"identifier of the include"`
 
 	Name     string   `toml:"name" comment:"Identifies the task, currently the name must be 'build'."`
-	Command  string   `toml:"command" comment:"Command that the task executes"`
+	Command  []string `toml:"command" comment:"Command to execute. The first element is the command, the following it's arguments.\n If the command element contains no path seperators, it's paths is tried to be looked up via the $PATH environment variable."`
 	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the include file location.\n Valid variables: $ROOT"`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
 	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`
 }
 
-func (t *TaskInclude) GetCommand() string {
+func (t *TaskInclude) GetCommand() []string {
 	return t.Command
 }
 
@@ -56,7 +56,8 @@ func (t *TaskInclude) toTask() *Task {
 	var result Task
 
 	result.Name = t.Name
-	result.Command = t.Command
+	result.Command = make([]string, len(t.Command))
+	copy(result.Command, t.Command)
 
 	deepcopy.MustCopy(t.Input, &result.Input)
 	deepcopy.MustCopy(t.Output, &result.Output)

--- a/cfg/upgrade/v4/v4.go
+++ b/cfg/upgrade/v4/v4.go
@@ -107,7 +107,7 @@ func UpgradeAppConfig(old *cfgv0.App) *cfg.App {
 
 	task := cfg.Task{
 		Name:    "build",
-		Command: old.Build.Command,
+		Command: []string{"sh", "-c", old.Build.Command},
 	}
 
 	if len(old.Build.Input.Files.Paths) > 0 {

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -108,7 +108,7 @@ func (*showCmd) strCmd(cmd []string) string {
 	var result strings.Builder
 
 	for i, e := range cmd {
-		result.WriteString(fmt.Sprintf("\"%s\"", e))
+		result.WriteString(fmt.Sprintf("'%s'", e))
 		if i < len(cmd)+1 {
 			result.WriteRune(' ')
 		}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -89,6 +89,19 @@ func mustWriteStringSliceRows(fmt format.Formatter, header string, indentlvl int
 	}
 }
 
+func (*showCmd) strCmd(cmd []string) string {
+	var result strings.Builder
+
+	for i, e := range cmd {
+		result.WriteString(fmt.Sprintf("\"%s\"", e))
+		if i < len(cmd)+1 {
+			result.WriteRune(' ')
+		}
+	}
+
+	return result.String()
+}
+
 func (c *showCmd) showApp(arg string) {
 	repo := mustFindRepository()
 	app := mustArgToApp(repo, arg)
@@ -105,7 +118,9 @@ func (c *showCmd) showApp(arg string) {
 	for taskIdx, task := range tasks {
 		mustWriteRow(formatter, term.Underline("Task"))
 		mustWriteRow(formatter, "", "Name:", term.Highlight(task.Name), "", "")
-		mustWriteRow(formatter, "", "Command:", term.Highlight(task.Command), "", "")
+		mustWriteRow(formatter, "", "Command:", term.Highlight(
+			c.strCmd(task.Command),
+		), "", "")
 
 		if task.HasInputs() {
 			mustWriteRow(formatter, "", "", "", "")

--- a/internal/command/testdata/var_in_include/tasks.toml
+++ b/internal/command/testdata/var_in_include/tasks.toml
@@ -2,4 +2,4 @@
   include_id = "build"
   includes = ["$ROOT/inputs.toml#input"]
   name = "build"
-  command = "ls $APPNAME.txt"
+  command = ["ls", "$APPNAME.txt"]

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -54,11 +54,6 @@ func Command(name string, arg ...string) *Cmd {
 	}
 }
 
-// ShellCommand executes a command in sh shell.
-func ShellCommand(cmd string) *Cmd {
-	return Command("sh", "-c", cmd)
-}
-
 // Directory changes the directory in which the command is executed.
 func (c *Cmd) Directory(dir string) *Cmd {
 	c.dir = dir

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,8 +1,6 @@
 package exec
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -10,23 +8,6 @@ func TestEchoStdout(t *testing.T) {
 	const echoStr = "hello world!"
 
 	res, err := Command("echo", "-n", echoStr).Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if res.ExitCode != 0 {
-		t.Fatalf("cmd exited with code %d, expected 0", res.ExitCode)
-	}
-
-	if res.StrOutput() != echoStr {
-		t.Errorf("expected output '%s', got '%s'", echoStr, res.StrOutput())
-	}
-}
-
-func TestShellEchoStderr(t *testing.T) {
-	const echoStr = "hello world!"
-
-	res, err := ShellCommand(fmt.Sprintf("echo -n \"%s\" >&2", echoStr)).Run()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,19 +46,4 @@ func TestExpectSuccess(t *testing.T) {
 		t.Fatalf("Command returned an error and result was not nil: %+v", res)
 	}
 
-}
-
-func TestShellLsGlob(t *testing.T) {
-	res, err := ShellCommand("ls -1").Directory("/").Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if res.ExitCode != 0 {
-		t.Errorf("exit code is %d, expected 0", res.ExitCode)
-	}
-
-	if len(strings.Split(res.StrOutput(), "\n")) < 2 {
-		t.Errorf("expected >=2 lines of output")
-	}
 }

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -47,7 +47,7 @@ func (r *Repo) CreateSimpleApp(t *testing.T) *cfg.App {
 		Tasks: []*cfg.Task{
 			{
 				Name:    "build",
-				Command: "./build.sh",
+				Command: []string{"sh", "./build.sh"},
 				Input: cfg.Input{
 					Files: []cfg.FileInputs{
 						{
@@ -69,7 +69,7 @@ func (r *Repo) CreateSimpleApp(t *testing.T) *cfg.App {
 
 			{
 				Name:    "check",
-				Command: "./check.sh",
+				Command: []string{"sh", "./check.sh"},
 				Input: cfg.Input{
 					Files: []cfg.FileInputs{
 						{

--- a/task.go
+++ b/task.go
@@ -17,7 +17,7 @@ type Task struct {
 	AppName string
 
 	Name             string
-	Command          string
+	Command          []string
 	UnresolvedInputs *cfg.Input
 	Outputs          *cfg.Output
 }

--- a/taskrunner.go
+++ b/taskrunner.go
@@ -25,7 +25,7 @@ func (t *TaskRunner) Run(task *Task) (*RunResult, error) {
 	startTime := time.Now()
 
 	// TODO: rework exec, stream the output instead of storing all in memory
-	execResult, err := exec.ShellCommand(task.Command).
+	execResult, err := exec.Command(task.Command[0], task.Command[1:]...).
 		Directory(task.Directory).
 		DebugfPrefix(color.YellowString(fmt.Sprintf("%s: ", task))).
 		Run()


### PR DESCRIPTION
Commands specified for a baur task where specified as a single string and always run via the sh-shell.
This allowed to use shell features like globs, etc.

The execution is changed to run the command directly instead.
The command and it's argument are specified in an array, exec-style.

This has the following advantages:

- command execution works on operating systems that do not have a sh-shell, like
  windows,
- the user can choose if a command should be run via a shell or if it should not,
- no unnecessary minimal overhead when shell functionality is not needed