### PR TITLE
ls inputs: support to list inputs of task runs

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -11,24 +11,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/baur/v1"
-	"github.com/simplesurance/baur/v1/internal/digest"
 	"github.com/simplesurance/baur/v1/internal/format"
 	"github.com/simplesurance/baur/v1/internal/format/csv"
 	"github.com/simplesurance/baur/v1/internal/format/table"
 	"github.com/simplesurance/baur/v1/storage"
 )
-
-type storageInput struct {
-	input *storage.Input
-}
-
-func (i *storageInput) Digest() (*digest.Digest, error) {
-	return digest.FromString(i.input.Digest)
-}
-
-func (i *storageInput) String() string {
-	return i.input.URI
-}
 
 type diffInputArgDetails struct {
 	arg      string
@@ -234,10 +221,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 	exitOnErr(err)
 
 	// Convert the inputs from the DB into baur.Input interface implementation
-	var baurInputs []baur.Input
-	for _, input := range storageInputs {
-		baurInputs = append(baurInputs, &storageInput{input})
-	}
+	baurInputs := toBaurInputs(storageInputs)
 
 	return baur.NewInputs(baur.InputAddStrIfNotEmpty(baurInputs, c.inputStr)), taskRun
 }

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -77,7 +77,9 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 
 func (c *lsInputsCmd) mustGetTaskRunInputs(taskRunID int) []baur.Input {
 	repo := mustFindRepository()
+
 	storageClt := mustNewCompatibleStorage(repo)
+	defer storageClt.Close()
 
 	inputs, err := storageClt.Inputs(ctx, taskRunID)
 	exitOnErr(err)

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -1,7 +1,9 @@
 package command
 
 import (
+	"os"
 	"sort"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -28,8 +30,8 @@ type lsInputsCmd struct {
 func newLsInputsCmd() *lsInputsCmd {
 	cmd := lsInputsCmd{
 		Command: cobra.Command{
-			Use:   "inputs <APP-NAME>.<TASK-NAME>]",
-			Short: "list resolved task inputs of an application",
+			Use:   "inputs (<APP-NAME>.<TASK-NAME>)|<TASK-RUN-ID>",
+			Short: "list inputs of a task or task run",
 			Args:  cobra.ExactArgs(1),
 		},
 	}
@@ -37,10 +39,10 @@ func newLsInputsCmd() *lsInputsCmd {
 	cmd.Run = cmd.run
 
 	cmd.Flags().BoolVar(&cmd.csv, "csv", false,
-		"Show output in RFC4180 CSV format")
+		"show output in RFC4180 CSV format")
 
 	cmd.Flags().BoolVarP(&cmd.quiet, "quiet", "q", false,
-		"Only show filepaths")
+		"only show filepaths")
 
 	cmd.Flags().BoolVar(&cmd.showDigest, "digests", false,
 		"show digests")
@@ -52,17 +54,52 @@ func newLsInputsCmd() *lsInputsCmd {
 }
 
 func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
+	var inputs []baur.Input
+
+	if taskID, err := strconv.Atoi(args[0]); err == nil {
+		if c.inputStr != "" {
+			stderr.Printf("--input-str can only be specified for task-names")
+			os.Exit(1)
+		}
+
+		inputs = c.mustGetTaskRunInputs(taskID)
+	} else {
+		inputs = c.mustGetTaskInputs(args[0])
+		inputs = baur.InputAddStrIfNotEmpty(inputs, c.inputStr)
+	}
+
+	sort.Slice(inputs, func(i, j int) bool {
+		return inputs[i].String() < inputs[j].String()
+	})
+
+	c.mustPrintTaskInputs(baur.NewInputs(inputs))
+}
+
+func (c *lsInputsCmd) mustGetTaskRunInputs(taskRunID int) []baur.Input {
+	repo := mustFindRepository()
+	storageClt := mustNewCompatibleStorage(repo)
+
+	inputs, err := storageClt.Inputs(ctx, taskRunID)
+	exitOnErr(err)
+
+	return toBaurInputs(inputs)
+}
+
+func (c *lsInputsCmd) mustGetTaskInputs(taskSpec string) []baur.Input {
+	repo := mustFindRepository()
+	task := mustArgToTask(repo, taskSpec)
+	inputResolver := baur.NewInputResolver()
+
+	inputs, err := inputResolver.Resolve(ctx, repo.Path, task)
+	exitOnErr(err)
+
+	return inputs
+}
+
+func (c *lsInputsCmd) mustPrintTaskInputs(inputs *baur.Inputs) {
 	var formatter format.Formatter
 	var headers []string
-
-	rep := mustFindRepository()
-	task := mustArgToTask(rep, args[0])
 	writeHeaders := !c.quiet && !c.csv
-
-	if !task.HasInputs() {
-		stderr.TaskPrintf(task, "has no inputs configured")
-		exitFunc(1)
-	}
 
 	if writeHeaders {
 		headers = []string{"Input"}
@@ -78,19 +115,7 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 		formatter = table.New(headers, stdout)
 	}
 
-	inputResolver := baur.NewInputResolver()
-
-	inputFiles, err := inputResolver.Resolve(ctx, rep.Path, task)
-	exitOnErr(err)
-
-	inputs := baur.NewInputs(baur.InputAddStrIfNotEmpty(inputFiles, c.inputStr))
-
-	inputsSlice := baur.NewInputs(baur.InputAddStrIfNotEmpty(inputFiles, c.inputStr)).Inputs()
-	sort.Slice(inputsSlice, func(i, j int) bool {
-		return inputsSlice[i].String() < inputsSlice[j].String()
-	})
-
-	for _, input := range inputsSlice {
+	for _, input := range inputs.Inputs() {
 		if !c.showDigest || c.quiet {
 			mustWriteRow(formatter, input)
 			continue
@@ -102,7 +127,7 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 		mustWriteRow(formatter, input, digest.String())
 	}
 
-	err = formatter.Flush()
+	err := formatter.Flush()
 	exitOnErr(err)
 
 	if c.showDigest && !c.quiet && !c.csv {

--- a/internal/command/ls_inputs_test.go
+++ b/internal/command/ls_inputs_test.go
@@ -1,0 +1,50 @@
+// +build dbtest
+
+package command
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1"
+	"github.com/simplesurance/baur/v1/internal/testutils/repotest"
+)
+
+func TestLsInputsTaskAndRunInputsAreTheSame(t *testing.T) {
+	initTest(t)
+
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	app := r.CreateAppWithNoOutputs(t, "myapp")
+	doInitDb(t)
+
+	taskSpec := fmt.Sprintf("%s.%s", app.Name, app.Tasks[0].Name)
+
+	stdout, _ := interceptCmdOutput(t)
+
+	lsInputsCmd := newLsInputsCmd()
+	lsInputsCmd.SetArgs([]string{"--csv", "--digests", taskSpec})
+	err := lsInputsCmd.Execute()
+	require.NoError(t, err)
+
+	lsTaskOutput := stdout.String()
+
+	runCmd := newRunCmd()
+	runCmd.run(&runCmd.Command, []string{taskSpec})
+
+	stdout.Reset()
+	lsInputsCmd.SetArgs([]string{"--csv", "--digests", "1"})
+	err = lsInputsCmd.Execute()
+	require.NoError(t, err)
+
+	appInputFile := fmt.Sprintf("%s/%s.txt", app.Name, app.Name)
+	appTomlFile := fmt.Sprintf("%s/%s", app.Name, baur.AppCfgFile)
+
+	lsTaskRunOutput := stdout.String()
+	assert.Contains(t, lsTaskRunOutput, appInputFile)
+	assert.Contains(t, lsTaskRunOutput, appTomlFile)
+
+	assert.Equal(t, lsTaskOutput, lsTaskRunOutput)
+}

--- a/internal/command/storageinputwrapper.go
+++ b/internal/command/storageinputwrapper.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"github.com/simplesurance/baur/v1"
+	"github.com/simplesurance/baur/v1/internal/digest"
+	"github.com/simplesurance/baur/v1/storage"
+)
+
+type storageInput struct {
+	input *storage.Input
+}
+
+func (i *storageInput) Digest() (*digest.Digest, error) {
+	return digest.FromString(i.input.Digest)
+}
+
+func (i *storageInput) String() string {
+	return i.input.URI
+}
+
+func toBaurInputs(inputs []*storage.Input) []baur.Input {
+	result := make([]baur.Input, 0, len(inputs))
+
+	for _, in := range inputs {
+		result = append(result, &storageInput{input: in})
+	}
+
+	return result
+}


### PR DESCRIPTION
"baur ls inputs" can now be passed a task run ID to list all inputs of a stored
task run.

- The storageInput struct from the diff_inputs.go is reused for the "ls inputs"
  implementation and moved to an own file.
- a simple testcase is added that runs "ls inputs" for a task, runs the task,
  runs "ls inputs" for the stored task run and compares the outputs

Closes #129 