### PR TITLE
Tests: log all output of commands via the test logger

### DIFF
--- a/cfg/app.go
+++ b/cfg/app.go
@@ -102,7 +102,7 @@ func (a *App) ToFile(filepath string, opts ...ToFileOpt) error {
 	return toFile(a, filepath, opts...)
 }
 
-// FilePath returns the path of the file from which the configuration was loaded.
+// FilePath returns the path of the app configuration file
 func (a *App) FilePath() string {
 	return a.filepath
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -42,7 +42,7 @@ func init() {
 func baurCSVLsApps(t *testing.T) [][]string {
 	t.Helper()
 
-	stdoutBuf, _ := interceptCmdOutput()
+	stdoutBuf, _ := interceptCmdOutput(t)
 
 	lsAppsCmd := newLsAppsCmd()
 	lsAppsCmd.csv = true
@@ -65,7 +65,7 @@ type csvStatus struct {
 func baurCSVStatus(t *testing.T, inputStr, lookupInputStr string) []*csvStatus {
 	t.Helper()
 
-	stdoutBuf, _ := interceptCmdOutput()
+	stdoutBuf, _ := interceptCmdOutput(t)
 
 	statusCmd := newStatusCmd()
 	statusCmd.csv = true

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -19,13 +19,6 @@ import (
 	"github.com/simplesurance/baur/v1/internal/testutils/repotest"
 )
 
-func runInitDb(t *testing.T) {
-	t.Helper()
-
-	t.Log("creating database schema")
-	initDb(initDbCmd, nil)
-}
-
 var testdataDir string
 
 func init() {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -30,6 +30,13 @@ func init() {
 	testdataDir = filepath.Join(wd, "testdata")
 }
 
+func runInitDb(t *testing.T) {
+	t.Helper()
+
+	t.Log("creating database schema")
+	initDb(initDbCmd, nil)
+}
+
 // baurCSVLsApps runs "baur ls apps --csv" and returns a slice where each
 // element is a slice of csv fields per line
 func baurCSVLsApps(t *testing.T) [][]string {

--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -385,7 +385,7 @@ func TestDifferencesOutputWithCorrectState(t *testing.T) {
 
 	exitFunc = func(code int) {}
 
-	stdoutBuf, _ := interceptCmdOutput()
+	stdoutBuf, _ := interceptCmdOutput(t)
 
 	diffInputsCmd := newDiffInputsCmd()
 	diffInputsCmd.csv = true

--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -53,6 +53,7 @@ func Test2ArgsRequired(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t)
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -90,6 +91,7 @@ func TestWildCardsNotAllowed(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t)
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -123,6 +125,7 @@ func TestAppAndTaskRequired(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t)
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -156,6 +159,7 @@ func TestUnknownAppOrTaskReturnsExitCode1(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t)
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -169,6 +173,7 @@ func TestUnknownAppOrTaskReturnsExitCode1(t *testing.T) {
 }
 
 func TestCurrentInputsAgainstSameTaskCurrentInputsReturnsExitCode1(t *testing.T) {
+	redirectOutputToLogger(t)
 	r := repotest.CreateBaurRepository(t)
 	r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -195,6 +200,7 @@ func TestNonExistentRunReturnsExitCode1(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -229,6 +235,7 @@ func TestCurrentInputsAgainstPreviousRunThatHasSameInputsReturnsExitCode0(t *tes
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -263,6 +270,7 @@ func TestPreviousRunAgainstAnotherPreviousRunThatHasSameInputsReturnsExitCode0(t
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -298,6 +306,7 @@ func TestCurrentInputsAgainstPreviousRunThatHasDifferentInputsReturnsExitCode2(t
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -333,6 +342,7 @@ func TestPreviousRunAgainstAnotherPreviousRunThatHasDifferentInputsReturnsExitCo
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
+			redirectOutputToLogger(t)
 			r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 			r.CreateAppWithNoOutputs(t, appOneName)
 
@@ -354,6 +364,7 @@ func TestPreviousRunAgainstAnotherPreviousRunThatHasDifferentInputsReturnsExitCo
 
 // Different apps will always return exit code 2 because their .app.toml files differ
 func TestDifferentAppsReturnExitCode2(t *testing.T) {
+	redirectOutputToLogger(t)
 	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 	r.CreateAppWithNoOutputs(t, appOneName)
 	r.CreateAppWithNoOutputs(t, appTwoName)
@@ -368,6 +379,7 @@ func TestDifferentAppsReturnExitCode2(t *testing.T) {
 }
 
 func TestDifferencesOutputWithCorrectState(t *testing.T) {
+	redirectOutputToLogger(t)
 	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 	r.CreateAppWithNoOutputs(t, appOneName)
 	fileName := "diff_test.txt"

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -16,23 +16,25 @@ import (
 // TestShowArgs verifies that the show command works with all supported
 // parameters to specify the app or task
 func TestShowArgs(t *testing.T) {
-	initTest(t)
 	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 	app := r.CreateSimpleApp(t)
 
 	showCmd := newShowCmd()
 
 	t.Run("appName", func(t *testing.T) {
+		initTest(t)
 		showCmd.Command.Run(&showCmd.Command, []string{app.Name})
 	})
 
 	t.Run("taskName", func(t *testing.T) {
+		initTest(t)
 		showCmd.Command.Run(&showCmd.Command, []string{
 			fmt.Sprintf("%s.%s", app.Name, app.Tasks[0].Name),
 		})
 	})
 
 	t.Run("appRelDir", func(t *testing.T) {
+		initTest(t)
 		appDir := filepath.Dir(app.FilePath())
 		relDir, err := filepath.Rel(r.Dir, appDir)
 		require.NoError(t, err)
@@ -41,6 +43,7 @@ func TestShowArgs(t *testing.T) {
 	})
 
 	t.Run("appCurrentDir", func(t *testing.T) {
+		initTest(t)
 		appDir := filepath.Dir(app.FilePath())
 
 		err := os.Chdir(appDir)

--- a/internal/command/upgrade_configs_test.go
+++ b/internal/command/upgrade_configs_test.go
@@ -38,7 +38,7 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(t, os.Chdir("/"))
 	gittest.Clone(t, gitDir, gitURL, commit)
 
-	stdoutBuf, stderrBuf := interceptCmdOutput()
+	stdoutBuf, stderrBuf := interceptCmdOutput(t)
 
 	require.NoError(t, os.Chdir(gitDir))
 

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -41,10 +41,3 @@ func redirectOutputToLogger(t *testing.T) {
 	stdout = term.NewStream(logwriter.New(t, ioutil.Discard))
 	stderr = term.NewStream(logwriter.New(t, ioutil.Discard))
 }
-
-func runInitDb(t *testing.T) {
-	t.Helper()
-
-	t.Log("creating database schema")
-	initDb(initDbCmd, nil)
-}

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -2,20 +2,23 @@ package command
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 
 	"github.com/simplesurance/baur/v1/internal/command/term"
 	"github.com/simplesurance/baur/v1/internal/exec"
+	"github.com/simplesurance/baur/v1/internal/testutils/logwriter"
 )
 
 // interceptCmdOutput changes the stdout and stderr streams to that the
-// commands write to the returned buffers
-func interceptCmdOutput() (stdoutBuf, stderrBuf *bytes.Buffer) {
+// commands write to the returned buffers, all output is additionaly still
+// logged via the test logger
+func interceptCmdOutput(t *testing.T) (stdoutBuf, stderrBuf *bytes.Buffer) {
 	var bufStdout bytes.Buffer
 	var bufStderr bytes.Buffer
 
-	stdout = term.NewStream(&bufStdout)
-	stderr = term.NewStream(&bufStderr)
+	stdout = term.NewStream(logwriter.New(t, &bufStdout))
+	stderr = term.NewStream(logwriter.New(t, &bufStderr))
 
 	return &bufStdout, &bufStderr
 }
@@ -31,4 +34,6 @@ func initTest(t *testing.T) {
 	}
 
 	exec.DefaultDebugfFn = t.Logf
+	stdout = term.NewStream(logwriter.New(t, ioutil.Discard))
+	stderr = term.NewStream(logwriter.New(t, ioutil.Discard))
 }

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/simplesurance/baur/v1/internal/command/term"
 	"github.com/simplesurance/baur/v1/internal/exec"
+	"github.com/simplesurance/baur/v1/internal/log"
 	"github.com/simplesurance/baur/v1/internal/testutils/logwriter"
 )
 
@@ -37,6 +38,7 @@ func initTest(t *testing.T) {
 }
 
 func redirectOutputToLogger(t *testing.T) {
+	log.StdLogger.SetOutput(log.NewTestLogOutput(t))
 	exec.DefaultDebugfFn = t.Logf
 	stdout = term.NewStream(logwriter.New(t, ioutil.Discard))
 	stderr = term.NewStream(logwriter.New(t, ioutil.Discard))

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // interceptCmdOutput changes the stdout and stderr streams to that the
-// commands write to the returned buffers, all output is additionaly still
+// commands write to the returned buffers, all output is additionally still
 // logged via the test logger
 func interceptCmdOutput(t *testing.T) (stdoutBuf, stderrBuf *bytes.Buffer) {
 	var bufStdout bytes.Buffer
@@ -33,7 +33,18 @@ func initTest(t *testing.T) {
 		t.Fatalf("baur command exited with code %d", code)
 	}
 
+	redirectOutputToLogger(t)
+}
+
+func redirectOutputToLogger(t *testing.T) {
 	exec.DefaultDebugfFn = t.Logf
 	stdout = term.NewStream(logwriter.New(t, ioutil.Discard))
 	stderr = term.NewStream(logwriter.New(t, ioutil.Discard))
+}
+
+func runInitDb(t *testing.T) {
+	t.Helper()
+
+	t.Log("creating database schema")
+	initDb(initDbCmd, nil)
 }

--- a/internal/log/testlogwrapper.go
+++ b/internal/log/testlogwrapper.go
@@ -1,0 +1,29 @@
+package log
+
+import "testing"
+
+type TestLogOutput struct {
+	t *testing.T
+}
+
+// NewTestLogOutput wraps the logger of testing.T to provide the Output
+// interface.
+func NewTestLogOutput(t *testing.T) *TestLogOutput {
+	return &TestLogOutput{t: t}
+}
+
+func (l *TestLogOutput) Printf(format string, v ...interface{}) {
+	l.t.Logf(format, v...)
+}
+
+func (l *TestLogOutput) Println(v ...interface{}) {
+	l.t.Log(v...)
+}
+
+func (l *TestLogOutput) Fatalf(format string, v ...interface{}) {
+	l.t.Fatalf(format, v...)
+}
+
+func (l *TestLogOutput) Fatalln(v ...interface{}) {
+	l.t.Fatal(v...)
+}

--- a/internal/testutils/logwriter/logwrap.go
+++ b/internal/testutils/logwriter/logwrap.go
@@ -1,27 +1,84 @@
 package logwriter
 
 import (
+	"bytes"
+	"fmt"
 	"io"
+	"strings"
+	"sync"
 	"testing"
 )
 
 type Logger struct {
-	t *testing.T
-	w io.Writer
+	t   *testing.T
+	w   io.Writer
+	buf bytes.Buffer
+	mu  sync.Mutex
 }
 
 // New returns an io.writer compatible writer that writes everything to w and
-// to t.Logf
+// to t.Logf.
+// It also registers Logger.Flush() as cleanup method for testing.T.
 func New(t *testing.T, w io.Writer) *Logger {
-	return &Logger{
+	l := Logger{
 		t: t,
 		w: w,
 	}
+
+	t.Cleanup(func() { _ = l.Flush() })
+
+	return &l
 }
 
-func (l *Logger) Write(p []byte) (n int, err error) {
-	n, err = l.w.Write(p)
-	l.t.Logf("%x", p[0:n])
+func (l *Logger) Write(p []byte) (int, error) {
+	l.t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
-	return n, err
+	n, writerErr := l.w.Write(p)
+	_, _ = l.buf.Write(p[0:n]) // returns always a nil error
+
+	if !bytes.ContainsRune(p, '\n') {
+		return n, writerErr
+	}
+
+	for {
+		line, err := l.buf.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				panic(fmt.Sprintf("logwrap: reading from buffer failed: %s", err))
+			}
+			// add chunk without line-ending back to buffer
+			_, _ = l.buf.WriteString(line) // returns always a nil error
+			break
+		}
+
+		l.t.Log(strings.TrimRight(line, "\n"))
+	}
+
+	return n, writerErr
+}
+
+// Flush writes all bytes in the buffer to the test logger and the io.writer.
+// It always returns a nil error and panics on errors.
+func (l *Logger) Flush() error {
+	l.t.Helper()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	b := l.buf.Bytes()
+
+	if len(b) == 0 {
+		return nil
+	}
+
+	_, err := l.w.Write(b)
+	if err != nil {
+		panic(fmt.Sprintf("logwrap: writing to w failed: %s", err))
+	}
+
+	l.t.Log(string(b))
+
+	return nil
 }

--- a/internal/testutils/logwriter/logwrap.go
+++ b/internal/testutils/logwriter/logwrap.go
@@ -1,0 +1,27 @@
+package logwriter
+
+import (
+	"io"
+	"testing"
+)
+
+type Logger struct {
+	t *testing.T
+	w io.Writer
+}
+
+// New returns an io.writer compatible writer that writes everything to w and
+// to t.Logf
+func New(t *testing.T, w io.Writer) *Logger {
+	return &Logger{
+		t: t,
+		w: w,
+	}
+}
+
+func (l *Logger) Write(p []byte) (n int, err error) {
+	n, err = l.w.Write(p)
+	l.t.Logf("%x", p[0:n])
+
+	return n, err
+}


### PR DESCRIPTION
This PR redirects output that is generated during test execution to the log functions of `testing.T`.
Forwarding the output to the test logger allows `go test` to associate output with the associated testcases.
This makes it easier to debug issues when tests are failing.

So far a lot of the output generated during test execution was printed simply to stdout or stderr and `go test` showed it intermingled with output from other tests.

1. The log package is changed to support forwarding all output to the test logger
2. A wrapper io.Writer wrapper for the testlogger is introduced that can be used as stdin and stdout streams for the commands.
3. Testcases are adapted to change the logger and stdin/stdout streams to log via the test logger.