### PR TITLE
inputs: add .app.toml and included cfg files to inputs of a task

### DIFF
--- a/cfg/include.go
+++ b/cfg/include.go
@@ -48,9 +48,25 @@ func IncludeFromFile(path string) (*Include, error) {
 		return nil, err
 	}
 
-	config.filePath = path
+	config.setFilepaths(path)
 
 	return &config, err
+}
+
+func (incl *Include) setFilepaths(path string) {
+	incl.filePath = path
+
+	for _, in := range incl.Input {
+		in.filepath = path
+	}
+
+	for _, out := range incl.Output {
+		out.filepath = path
+	}
+
+	for _, task := range incl.Task {
+		task.cfgFiles = map[string]struct{}{path: {}}
+	}
 }
 
 // ValidateUniqIncludeIDs validates that IDs of all Input, Output and Task

--- a/cfg/includedb.go
+++ b/cfg/includedb.go
@@ -175,6 +175,7 @@ func (db *IncludeDB) parseIncludeSpec(resolver resolver.Resolver, workingDir, in
 // Includes referenced in TaskIncludes a recursively loaded and included.
 func (db *IncludeDB) load(path string, resolver resolver.Resolver) error {
 	db.logf("includedb: loading %q", path)
+
 	include, err := IncludeFromFile(path)
 	if err != nil {
 		// the error includes the path to the file

--- a/cfg/inputinclude.go
+++ b/cfg/inputinclude.go
@@ -9,6 +9,8 @@ type InputInclude struct {
 	Files         []FileInputs    `comment:"Inputs specified by file glob paths"`
 	GitFiles      []GitFileInputs `comment:"Inputs specified by path, matching only Git tracked files"`
 	GolangSources []GolangSources `comment:"Inputs specified by directories containing Golang applications"`
+
+	filepath string
 }
 
 func (in *InputInclude) FileInputs() []FileInputs {
@@ -45,7 +47,9 @@ func (in *InputInclude) Validate() error {
 
 func (in *InputInclude) clone() *InputInclude {
 	var clone InputInclude
+
 	deepcopy.MustCopy(in, &clone)
+	clone.filepath = in.filepath
 
 	return &clone
 }

--- a/cfg/outputinclude.go
+++ b/cfg/outputinclude.go
@@ -12,6 +12,8 @@ type OutputInclude struct {
 
 	DockerImage []DockerImageOutput `comment:"Docker images that are produced by the [Task.command]"`
 	File        []FileOutput        `comment:"Files that are produces by the [Task.command]"`
+
+	filepath string
 }
 
 func (out *OutputInclude) DockerImageOutputs() []DockerImageOutput {
@@ -44,7 +46,9 @@ func (out *OutputInclude) Validate() error {
 
 func (out *OutputInclude) clone() *OutputInclude {
 	var clone OutputInclude
+
 	deepcopy.MustCopy(out, &clone)
+	clone.filepath = out.filepath
 
 	return &clone
 }

--- a/cfg/task.go
+++ b/cfg/task.go
@@ -11,6 +11,29 @@ type Task struct {
 	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory.\n Valid variables: $ROOT."`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
 	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`
+
+	// multiple include sections of the same file can be included, use a map
+	// instead of a slice to act as a Set datastructure
+	cfgFiles map[string]struct{}
+}
+
+func (t *Task) addCfgFilepath(path string) {
+	if path == "" {
+		panic("path is empty")
+	}
+	t.cfgFiles[path] = struct{}{}
+}
+
+// Filepaths returns a list of all parsed config files.
+// This is the app config file and files of the included sections.
+func (t *Task) Filepaths() []string {
+	result := make([]string, 0, len(t.cfgFiles))
+
+	for p := range t.cfgFiles {
+		result = append(result, p)
+	}
+
+	return result
 }
 
 func (t *Task) GetCommand() []string {

--- a/cfg/taskdef.go
+++ b/cfg/taskdef.go
@@ -13,6 +13,7 @@ type TaskDef interface {
 	GetInput() *Input
 	GetName() string
 	GetOutput() *Output
+	addCfgFilepath(path string)
 }
 
 // TaskMerge loads the includes of the task and merges them with the task itself.
@@ -22,6 +23,7 @@ func TaskMerge(task TaskDef, workingDir string, resolver resolver.Resolver, incl
 		if err == nil {
 			inputInclude = inputInclude.clone()
 			task.GetInput().Merge(inputInclude)
+			task.addCfgFilepath(inputInclude.filepath)
 
 			continue
 		}
@@ -44,6 +46,8 @@ func TaskMerge(task TaskDef, workingDir string, resolver resolver.Resolver, incl
 
 		outputInclude = outputInclude.clone()
 		task.GetOutput().Merge(outputInclude)
+
+		task.addCfgFilepath(outputInclude.filepath)
 	}
 
 	return nil

--- a/cfg/taskinclude.go
+++ b/cfg/taskinclude.go
@@ -13,6 +13,12 @@ type TaskInclude struct {
 	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the include file location.\n Valid variables: $ROOT"`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
 	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`
+
+	cfgFiles map[string]struct{}
+}
+
+func (t *TaskInclude) addCfgFilepath(path string) {
+	t.cfgFiles[path] = struct{}{}
 }
 
 func (t *TaskInclude) GetCommand() []string {
@@ -58,6 +64,11 @@ func (t *TaskInclude) toTask() *Task {
 	result.Name = t.Name
 	result.Command = make([]string, len(t.Command))
 	copy(result.Command, t.Command)
+
+	result.cfgFiles = make(map[string]struct{}, len(result.cfgFiles))
+	for k, v := range t.cfgFiles {
+		result.cfgFiles[k] = v
+	}
 
 	deepcopy.MustCopy(t.Input, &result.Input)
 	deepcopy.MustCopy(t.Output, &result.Output)

--- a/cfg/taskincludes.go
+++ b/cfg/taskincludes.go
@@ -20,7 +20,8 @@ func (tasks TaskIncludes) Validate() error {
 
 func (tasks TaskIncludes) Merge(workingDir string, resolver resolver.Resolver, db *IncludeDB) error {
 	for _, task := range tasks {
-		if err := TaskMerge(task, workingDir, resolver, db); err != nil {
+		err := TaskMerge(task, workingDir, resolver, db)
+		if err != nil {
 			if task.Name != "" {
 				err = FieldErrorWrap(err, task.Name)
 			}

--- a/inputresolver.go
+++ b/inputresolver.go
@@ -53,7 +53,7 @@ func (i *InputResolver) Resolve(ctx context.Context, repositoryDir string, task 
 
 	// Add the .app.toml file of the app to the inputs
 	// TODO: add the files that were included in the .app.toml and it's includes
-	allInputsPaths = append(allInputsPaths, filepath.Join(task.Directory, AppCfgFile))
+	allInputsPaths = append(allInputsPaths, task.CfgFilepaths...)
 
 	uniqInputs, err := i.pathsToUniqInputs(repositoryDir, allInputsPaths)
 	if err != nil {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -41,7 +41,7 @@ func mustFindRepository() *baur.Repository {
 				baur.RepositoryCfgFile)
 			exitFunc(1)
 		}
-		stderr.Println("locating baur repository failed")
+		stderr.Printf("locating baur repository failed: %s\n", err)
 		exitFunc(1)
 	}
 

--- a/task.go
+++ b/task.go
@@ -20,6 +20,7 @@ type Task struct {
 	Command          []string
 	UnresolvedInputs *cfg.Input
 	Outputs          *cfg.Output
+	CfgFilepaths     []string
 }
 
 // NewTask returns a new Task.
@@ -28,6 +29,7 @@ func NewTask(cfg *cfg.Task, appName, repositoryRootdir, workingDir string) *Task
 		RepositoryRoot:   repositoryRootdir,
 		Directory:        workingDir,
 		Outputs:          &cfg.Output,
+		CfgFilepaths:     cfg.Filepaths(),
 		Command:          cfg.Command,
 		Name:             cfg.Name,
 		AppName:          appName,


### PR DESCRIPTION
        inputs: add .app.toml and included cfg files to inputs of a task

        All config files that are parsed to load a Task are now automatically included
        as the inputs of the task. This includes the included files.
 

Closes #84 