### PR TITLE
test: reset environment variable envVarPSQLURL when testcase finishes

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -273,6 +273,10 @@ func TestVarInInclude(t *testing.T) {
 	dbURL, err := dbtest.CreateDB(dbtest.UniqueDBName())
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		os.Setenv(envVarPSQLURL, "")
+	})
+
 	err = os.Setenv(envVarPSQLURL, dbURL)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The testcase sets the environment variable envVarPSQLURL to a specific database
url.

Before the next testcase runs, the environment variable must be unset again.
If this is not done, the environment variable is still set when the next
testcase runs, the wrong database might be used which can cause test failures.