### PR TITLE
inputresolver: add additional testcases

### DIFF
--- a/inputresolver_test.go
+++ b/inputresolver_test.go
@@ -117,6 +117,37 @@ func TestFilesOptional(t *testing.T) {
 		},
 
 		{
+			name:          "file_input_optional_2defs_one_missing",
+			filesToCreate: []string{"file.1"},
+			expectError:   true,
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					Files: []cfg.FileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "gitfile_input_optional_2defs_one_missing",
+			filesToCreate: []string{"file.1"},
+			expectError:   true,
+			task: Task{
+				UnresolvedInputs: &cfg.Input{
+					GitFiles: []cfg.GitFileInputs{
+						{
+							Paths:    []string{"*.1", "*.2"},
+							Optional: false,
+						},
+					},
+				},
+			},
+		},
+
+		{
 			name:          "file_input_exists",
 			filesToCreate: []string{"file.1", "file.2"},
 			task: Task{

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1,3 +1,5 @@
+// +build dbtest
+
 package command
 
 import (


### PR DESCRIPTION
```
        inputresolver: add testcase

        Add a testcase that ensures that an error is returned when the Optional flag for
        GitFileInputs and FileInputs is set and one of the patterns in the Path slice
        matches and another doesn't.

-------------------------------------------------------------------------------
        tests: add missing dbtest build tag

        The show_test.go file is requiring a postgresql to be available but the dbtest
        build tag was not set.
```

This closes #203. The described issue does not exist. It works as expected.
The PR adds only testcases to cover the described scenario.