### PR TITLE
Cleanup of the log package

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -285,8 +285,4 @@ func TestVarInInclude(t *testing.T) {
 
 	runCmd := newRunCmd()
 	runCmd.Command.Run(&runCmd.Command, []string{"app1", "app2"})
-
-	exitFunc = func(code int) {
-		t.Errorf("baur command exited with code %d", code)
-	}
 }

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -201,12 +201,12 @@ func exitOnErr(err error, msg ...interface{}) {
 	}
 
 	if len(msg) == 0 {
-		fmt.Fprintln(os.Stderr, errorPrefix, err)
+		stderr.Println(errorPrefix, err)
 		exitFunc(1)
 	}
 
 	wholeMsg := fmt.Sprint(msg...)
-	fmt.Fprintf(os.Stderr, "%s %s: %s\n", errorPrefix, wholeMsg, err)
+	stderr.Printf("%s %s: %s\n", errorPrefix, wholeMsg, err)
 
 	exitFunc(1)
 }

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -37,11 +37,12 @@ func mustFindRepository() *baur.Repository {
 	repo, err := findRepository()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			log.Fatalf("baur repository not found, ensure a %q file exist in the current or a parent directory\n",
+			stderr.Printf("baur repository not found, ensure a %q file exist in the current or a parent directory\n",
 				baur.RepositoryCfgFile)
+			exitFunc(1)
 		}
-
-		exitOnErr(err, "locating baur repository failed")
+		stderr.Println("locating baur repository failed")
+		exitFunc(1)
 	}
 
 	return repo
@@ -50,7 +51,8 @@ func mustFindRepository() *baur.Repository {
 func mustArgToTask(repo *baur.Repository, arg string) *baur.Task {
 	tasks := mustArgToTasks(repo, []string{arg})
 	if len(tasks) > 1 {
-		log.Fatalf("argument %q matches multiple tasks, must match only 1 task\n", arg)
+		stderr.Printf("argument %q matches multiple tasks, must match only 1 task\n", arg)
+		exitFunc(1)
 	}
 
 	// mustArgToApps ensures that >=1 apps are returned
@@ -60,7 +62,8 @@ func mustArgToTask(repo *baur.Repository, arg string) *baur.Task {
 func mustArgToApp(repo *baur.Repository, arg string) *baur.App {
 	apps := mustArgToApps(repo, []string{arg})
 	if len(apps) > 1 {
-		log.Fatalf("argument %q matches multiple apps, must match only 1 app\n", arg)
+		stderr.Printf("argument %q matches multiple apps, must match only 1 app\n", arg)
+		exitFunc(1)
 	}
 
 	// mustArgToApps ensures that >=1 apps are returned
@@ -102,9 +105,10 @@ func mustHavePSQLURI(r *baur.Repository) {
 	}
 
 	if len(os.Getenv(envVarPSQLURL)) == 0 {
-		log.Fatalf("PostgreSQL connection information is missing.\n"+
+		stderr.Printf("PostgreSQL connection information is missing.\n"+
 			"- set postgres_url in your repository config or\n"+
 			"- set the $%s environment variable", envVarPSQLURL)
+		exitFunc(1)
 	}
 }
 

--- a/internal/command/init_app.go
+++ b/internal/command/init_app.go
@@ -10,7 +10,6 @@ import (
 	"github.com/simplesurance/baur/v1"
 	"github.com/simplesurance/baur/v1/cfg"
 	"github.com/simplesurance/baur/v1/internal/command/term"
-	"github.com/simplesurance/baur/v1/internal/log"
 )
 
 func init() {
@@ -50,10 +49,12 @@ func initApp(cmd *cobra.Command, args []string) {
 	err = appCfg.ToFile(filepath.Join(cwd, baur.AppCfgFile), cfg.ToFileOptCommented())
 	if err != nil {
 		if os.IsExist(err) {
-			log.Fatalf("%s already exist\n", baur.AppCfgFile)
+			stderr.Printf("%s already exist\n", baur.AppCfgFile)
+			exitFunc(1)
 		}
 
-		log.Fatalln(err)
+		stderr.Println(err)
+		exitFunc(1)
 	}
 
 	stdout.Printf("Application configuration file was written to %s\n",

--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/simplesurance/baur/v1/internal/command/term"
 	"github.com/simplesurance/baur/v1/internal/fs"
-	"github.com/simplesurance/baur/v1/internal/log"
 )
 
 const bashCompLongHelp = `
@@ -72,12 +71,14 @@ func mustCreatebashComplDir(path string) {
 		}
 
 		if !isDir {
-			log.Fatalf("'%s' must be a directory", path)
+			stderr.Printf("'%s' must be a directory", path)
+			exitFunc(1)
 		}
 	}
 
 	if !os.IsNotExist(err) {
-		log.Fatalln(err)
+		stderr.Println(err)
+		exitFunc(1)
 	}
 
 	err = fs.Mkdir(path)

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/simplesurance/baur/v1"
 	"github.com/simplesurance/baur/v1/internal/command/term"
-	"github.com/simplesurance/baur/v1/internal/log"
 )
 
 const initDbExample = `
@@ -44,12 +43,14 @@ func initDb(cmd *cobra.Command, args []string) {
 		repo, err := findRepository()
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Fatalf("could not find '%s' repository config file.\n"+
+				stderr.Printf("could not find '%s' repository config file.\n"+
 					"Run '%s' first or pass the Postgres URL as argument.",
 					term.Highlight(baur.RepositoryCfgFile), term.Highlight(cmdInitRepo))
+				exitFunc(1)
 			}
 
-			log.Fatalln(err)
+			stderr.Println(err)
+			exitFunc(1)
 		}
 
 		dbURL = repo.PSQLURL

--- a/internal/command/init_include.go
+++ b/internal/command/init_include.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/simplesurance/baur/v1/cfg"
 	"github.com/simplesurance/baur/v1/internal/command/term"
-	"github.com/simplesurance/baur/v1/internal/log"
 )
 
 func init() {
@@ -45,10 +44,12 @@ func initInclude(cmd *cobra.Command, args []string) {
 	err := cfgInclude.ToFile(filename, cfg.ToFileOptCommented())
 	if err != nil {
 		if os.IsExist(err) {
-			log.Fatalf("%s already exist\n", filename)
+			stderr.Printf("%s already exist\n", filename)
+			exitFunc(1)
 		}
 
-		log.Fatalln(err)
+		stderr.Println(err)
+		exitFunc(1)
 	}
 
 	stdout.Printf("Include configuration file was written to %s\n",

--- a/internal/command/init_repo.go
+++ b/internal/command/init_repo.go
@@ -10,7 +10,6 @@ import (
 	"github.com/simplesurance/baur/v1"
 	"github.com/simplesurance/baur/v1/cfg"
 	"github.com/simplesurance/baur/v1/internal/command/term"
-	"github.com/simplesurance/baur/v1/internal/log"
 )
 
 func init() {
@@ -48,10 +47,12 @@ func initRepo(cmd *cobra.Command, args []string) {
 	err = repoCfg.ToFile(repoCfgPath)
 	if err != nil {
 		if os.IsExist(err) {
-			log.Fatalf("%s already exist\n", repoCfgPath)
+			stderr.Printf("%s already exist\n", repoCfgPath)
+			exitFunc(1)
 		}
 
-		log.Fatalln(err)
+		stderr.Println(err)
+		exitFunc(1)
 	}
 
 	stdout.Printf("Repository configuration was written to %s\n",

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -51,15 +51,16 @@ func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
 
 	taskRunID, err := strconv.Atoi(args[0])
 	if err != nil {
-		log.Fatalf("'%s' is not a numeric task run ID", args[0])
+		stderr.Printf("'%s' is not a numeric task run ID", args[0])
+		exitFunc(1)
 	}
 
 	_, err = pgClient.TaskRun(ctx, taskRunID)
 	if err != nil {
 		if err == storage.ErrNotExist {
-			log.Fatalf("task run with ID %d does not exist", taskRunID)
+			stderr.Printf("task run with ID %d does not exist", taskRunID)
+			exitFunc(1)
 		}
-
 	}
 
 	outputs, err := pgClient.Outputs(ctx, taskRunID)

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/simplesurance/baur/v1/internal/format"
 	"github.com/simplesurance/baur/v1/internal/format/csv"
 	"github.com/simplesurance/baur/v1/internal/format/table"
-	"github.com/simplesurance/baur/v1/internal/log"
 	"github.com/simplesurance/baur/v1/storage"
 )
 
@@ -145,10 +144,11 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 
 	if err != nil {
 		if err == storage.ErrNotExist {
-			log.Fatalf("no matching task runs exist")
+			stderr.Printf("no matching task runs exist")
+			exitFunc(1)
 		}
-
-		exitOnErr(err)
+		stderr.Println(err)
+		exitFunc(1)
 	}
 
 	exitOnErr(formatter.Flush())

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -47,13 +47,10 @@ func initSb(_ *cobra.Command, _ []string) {
 
 	if cpuProfilingFlag {
 		cpuProfFile, err := os.Create(defCPUProfFile)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		exitOnErr(err)
 
-		if err := pprof.StartCPUProfile(cpuProfFile); err != nil {
-			log.Fatalln(err)
-		}
+		err = pprof.StartCPUProfile(cpuProfFile)
+		exitOnErr(err)
 	}
 }
 
@@ -69,9 +66,8 @@ func Execute() {
 		fmt.Sprintf("enable cpu profiling, result is written to %q", defCPUProfFile))
 	rootCmd.PersistentFlags().BoolVar(&noColorFlag, "no-color", false, "disable color output")
 
-	if err := rootCmd.Execute(); err != nil {
-		log.Fatalln(err)
-	}
+	err := rootCmd.Execute()
+	exitOnErr(err)
 
 	if cpuProfilingFlag {
 		stdout.Printf("\ncpu profile written to %q\n", defCPUProfFile)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -221,7 +221,7 @@ func (c *runCmd) runUploadStore(taskToRun []*pendingTask) {
 		if runResult.Result.ExitCode != 0 {
 			statusStr := term.RedHighlight("failed")
 
-			log.Fatalf("%s: execution %s (%s), command exited with code %d, output:\n%s\n",
+			stderr.Printf("%s: execution %s (%s), command exited with code %d, output:\n%s\n",
 				t.task,
 				statusStr,
 				term.FormatDuration(
@@ -229,6 +229,7 @@ func (c *runCmd) runUploadStore(taskToRun []*pendingTask) {
 				),
 				runResult.ExitCode,
 				runResult.StrOutput())
+			exitFunc(1)
 		}
 
 		statusStr := term.GreenHighlight("successful")

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -13,7 +13,6 @@ import (
 	"github.com/simplesurance/baur/v1/internal/format"
 	"github.com/simplesurance/baur/v1/internal/format/table"
 	"github.com/simplesurance/baur/v1/internal/fs"
-	"github.com/simplesurance/baur/v1/internal/log"
 	"github.com/simplesurance/baur/v1/storage"
 )
 
@@ -267,10 +266,12 @@ func (*showCmd) showBuild(taskRunID int) {
 	taskRun, err := storageClt.TaskRun(ctx, taskRunID)
 	if err != nil {
 		if err == storage.ErrNotExist {
-			log.Fatalf("task run with id %d does not exist\n", taskRunID)
+			stderr.Printf("task run with id %d does not exist\n", taskRunID)
+			exitFunc(1)
 		}
 
-		exitOnErr(err)
+		stderr.Println(err)
+		exitFunc(1)
 	}
 
 	outputs, err := storageClt.Outputs(ctx, taskRun.ID)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -84,20 +84,6 @@ func (l *Logger) Fatalf(format string, v ...interface{}) {
 	l.getOutput().Fatalf(errorPrefix+format, v...)
 }
 
-// Errorln logs a message to stderr
-func (l *Logger) Errorln(v ...interface{}) {
-	if len(v) != 0 {
-		v[0] = fmt.Sprintf("%s %s", errorPrefix, v[0])
-	}
-
-	l.getOutput().Println(v...)
-}
-
-// Errorf logs a message to stderr
-func (l *Logger) Errorf(format string, v ...interface{}) {
-	l.getOutput().Printf(errorPrefix+" "+format, v...)
-}
-
 func (l *Logger) getOutput() Output {
 	l.outputLock.Lock()
 	defer l.outputLock.Unlock()
@@ -138,14 +124,4 @@ func Fatalln(v ...interface{}) {
 // Fatalf logs a message to stderr and terminates the application with an error
 func Fatalf(format string, v ...interface{}) {
 	StdLogger.Fatalf(format, v...)
-}
-
-// Errorln logs a message to stderr
-func Errorln(v ...interface{}) {
-	StdLogger.Errorln(v...)
-}
-
-// Errorf logs a message to stderr
-func Errorf(format string, v ...interface{}) {
-	StdLogger.Errorf(format, v...)
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,15 +1,10 @@
 package log
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"sync"
-
-	"github.com/fatih/color"
 )
-
-var errorPrefix = color.New(color.FgRed).Sprint("ERROR: ")
 
 // Logger logs messages
 type Logger struct {
@@ -24,8 +19,6 @@ type Logger struct {
 type Output interface {
 	Printf(format string, v ...interface{})
 	Println(v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Fatalln(v ...interface{})
 }
 
 // StdLogger is the logger that is used from the log functions in this package
@@ -70,20 +63,6 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 	l.getOutput().Printf(format, v...)
 }
 
-// Fatalln logs a message to stderr and terminates the application with an error
-func (l *Logger) Fatalln(v ...interface{}) {
-	if len(v) != 0 {
-		v[0] = fmt.Sprintf("%s%s", errorPrefix, v[0])
-	}
-
-	l.getOutput().Fatalln(v...)
-}
-
-// Fatalf logs a message to stderr and terminates the application with an error
-func (l *Logger) Fatalf(format string, v ...interface{}) {
-	l.getOutput().Fatalf(errorPrefix+format, v...)
-}
-
 func (l *Logger) getOutput() Output {
 	l.outputLock.Lock()
 	defer l.outputLock.Unlock()
@@ -114,14 +93,4 @@ func Debugln(v ...interface{}) {
 // It's only shown if debugging is enabled.
 func Debugf(format string, v ...interface{}) {
 	StdLogger.Debugf(format, v...)
-}
-
-// Fatalln logs a message to stderr and terminates the application with an error
-func Fatalln(v ...interface{}) {
-	StdLogger.Fatalln(v...)
-}
-
-// Fatalf logs a message to stderr and terminates the application with an error
-func Fatalf(format string, v ...interface{}) {
-	StdLogger.Fatalf(format, v...)
 }

--- a/internal/log/testlogwrapper.go
+++ b/internal/log/testlogwrapper.go
@@ -19,11 +19,3 @@ func (l *TestLogOutput) Printf(format string, v ...interface{}) {
 func (l *TestLogOutput) Println(v ...interface{}) {
 	l.t.Log(v...)
 }
-
-func (l *TestLogOutput) Fatalf(format string, v ...interface{}) {
-	l.t.Fatalf(format, v...)
-}
-
-func (l *TestLogOutput) Fatalln(v ...interface{}) {
-	l.t.Fatal(v...)
-}


### PR DESCRIPTION
```
        test: remove unnecessary overwrite of exitfunc

        exitFunc() is already set by initTest() and is sufficient for the need of the
        testcase

-------------------------------------------------------------------------------
        log: remove Fatal functions

        remove the Fatalln and Fatalf functions from the logger.

        Fatal errors should always result in a message to the users which should be
        printed via the stderr stream.
        The Fatal log functions were also not terminating the program via the exitFunc()
        which caused different behaviors when they were run in testcases.

-------------------------------------------------------------------------------
        command: always use stdout/stderr streams

        Use the stdout and stderr streams printing output from commands instead of
        directly printing to stdout/stderr.

        This ensures the output can be redirected by changing the stream, e.g. in
        testcases.

-------------------------------------------------------------------------------
        log: remove unused Errorln/Errorf methods

        The logger is currently only used to log additional debug messages when
        "--verbose" is passed to baur commands.

        Output that is part of the user interface is logged via the stdout/stderr
        streams.

        Errorln and Errorf were not used and are not needed in the current approach
```