### PR TITLE
Support input-str and lookup-input-str flags in diff inputs command

### DIFF
--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -207,6 +207,36 @@ func TestNonExistentRunReturnsExitCode1(t *testing.T) {
 	}
 }
 
+func TestNoPreviousRunWithInputStrReturnsExitCode1(t *testing.T) {
+	initTest(t)
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	r.CreateAppWithNoOutputs(t, appOneName)
+
+	doInitDb(t)
+
+	runCmd := newRunCmd()
+	runCmd.run(&runCmd.Command, []string{appOneWithBuildTask})
+
+	diffInputsCmd := newDiffInputsCmd()
+	diffInputsCmd.SetArgs([]string{appOneWithBuildTask, fmt.Sprintf("%s^", appOneWithBuildTask), "--input-str=foo"})
+	execCmd(t, diffInputsCmd, 1)
+}
+
+func TestNoPreviousRunWithInputStrOrLookupInputStrReturnsExitCode1(t *testing.T) {
+	initTest(t)
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	r.CreateAppWithNoOutputs(t, appOneName)
+
+	doInitDb(t)
+
+	runCmd := newRunCmd()
+	runCmd.run(&runCmd.Command, []string{appOneWithBuildTask})
+
+	diffInputsCmd := newDiffInputsCmd()
+	diffInputsCmd.SetArgs([]string{appOneWithBuildTask, fmt.Sprintf("%s^", appOneWithBuildTask), "--input-str=foo", "--lookup-input-str=bar"})
+	execCmd(t, diffInputsCmd, 1)
+}
+
 func TestCurrentInputsAgainstPreviousRunThatHasSameInputsReturnsExitCode0(t *testing.T) {
 	testcases := []struct {
 		testname    string
@@ -238,6 +268,42 @@ func TestCurrentInputsAgainstPreviousRunThatHasSameInputsReturnsExitCode0(t *tes
 			execCmd(t, diffInputsCmd, 0)
 		})
 	}
+}
+
+func TestCurrentInputsAgainstPreviousRunWithInputStrThatHasSameInputsReturnsExitCode0(t *testing.T) {
+	initTest(t)
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	r.CreateAppWithNoOutputs(t, appOneName)
+
+	doInitDb(t)
+
+	inputStr := "foo"
+
+	runCmd := newRunCmd()
+	runCmd.SetArgs([]string{appOneWithBuildTask, fmt.Sprintf("--input-str=%s", inputStr)})
+	runCmd.Execute()
+
+	diffInputsCmd := newDiffInputsCmd()
+	diffInputsCmd.SetArgs([]string{appOneWithBuildTask, fmt.Sprintf("%s^", appOneWithBuildTask), fmt.Sprintf("--input-str=%s", inputStr)})
+	execCmd(t, diffInputsCmd, 0)
+}
+
+func TestCurrentInputsAgainstPreviousRunWithLookupInputStrThatHasSameInputsReturnsExitCode0(t *testing.T) {
+	initTest(t)
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	r.CreateAppWithNoOutputs(t, appOneName)
+
+	doInitDb(t)
+
+	lookupInputStr := "bar"
+
+	runCmd := newRunCmd()
+	runCmd.SetArgs([]string{appOneWithBuildTask, fmt.Sprintf("--input-str=%s", lookupInputStr)})
+	runCmd.Execute()
+
+	diffInputsCmd := newDiffInputsCmd()
+	diffInputsCmd.SetArgs([]string{appOneWithBuildTask, fmt.Sprintf("%s^", appOneWithBuildTask), "--input-str=foo", fmt.Sprintf("--lookup-input-str=%s", lookupInputStr)})
+	execCmd(t, diffInputsCmd, 0)
 }
 
 func TestPreviousRunAgainstAnotherPreviousRunThatHasSameInputsReturnsExitCode0(t *testing.T) {

--- a/storage/filter.go
+++ b/storage/filter.go
@@ -17,6 +17,7 @@ const (
 	FieldDuration
 	FieldStartTime
 	FieldID
+	FieldDigest
 )
 
 func (f Field) String() string {
@@ -31,6 +32,8 @@ func (f Field) String() string {
 		return "FieldStartTime"
 	case FieldID:
 		return "FieldID"
+	case FieldDigest:
+		return "FieldDigest"
 	default:
 		return "FieldUndefined"
 	}

--- a/storage/postgres/filters_sorters.go
+++ b/storage/postgres/filters_sorters.go
@@ -25,6 +25,8 @@ func columnName(f storage.Field) (string, error) {
 		return "start_timestamp", nil
 	case storage.FieldID:
 		return "task_run_id", nil
+	case storage.FieldDigest:
+		return "digest", nil
 
 	default:
 		return "", fmt.Errorf("no postgresql mapping for storage field %s exists", f)

--- a/storage/postgres/query.go
+++ b/storage/postgres/query.go
@@ -207,7 +207,7 @@ func (c *Client) TaskRuns(
 	cb func(*storage.TaskRunWithID) error,
 ) error {
 	const queryStr = `
-	SELECT *
+	SELECT task_run_id, application_name, task_name, revision, dirty, total_digest, start_timestamp, stop_timestamp, result
 	  FROM (
 	       SELECT DISTINCT ON (task_run.id)
 		      task_run.id AS task_run_id,
@@ -228,6 +228,57 @@ func (c *Client) TaskRuns(
 	       ) tr
 	  `
 
+	return taskRuns(ctx, queryStr, c.db, filters, sorters, cb)
+}
+
+func (c *Client) TaskRunsWithInputDigest(
+	ctx context.Context,
+	filters []*storage.Filter,
+	sorters []*storage.Sorter,
+	digest string,
+	cb func(*storage.TaskRunWithID) error,
+) error {
+	const queryStr = `
+	SELECT task_run_id, application_name, task_name, revision, dirty, total_digest, start_timestamp, stop_timestamp, result
+	  FROM (
+	       SELECT DISTINCT ON (task_run.id, input.digest)
+		      task_run.id AS task_run_id,
+	              application.name AS application_name,
+	              task.name AS task_name,
+	              vcs.revision,
+	              vcs.dirty,
+	              task_run_input.total_digest,
+	              task_run.start_timestamp AS start_timestamp,
+	              task_run.stop_timestamp,
+		      task_run.result,
+		      input.digest AS digest,
+	              (EXTRACT(EPOCH FROM (task_run.stop_timestamp - task_run.start_timestamp))::bigint * 1000000000) AS duration
+	         FROM application
+	         JOIN task ON application.id = task.application_id
+	         JOIN task_run ON task.id = task_run.task_id
+		 JOIN task_run_input ON task_run_input.task_run_id = task_run.id
+		 JOIN input ON task_run_input.input_id = input.id
+	         LEFT OUTER JOIN vcs ON vcs.id = task_run.vcs_id
+	       ) tr
+	  `
+
+	filters = append(filters, &storage.Filter{
+		Field:    storage.FieldDigest,
+		Operator: storage.OpEQ,
+		Value:    digest,
+	})
+
+	return taskRuns(ctx, queryStr, c.db, filters, sorters, cb)
+}
+
+func taskRuns(
+	ctx context.Context,
+	queryStr string,
+	db dbConn,
+	filters []*storage.Filter,
+	sorters []*storage.Sorter,
+	cb func(*storage.TaskRunWithID) error,
+) error {
 	var queryReturnedRows bool
 
 	q := query{
@@ -241,7 +292,7 @@ func (c *Client) TaskRuns(
 		return fmt.Errorf("compiling query string failed: %w", err)
 	}
 
-	rows, err := c.db.Query(ctx, query, args...)
+	rows, err := db.Query(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("query %s with args: %s failed: %w", query, strArgList(args), err)
 	}
@@ -261,7 +312,6 @@ func (c *Client) TaskRuns(
 			&taskRun.StartTimestamp,
 			&taskRun.StopTimestamp,
 			&taskRun.Result,
-			nil, // skip scanning of duration value, it's only used for filtering and sorting
 		)
 
 		if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -102,6 +102,19 @@ type Storer interface {
 		callback func(*TaskRunWithID) error,
 	) error
 
+	// TaskRunsWithInputDigest queries the storage for runs that match the filters
+	// and contain an input with the given digest value.
+	// The found results are passed in iterative manner to the callback
+	// function. When the callback function returns an error, the iteration
+	// stops.
+	// When no matching records exist, the method returns ErrNotExist.
+	TaskRunsWithInputDigest(ctx context.Context,
+		filters []*Filter,
+		sorters []*Sorter,
+		digest string,
+		callback func(*TaskRunWithID) error,
+	) error
+
 	Inputs(ctx context.Context, taskRunID int) ([]*Input, error)
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
 }


### PR DESCRIPTION
This change set addresses https://github.com/simplesurance/baur/issues/232

I decided to add a new query to load task runs that contain an input with a given digest to find runs by their input-str instead of loading all task runs then iterating over them within baur. 

Example outputs from these changes:
A single run exists for baur_foo.build that contains an input-str of "master"
**run with given input-str does not exist**
![image](https://user-images.githubusercontent.com/20102859/101295548-29e9ee00-3883-11eb-9ad0-ff014f548164.png)
**run with given input-str and lookup-input-str does not exist**
![image](https://user-images.githubusercontent.com/20102859/101295559-3f5f1800-3883-11eb-8391-ad8b599c7679.png)
**run with given input-str does exist**
![image](https://user-images.githubusercontent.com/20102859/101295583-64538b00-3883-11eb-9f90-78c454cc0142.png)
**run with given input-str does not exist but given lookup-input-str does exist**
![image](https://user-images.githubusercontent.com/20102859/101295593-77665b00-3883-11eb-8f55-61b88f1d9107.png)

@fho



