### PR TITLE
digest: fix: leading zero was truncating from sha384 string representation

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,8 +1,8 @@
 package digest
 
 import (
+	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -34,16 +34,16 @@ func (t Algorithm) String() string {
 
 // Digest contains a checksum
 type Digest struct {
-	Sum       big.Int
+	Sum       []byte
 	Algorithm Algorithm
 }
 
-// String returns '<Algorithm>:<checksum>'
+// String returns '<Algorithm>:<hash>'
 func (d *Digest) String() string {
-	return fmt.Sprintf("%s:%s", d.Algorithm, d.Sum.Text(16))
+	return fmt.Sprintf("%s:%s", d.Algorithm, hex.EncodeToString(d.Sum))
 }
 
-// FromString converts a "sha256:<hash> string to Digest
+// FromString converts a "<Algorithm>:<hash> string to Digest
 func FromString(in string) (*Digest, error) {
 	var algorithm Algorithm
 
@@ -69,10 +69,9 @@ func FromString(in string) (*Digest, error) {
 		return nil, errors.New("unsupported format %q")
 	}
 
-	sum := big.Int{}
-	_, err := fmt.Sscan("0x"+spl[1], &sum)
+	sum, err := hex.DecodeString(spl[1])
 	if err != nil {
-		return nil, errors.Wrap(err, "converting digest to big int failed")
+		return nil, errors.Wrap(err, "converting string sum to hex failed")
 	}
 
 	return &Digest{

--- a/internal/digest/sha384/sha384.go
+++ b/internal/digest/sha384/sha384.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha512"
 	stdhash "hash"
 	"io"
-	"math/big"
 	"os"
 	"sort"
 
@@ -42,8 +41,7 @@ func (h *Hash) AddFile(path string) error {
 
 // Digest returns the digest of the hash
 func (h *Hash) Digest() *digest.Digest {
-	sum := big.Int{}
-	sum.SetBytes(h.hash.Sum(nil))
+	sum := h.hash.Sum(nil)
 
 	return &digest.Digest{
 		Algorithm: digest.SHA384,
@@ -75,7 +73,7 @@ func Sum(digests []*digest.Digest) (*digest.Digest, error) {
 			return false
 		}
 
-		return digests[i].Sum.Cmp(&digests[j].Sum) == -1
+		return bytes.Compare(digests[i].Sum, digests[j].Sum) == -1
 	})
 
 	for _, d := range digests {


### PR DESCRIPTION
@StephenDiligent figured out, that creating a sha384 digest and converting
it's string representation back to a digest can fail with a "hash length is 95,
expected length 96" error.

If a calculated digest started with 0, the leading 0 was truncated from the
hash.
This happened because the hash was stored as big.Int, leading zeroes can be
omitted for an integer without changing the meaning. Truncating a zero from a
digest makes it invalid.

Fix this by using the helpers from the hex package to create a string
representation of the hash instead of big.Int.

A testcase is added for the bug.
The existing testcase are changed to compare digests via their string
representation instead of converting the Sum to a string on their own.