### PR TITLE
diff inputs: fix parameter validation: only allows '^' after a '^'

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -109,7 +109,7 @@ func diffArgs() cobra.PositionalArgs {
 			return fmt.Errorf("%s and %s refer to the same task-run", args[0], args[1])
 		}
 
-		validArgRE := regexp.MustCompile(`^[\w-]+\.[\w-\^]+$|^[0-9]+\d*$`)
+		validArgRE := regexp.MustCompile(`^[\w-]+\.[\w-]+\^*$|^[0-9]+\d*$`)
 		for _, arg := range args {
 			if !validArgRE.MatchString(arg) {
 				return fmt.Errorf("invalid argument: %q", arg)


### PR DESCRIPTION
The "baur diff input" command was allowing to pass an arbitrary character after
a '^' in the parameters.
Every character after a '^' was interpreted as a '^' and had the same effect,
e.g: mail.build^^^ == mail.build^AbZ

Fix the syntax, only allow '^' to follow a '^' character in the parameters.