### PR TITLE
 loader: fix paths containing dots not correctly interpreted

### DIFF
--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -1,0 +1,102 @@
+// +build dbtest
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1/internal/testutils/repotest"
+)
+
+func TestStatusArgs(t *testing.T) {
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	app := r.CreateSimpleApp(t)
+	taskSpec := fmt.Sprintf("%s.%s", app.Name, app.Tasks[0].Name)
+	runInitDb(t)
+	statusCmd := newStatusCmd()
+
+	type testcase struct {
+		name       string
+		taskRunArg string
+	}
+
+	testcases := []*testcase{
+		{
+			name:       "appName",
+			taskRunArg: app.Name,
+		},
+		{
+			name:       "wildcard",
+			taskRunArg: "*",
+		},
+		{
+			name:       "taskSpec",
+			taskRunArg: fmt.Sprintf("%s.%s", app.Name, app.Tasks[0].Name),
+		},
+		{
+			name:       "taskSpecTaskWildcard",
+			taskRunArg: fmt.Sprintf("%s.%s", app.Name, "*"),
+		},
+		{
+			name:       "taskSpecAppWildcard",
+			taskRunArg: fmt.Sprintf("%s.%s", "*", app.Tasks[0].Name),
+		},
+		{
+			name:       "absPath",
+			taskRunArg: filepath.Dir(app.FilePath()),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			initTest(t)
+			stdoutBuf, _ := interceptCmdOutput(t)
+
+			statusCmd.Command.Run(&statusCmd.Command, []string{tc.taskRunArg})
+			assert.Contains(t, stdoutBuf.String(), taskSpec)
+		})
+	}
+
+	t.Run("relPath", func(t *testing.T) {
+		initTest(t)
+		stdoutBuf, _ := interceptCmdOutput(t)
+
+		appDir := filepath.Dir(app.FilePath())
+		appRelPath, err := filepath.Rel(r.Dir, appDir)
+		require.NoError(t, err)
+
+		statusCmd.Command.Run(&statusCmd.Command, []string{appRelPath})
+		assert.Contains(t, stdoutBuf.String(), taskSpec)
+	})
+
+	t.Run("currentDirPath", func(t *testing.T) {
+		initTest(t)
+		stdoutBuf, _ := interceptCmdOutput(t)
+
+		appDir := filepath.Dir(app.FilePath())
+		require.NoError(t, os.Chdir(appDir))
+		statusCmd.Command.Run(&statusCmd.Command, []string{"."})
+		assert.Contains(t, stdoutBuf.String(), taskSpec)
+	})
+
+	t.Run("parentDirPath", func(t *testing.T) {
+		initTest(t)
+		stdoutBuf, _ := interceptCmdOutput(t)
+
+		appDir := filepath.Dir(app.FilePath())
+		childDir := filepath.Join(appDir, uuid.New().String())
+
+		require.NoError(t, os.Mkdir(childDir, 0700))
+		require.NoError(t, os.Chdir(childDir))
+
+		statusCmd.Command.Run(&statusCmd.Command, []string{".."})
+		assert.Contains(t, stdoutBuf.String(), taskSpec)
+	})
+}

--- a/loader_specifiers.go
+++ b/loader_specifiers.go
@@ -1,0 +1,78 @@
+package baur
+
+import (
+	"fmt"
+	"strings"
+)
+
+type taskSpec struct {
+	appName  string
+	taskName string
+}
+
+func (t *taskSpec) String() string {
+	return fmt.Sprintf("%s.%s", t.appName, t.taskName)
+}
+
+type specs struct {
+	all       bool
+	appDirs   []string
+	appNames  []string
+	taskSpecs []*taskSpec
+}
+
+// parseSpecs parses the task and app specifiers and returns a new *specs object.
+// The following specifiers are supported:
+// - '*' to match all apps and tasks,
+// - <APP-DIR-PATH> path to an application directory containing an .app.toml file,
+// <APP-SPEC>[.<TASK-SPEC>] where:
+//     <APP-SPEC> is:
+//       - <APP-NAME> or
+//       - '*'
+//     <TASK-SPEC> is:
+//       - Task Name or
+//       - '*'
+func parseSpecs(specifiers []string) (*specs, error) {
+	var result specs
+
+	for _, spec := range specifiers {
+		if spec == "*" {
+			result.all = true
+			return &result, nil
+		}
+
+		if isAppDirectory(spec) {
+			result.appDirs = append(result.appDirs, spec)
+			continue
+		}
+
+		if !strings.Contains(spec, ".") {
+			result.appNames = append(result.appNames, spec)
+			continue
+		}
+
+		spl := strings.Split(spec, ".")
+		switch len(spl) {
+		case 0:
+			// impossible condition
+			panic(fmt.Sprintf("strings.Split(%q, \".\") returned empty slice", spec))
+		case 1:
+			result.appNames = append(result.appNames, spl[0])
+		case 2:
+			appName := spl[0]
+			taskName := spl[1]
+
+			if taskName == "*" {
+				result.appNames = append(result.appNames, appName)
+				continue
+			}
+
+			result.taskSpecs = append(result.taskSpecs, &taskSpec{appName: appName, taskName: taskName})
+
+		default:
+			return nil, fmt.Errorf("invalid specifier: %q is not a path to an existing directory and contains > 1 dots ", spec)
+		}
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
```
        loader: fix paths containing dots not correctly interpreted

        If an app or tasks were loaded by specifying a path and the path contained dots,
        e.g. "../", the loader failed with the error that the specifier contained too
        many dots.

        This is fixed by first checking if a specifier is the path of an existing
        directory that contains an .app.toml file, before interpreting it as app-name.

        The loader was refactored to share more code between LoadTasks() and LoadApps().
        Parsing the  specifiers is moved to an own function (parseSpecs()).

-------------------------------------------------------------------------------
        status: add testcases for handling arguments

        Add testcases that ensure arguments are parsed and interpreted as expected by
        "baur status".

        These testcases mainly test the Loader functionality
```

Closes #157 