### PR TITLE
commands: close db connections explicitly

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -230,6 +230,8 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 	taskRun := getTaskRun(repo, argDetails)
 
 	psql := mustNewCompatibleStorage(repo)
+	defer psql.Close()
+
 	storageInputs, err := psql.Inputs(ctx, taskRun.ID)
 	exitOnErr(err)
 
@@ -244,6 +246,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 
 func getTaskRun(repo *baur.Repository, argDetails *diffInputArgDetails) *storage.TaskRunWithID {
 	psql := mustNewCompatibleStorage(repo)
+	defer psql.Close()
 
 	if strings.Contains(argDetails.runID, "^") {
 		return getPreviousTaskRun(repo, psql, argDetails)

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -60,6 +60,7 @@ func initDb(cmd *cobra.Command, args []string) {
 
 	storageClt, err := newStorageClient(dbURL)
 	exitOnErr(err, "establishing connection failed")
+	defer storageClt.Close()
 
 	err = storageClt.Init(ctx)
 	exitOnErr(err)

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -48,6 +48,7 @@ func newLsOutputsCmd() *lsOutputsCmd {
 func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
 	repo := mustFindRepository()
 	pgClient := mustNewCompatibleStorage(repo)
+	defer pgClient.Close()
 
 	taskRunID, err := strconv.Atoi(args[0])
 	if err != nil {

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -113,6 +113,7 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 
 	repo := mustFindRepository()
 	psql := mustNewCompatibleStorage(repo)
+	defer psql.Close()
 
 	var formatter format.Formatter
 	if c.csv {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -113,6 +113,7 @@ func (c *runCmd) run(cmd *cobra.Command, args []string) {
 	c.repoRootPath = repo.Path
 
 	c.storage = mustNewCompatibleStorage(repo)
+	defer c.storage.Close()
 
 	c.uploadRoutinePool = routines.NewPool(1) // run 1 upload in parallel with builds
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -262,6 +262,7 @@ func vcsStr(v *storage.TaskRun) string {
 func (*showCmd) showBuild(taskRunID int) {
 	repo := mustFindRepository()
 	storageClt := mustNewCompatibleStorage(repo)
+	defer storageClt.Close()
 
 	taskRun, err := storageClt.TaskRun(ctx, taskRunID)
 	if err != nil {

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -133,6 +133,7 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 
 	if storageQueryNeeded {
 		storageClt = mustNewCompatibleStorage(repo)
+		defer storageClt.Close()
 	}
 
 	if writeHeaders {


### PR DESCRIPTION
The commands were never closing the database connections that they acquired.
This was not an issue because most commands were only acquiring 1 connections,
when baur terminated the tcp connection was closed from the OS.
Closing the pgx connection also do not return any errors that could indicate
that previous operations failed like for writes to files.

The command functions were also invoked in testcases though. It happened that a
test run kept open more db connections then the psql server allowed, operations
failed with "FATAL: sorry, too many clients already".

Close database connections properly to prevent issues like this.