### PR TITLE
docker: improve credential handling, remove support for specifying docker credentials via env var

### DIFF
--- a/internal/command/build.go
+++ b/internal/command/build.go
@@ -26,9 +26,6 @@ import (
 )
 
 const (
-	dockerEnvUsernameVar = "BAUR_DOCKER_USERNAME"
-	dockerEnvPasswordVar = "BAUR_DOCKER_PASSWORD"
-
 	appColSep = " => "
 	sepLen    = len(appColSep)
 )
@@ -51,8 +48,6 @@ The following Environment Variables are supported:
     %s
     %s
     %s
-    %s
-    %s
 `,
 	coloredBuildStatus(baur.BuildStatusPending),
 	coloredBuildStatus(baur.BuildStatusInputsUndefined),
@@ -63,8 +58,6 @@ The following Environment Variables are supported:
 	highlight("AWS_ACCESS_KEY_ID"),
 	highlight("AWS_SECRET_ACCESS_KEY"),
 
-	highlight(dockerEnvUsernameVar),
-	highlight(dockerEnvPasswordVar),
 	highlight("DOCKER_HOST"),
 	highlight("DOCKER_API_VERSION"),
 	highlight("DOCKER_CERT_PATH"),
@@ -212,10 +205,6 @@ func outputCount(apps []*baur.App) int {
 	return cnt
 }
 
-func dockerAuthFromEnv() (string, string) {
-	return os.Getenv(dockerEnvUsernameVar), os.Getenv(dockerEnvPasswordVar)
-}
-
 func calcDigests(app *baur.App) ([]*storage.Input, string) {
 	var totalDigest string
 	var storageInputs []*storage.Input
@@ -287,15 +276,7 @@ func startBGUploader(outputCnt int, uploadChan chan *scheduler.Result) scheduler
 		log.Fatalln(err.Error())
 	}
 
-	dockerUser, dockerPass := dockerAuthFromEnv()
-	if len(dockerUser) != 0 {
-		log.Debugf("using docker authentication data from %s, %s Environment variables, authenticating as '%s'",
-			dockerEnvUsernameVar, dockerEnvPasswordVar, dockerUser)
-		dockerUploader, err = docker.NewClientwAuth(log.StdLogger.Debugf, dockerUser, dockerPass)
-	} else {
-		log.Debugf("environment variable %s not set", dockerEnvUsernameVar)
-		dockerUploader, err = docker.NewClient(log.StdLogger.Debugf)
-	}
+	dockerUploader, err = docker.NewClient(log.StdLogger.Debugf)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/upload/docker/docker.go
+++ b/upload/docker/docker.go
@@ -19,40 +19,10 @@ const dockerRegistryDefaultPort = "5000"
 type Client struct {
 	clt        *docker.Client
 	auths      *docker.AuthConfigurations
-	auth       *docker.AuthConfiguration
 	debugLogFn func(string, ...interface{})
 }
 
 var defLogFn = func(string, ...interface{}) {}
-
-// NewClientwAuth intializes a new docker client.
-// The username and password is used to authenticate at the registry for an
-// Upload() = docker push) operation.
-// The following environment variables are respected:
-// Use DOCKER_HOST to set the url to the docker server.
-// Use DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.
-// Use DOCKER_CERT_PATH to load the TLS certificates from.
-// Use DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.
-func NewClientwAuth(debugLogFn func(string, ...interface{}), username, password string) (*Client, error) {
-	logFn := defLogFn
-	if debugLogFn != nil {
-		logFn = debugLogFn
-	}
-
-	dockerClt, err := docker.NewClientFromEnv()
-	if err != nil {
-		return nil, err
-	}
-
-	return &Client{
-		clt: dockerClt,
-		auth: &docker.AuthConfiguration{
-			Username: username,
-			Password: password,
-		},
-		debugLogFn: logFn,
-	}, nil
-}
 
 // NewClient initializes a new docker client.
 // It supports the same environment variables then NewClientwAuth().
@@ -95,17 +65,12 @@ func hostPort(host, port string) string {
 
 // getAuth returns authentication date for the given server, server can be a
 // hostname or URL.
-// getAuth returns c.auth if it's not nil otherwise:
 // if server is empty, the function panics.
-// If server is not empty, authentication data is returned for a registry with a matching address.
-// if the client has no authentication data or no authentication data for the
-// server exist, an AuthConfiguration is returned with only the
-// ServerAddress set to server.
+// if the client has no authentication data (c.auths is empty), an empty
+// AuthConfiguration is returned.
+// If server is not empty, authentication data is returned for a registry with
+// a matching address.
 func (c *Client) getAuth(server string) docker.AuthConfiguration {
-	if c.auth != nil {
-		return *c.auth
-	}
-
 	if c.auths == nil || len(c.auths.Configs) == 0 {
 		return docker.AuthConfiguration{}
 	}

--- a/upload/docker/docker.go
+++ b/upload/docker/docker.go
@@ -3,7 +3,9 @@ package docker
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
+	"net/url"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
@@ -11,6 +13,7 @@ import (
 
 // DefaultRegistry is the registry for that authentication data is used
 const DefaultRegistry = "https://index.docker.io/v1/"
+const dockerRegistryDefaultPort = "5000"
 
 // Client is a docker client
 type Client struct {
@@ -86,10 +89,18 @@ func NewClient(debugLogFn func(string, ...interface{})) (*Client, error) {
 	}, nil
 }
 
+func hostPort(host, port string) string {
+	return fmt.Sprintf("%s:%s", host, port)
+}
+
+// getAuth returns authentication date for the given server, server can be a
+// hostname or URL.
 // getAuth returns c.auth if it's not nil otherwise:
-// if the client has no authentication data (c.auths is empty), an empty AuthConfiguration is returned.
-// If server is not empty, the authentication data for the server is returned if it exist.
-// If server is an empty string, the authentication data for DefaultRegistry is returned if it exists.
+// if server is empty, the function panics.
+// If server is not empty, authentication data is returned for a registry with a matching address.
+// if the client has no authentication data or no authentication data for the
+// server exist, an AuthConfiguration is returned with only the
+// ServerAddress set to server.
 func (c *Client) getAuth(server string) docker.AuthConfiguration {
 	if c.auth != nil {
 		return *c.auth
@@ -99,35 +110,51 @@ func (c *Client) getAuth(server string) docker.AuthConfiguration {
 		return docker.AuthConfiguration{}
 	}
 
-	if len(server) != 0 {
-		for registry, v := range c.auths.Configs {
-			if registry == server {
-				c.debugLogFn("docker: using auth data for registry '%s'", registry)
-				return v
+	if server == "" {
+		panic("server is empty")
+	}
+
+	if len(server) == 0 {
+		for registry, auth := range c.auths.Configs {
+			if registry == DefaultRegistry {
+				c.debugLogFn("docker: no registry specified, using auth data for default registry %q", registry)
+				return auth
+			}
+		}
+	}
+
+	for _, cfg := range c.auths.Configs {
+		c.debugLogFn("docker: found credentials for registry %q, searching %q credentials", cfg.ServerAddress, server)
+
+		if cfg.ServerAddress == server {
+			c.debugLogFn("docker: using auth data for registry '%s'", cfg.ServerAddress)
+			return cfg
+		}
+
+		url, err := url.Parse(cfg.ServerAddress)
+		if err != nil || url.Hostname() == "" {
+			continue
+		}
+
+		if url.Port() == "" {
+			if url.Hostname() == server || hostPort(url.Hostname(), dockerRegistryDefaultPort) == server {
+				c.debugLogFn("docker: using auth data for registry '%s'", cfg.ServerAddress)
+				return cfg
 			}
 
-			c.debugLogFn("docker: found credentials for registry %q, searching %q credentials", registry, server)
+			continue
+		}
+
+		registryHostPort := hostPort(url.Hostname(), url.Port())
+		if registryHostPort == server || registryHostPort == hostPort(server, dockerRegistryDefaultPort) {
+			c.debugLogFn("docker: using auth data for registry '%s'", cfg.ServerAddress)
+			return cfg
 		}
 	}
 
-	// try to find an entry for DefaultRegistry
-	for registry, auth := range c.auths.Configs {
-		if registry == DefaultRegistry {
-			c.debugLogFn("docker: using auth data for default registry '%s'", registry)
-			return auth
-		}
-	}
+	c.debugLogFn("docker: no auth configuration for registry %q found", server)
 
-	// otherwise use the first entry in the map
-	for registry, auth := range c.auths.Configs {
-		c.debugLogFn("docker: using auth data for registry '%s'", registry)
-
-		return auth
-	}
-
-	// this can't happen, auths must have been non-empty and
-	// therefore we can return the first element
-	panic("docker: could not find any auth data in a config.json")
+	return docker.AuthConfiguration{ServerAddress: server}
 }
 
 // Upload tags and uploads an image into a docker registry repository
@@ -137,12 +164,11 @@ func (c *Client) Upload(image, registryAddr, repository, tag string) (string, er
 	var destURI string
 
 	if registryAddr == "" {
-		addrRepo = repository
-		destURI = repository + ":" + tag
-	} else {
-		addrRepo = registryAddr + "/" + repository
-		destURI = registryAddr + "/" + repository + ":" + tag
+		registryAddr = DefaultRegistry
 	}
+
+	addrRepo = registryAddr + "/" + repository
+	destURI = registryAddr + "/" + repository + ":" + tag
 
 	c.debugLogFn("docker: creating tag, repo: %q, tag: %q referring to image %q", addrRepo, tag, image)
 	err := c.clt.TagImage(image, docker.TagImageOptions{


### PR DESCRIPTION
```
        build: remove support for BAUR_DOCKER_USERNAME, BAUR_DOCKER_PASSWORD env vars

        Remove support for specifying docker registry username and password per
        environment variable:

        - settings credentials via environment variables can be insecure,
          the docker configuration (docker login) offers a standardized and secure way
          to specify credentials
        - the implementation was not secure, it was only possible to specify a user and
          password but not the url of the registry for which the credentials were used,
          the user+password were tried to be used for every push that baur did to
          every registry

-------------------------------------------------------------------------------
        docker: improve choosing credentials for registry, support URLs

        "docker login" supports to specify registry per hostname and as URL.
        If the credentials used the URL, baur was not able to find the credentials when
        the push was done using only the hostname of the registry server.
        This is a common usecase for GCR auth per json_key.

        The authentication logic was also approved in the following ways:
        - registry URLs with ports are supported,
          If a registry was authenticated with the default port 5000), and no port is
          given for the registry url in the app config, the credentials for the
          registry with the default port is used
        - the credentials for the default registry (index.docker.io) are only used when
          the host of the specified registry matches or no registry is given in the app
          config
        - when no credentials were found for registry, none are used instead of the
          first found one, this was a security issue, credentials might have been send
          to a wrong server

```