### PR TITLE
baur ls apps: fix: no output when "-s" and "-f" flags are passed together (v0 backport)

### DIFF
--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -165,6 +165,10 @@ func ls(cmd *cobra.Command, args []string) {
 }
 
 func storageQueryIsNeeded() bool {
+	if lsAppsConfig.buildStatus.IsSet() {
+		return true
+	}
+
 	for _, f := range lsAppsConfig.fields.Fields {
 		switch f {
 		case lsAppBuildStatusParam:


### PR DESCRIPTION
When then --fields and --status parameters were passed together to "baur ls
apps", the command printed no output.
The storage was not queried for the task therefore no task matched the specified
status and nothing was printed.

Ensure the storage is queried when --status is passed.


This is a backport of https://github.com/simplesurance/baur/pull/222 for version 0.x