### PR TITLE
test: reset env var to old value instead of setting it to an empty string

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -273,8 +273,9 @@ func TestVarInInclude(t *testing.T) {
 	dbURL, err := dbtest.CreateDB(dbtest.UniqueDBName())
 	require.NoError(t, err)
 
+	oldEnvVal := os.Getenv(envVarPSQLURL)
 	t.Cleanup(func() {
-		os.Setenv(envVarPSQLURL, "")
+		os.Setenv(envVarPSQLURL, oldEnvVal)
 	})
 
 	err = os.Setenv(envVarPSQLURL, dbURL)


### PR DESCRIPTION
Restore the value before it was set in the testcase instead of setting it to an
empty string.

Setting it to an empty string still might change it's value and affect following
testcases