### PR TITLE
Remove using pkg/errors #211

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,10 +1,9 @@
 package baur
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
-
-	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/v1/cfg"
 )
@@ -26,7 +25,7 @@ func NewApp(appCfg *cfg.App, repositoryRootPath string) (*App, error) {
 
 	appRelPath, err := filepath.Rel(repositoryRootPath, appDir)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s: resolving repository relative application path failed", appCfg.Name)
+		return nil, fmt.Errorf("%s: resolving repository relative application path failed: %w", appCfg.Name, err)
 	}
 
 	app := App{

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.8.0
-	github.com/pkg/errors v0.9.1
 	github.com/simplesurance/baur v0.18.1
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -2,10 +2,9 @@ package digest
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Algorithm describes the digest algorithm
@@ -66,12 +65,12 @@ func FromString(in string) (*Digest, error) {
 
 		algorithm = SHA384
 	default:
-		return nil, errors.New("unsupported format %q")
+		return nil, fmt.Errorf("unsupported format %q", a)
 	}
 
 	sum, err := hex.DecodeString(spl[1])
 	if err != nil {
-		return nil, errors.Wrap(err, "converting string sum to hex failed")
+		return nil, fmt.Errorf("converting string sum to hex failed: %w", err)
 	}
 
 	return &Digest{

--- a/internal/digest/sha384/sha384.go
+++ b/internal/digest/sha384/sha384.go
@@ -3,12 +3,11 @@ package sha384
 import (
 	"bytes"
 	"crypto/sha512"
+	"fmt"
 	stdhash "hash"
 	"io"
 	"os"
 	"sort"
-
-	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/v1/internal/digest"
 )
@@ -27,13 +26,13 @@ func New() *Hash {
 func (h *Hash) AddFile(path string) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return errors.Wrap(err, "opening file failed")
+		return fmt.Errorf("opening file failed: %w", err)
 	}
 
 	defer f.Close()
 
 	if _, err := io.Copy(h.hash, f); err != nil {
-		return errors.Wrap(err, "reading file failed")
+		return fmt.Errorf("reading file failed: %w", err)
 	}
 
 	return nil
@@ -53,7 +52,7 @@ func (h *Hash) Digest() *digest.Digest {
 func (h *Hash) AddBytes(b []byte) error {
 	_, err := h.hash.Write(b)
 	if err != nil {
-		return errors.Wrap(err, "writing to hash stream failed")
+		return fmt.Errorf("writing to hash stream failed: %w", err)
 	}
 
 	return nil

--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/simplesurance/baur/fs"
 )
 
@@ -22,7 +20,7 @@ func FileGlob(pattern string) ([]string, error) {
 	if strings.Contains(pattern, "**") {
 		expandedPaths, err := expandDoubleStarGlob(pattern)
 		if err != nil {
-			return nil, errors.Wrap(err, "expanding '**' failed")
+			return nil, fmt.Errorf("expanding '**' failed: %w", err)
 		}
 
 		globPaths = expandedPaths
@@ -48,7 +46,7 @@ func FileGlob(pattern string) ([]string, error) {
 	for _, p := range paths {
 		isFile, err := fs.IsFile(p)
 		if err != nil {
-			return nil, errors.Wrapf(err, "resolved path %q does not exist", p)
+			return nil, fmt.Errorf("resolved path %q does not exist: %w", p, err)
 		}
 
 		if isFile {
@@ -62,7 +60,7 @@ func FileGlob(pattern string) ([]string, error) {
 func findAllDirsNoDups(result map[string]struct{}, path string) error {
 	isDir, err := fs.IsDir(path)
 	if err != nil {
-		return errors.Wrapf(err, "IsDir(%s) failed", path)
+		return fmt.Errorf("IsDir(%s) failed: %w", path, err)
 	}
 
 	if !isDir {
@@ -71,7 +69,7 @@ func findAllDirsNoDups(result map[string]struct{}, path string) error {
 
 	path, err = filepath.EvalSymlinks(path)
 	if err != nil {
-		return errors.Wrapf(err, "resolving symlinks in %q failed", path)
+		return fmt.Errorf("resolving symlinks in %q failed: %w", path, err)
 	}
 
 	if _, exist := result[path]; exist {
@@ -82,7 +80,7 @@ func findAllDirsNoDups(result map[string]struct{}, path string) error {
 	globPath := filepath.Join(path, "*")
 	rootGlob, err := filepath.Glob(globPath) // is filepath.Walk() faster?
 	if err != nil {
-		return errors.Wrapf(err, "glob of %q failed", globPath)
+		return fmt.Errorf("glob of %q failed: %w", globPath, err)
 	}
 
 	for _, path := range rootGlob {

--- a/internal/upload/docker/docker.go
+++ b/internal/upload/docker/docker.go
@@ -3,10 +3,10 @@ package docker
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/pkg/errors"
 )
 
 // DefaultRegistry is the registry for that authentication data is used
@@ -119,7 +119,7 @@ func (c *Client) Upload(image, registryAddr, repository, tag string) (string, er
 		Tag:  tag,
 	})
 	if err != nil {
-		return "", errors.Wrapf(err, "tagging image failed")
+		return "", fmt.Errorf("tagging image failed: %w", err)
 	}
 
 	auth := c.getAuth(registryAddr)

--- a/internal/upload/filecopy/filecopy.go
+++ b/internal/upload/filecopy/filecopy.go
@@ -1,11 +1,10 @@
 package filecopy
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/v1/internal/fs"
 )
@@ -30,7 +29,7 @@ func New(debugLogFn func(string, ...interface{})) *Client {
 func copyFile(src, dst string) error {
 	srcFd, err := os.Open(src)
 	if err != nil {
-		return errors.Wrapf(err, "opening %s failed", src)
+		return fmt.Errorf("opening %s failed: %w", src, err)
 	}
 
 	// nolint: errcheck
@@ -38,14 +37,14 @@ func copyFile(src, dst string) error {
 
 	srcFi, err := os.Stat(src)
 	if err != nil {
-		return errors.Wrapf(err, "stat %s failed", src)
+		return fmt.Errorf("stat %s failed: %w", src, err)
 	}
 
 	srcFileMode := srcFi.Mode().Perm()
 
 	dstFd, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcFileMode)
 	if err != nil {
-		return errors.Wrapf(err, "opening %s failed", dst)
+		return fmt.Errorf("opening %s failed: %w", dst, err)
 	}
 
 	_, err = io.Copy(dstFd, srcFd)
@@ -73,13 +72,12 @@ func (c *Client) Upload(src string, dst string) (string, error) {
 
 		err = fs.Mkdir(destDir)
 		if err != nil {
-			return "", errors.Wrapf(err, "creating directory '%s' failed", destDir)
+			return "", fmt.Errorf("creating directory %s failed: %w", destDir, err)
 		}
-
 		c.debugLogFn("filecopy: created directory '%s'", destDir)
 	} else {
 		if !isDir {
-			return "", errors.Wrapf(err, "%s is not a directory", destDir)
+			return "", fmt.Errorf("%s is not a directory", destDir)
 		}
 	}
 
@@ -93,7 +91,7 @@ func (c *Client) Upload(src string, dst string) (string, error) {
 	}
 
 	if !regFile {
-		return "", errors.Wrapf(err, "'%s' exist but is not a regular file", dst)
+		return "", fmt.Errorf("%s exist but is not a regular file", dst)
 	}
 
 	sameFile, err := fs.SameFile(src, dst)

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -3,14 +3,13 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	stdexec "os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/v1/internal/exec"
 	"github.com/simplesurance/baur/v1/internal/fs"
@@ -74,7 +73,7 @@ func CommitID(dir string) (string, error) {
 
 	commitID := strings.TrimSpace(res.StrOutput())
 	if len(commitID) == 0 {
-		return "", errors.Wrap(err, "executing git rev-parse HEAD failed, no Stdout output")
+		return "", errors.New("executing git rev-parse HEAD failed, no Stdout output")
 	}
 
 	return commitID, err
@@ -109,7 +108,7 @@ func LsFiles(dir string, errorUnmatch bool, arg ...string) (string, error) {
 		}
 
 		if err := scanner.Err(); err != nil {
-			return "", errors.Wrap(err, "scanning cmd output failed")
+			return "", fmt.Errorf("scanning cmd output failed: %w", err)
 		}
 
 		if len(errMsgs) != 0 {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,8 +3,6 @@ package version
 import (
 	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -28,7 +26,7 @@ var (
 func LoadPackageVars() error {
 	s, err := FromString(Version)
 	if err != nil {
-		return errors.Wrapf(err, "parsing version '%s' failed", Version)
+		return fmt.Errorf("parsing version %q failed: %w", Version, err)
 	}
 
 	CurSemVer = *s
@@ -74,7 +72,7 @@ func FromString(ver string) (*SemVer, error) {
 
 	matches, err := fmt.Sscanf(ver, "%d.%d.%d-%s", &major, &minor, &patch, &appendix)
 	if (err != nil && err != io.ErrUnexpectedEOF) || matches < 1 {
-		return nil, errors.Wrapf(err, "invalid format, should be <Major>[.<Minor>[.<Patch>[-appendix]]]")
+		return nil, fmt.Errorf("invalid format, should be <Major>[.<Minor>[.<Patch>[-appendix]]]: %w", err)
 	}
 
 	return &SemVer{

--- a/repository.go
+++ b/repository.go
@@ -1,10 +1,9 @@
 package baur
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/simplesurance/baur/v1/cfg"
 	"github.com/simplesurance/baur/v1/internal/fs"
@@ -43,14 +42,14 @@ func FindRepositoryCfgCwd() (string, error) {
 func NewRepository(cfgPath string) (*Repository, error) {
 	repoCfg, err := cfg.RepositoryFromFile(cfgPath)
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"reading repository config %s failed", cfgPath)
+		return nil, fmt.Errorf(
+			"reading repository config %s failed: %w", cfgPath, err)
 	}
 
 	err = repoCfg.Validate()
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"validating repository config %q failed", cfgPath)
+		return nil, fmt.Errorf(
+			"validating repository config %q failed: %w", cfgPath, err)
 	}
 	repoPath := filepath.Dir(cfgPath)
 

--- a/uploader.go
+++ b/uploader.go
@@ -2,6 +2,7 @@ package baur
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"time"
 )
@@ -115,7 +116,9 @@ func (u *Uploader) DockerImage(o *OutputDockerImage) (*UploadResult, error) {
 func (u *Uploader) FileCopy(o *OutputFile) (*UploadResult, error) {
 	startTime := time.Now()
 
-	url, err := u.filecopyUploader.Upload(o.AbsPath, o.UploadsFilecopy.DestinationPath)
+	destFile := filepath.Join(o.UploadsFilecopy.DestinationPath, filepath.Base(o.AbsPath))
+
+	url, err := u.filecopyUploader.Upload(o.AbsPath, destFile)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,6 @@ github.com/opencontainers/runc/libcontainer/user
 ## explicit
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
Fixes #211 

- using Golangs errors wrapper `fmt.Errorf %w` 
- `errors.Is` is used Golang standard `errors`
- Also remove `go.mod` and vendor directory
