### PR TITLE
baur status: fix: no output when "-s" and "-f" flags are passed together

### DIFF
--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -188,6 +188,10 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 }
 
 func (c *statusCmd) storageQueryIsNeeded() bool {
+	if c.buildStatus.IsSet() {
+		return true
+	}
+
 	for _, f := range c.fields.Fields {
 		switch f {
 		case statusStatusParam:

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -1,0 +1,26 @@
+// +build dbtest
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1/internal/testutils/repotest"
+)
+
+func TestStatusCombininingFieldAndStatusParameters(t *testing.T) {
+	initTest(t)
+
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	app := r.CreateSimpleApp(t)
+
+	runInitDb(t)
+	stdoutBuf, _ := interceptCmdOutput(t)
+	statusCmd := newStatusCmd()
+	statusCmd.SetArgs([]string{"-f", "task-id", "-s", "pending"})
+	statusCmd.Execute()
+
+	require.Contains(t, stdoutBuf.String(), app.Name)
+}


### PR DESCRIPTION
When then --fields and --status parameters were passed together to "baur status", the command
printed no output.
The storage was not queried for the task,  therefore no task matched the specified status
and nothing was printed.

Ensure the storage is queried when --status is passed.

Closes #80 