### PR TITLE
Add input-str and limit filtering to ls runs command

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -271,6 +271,7 @@ func getPreviousTaskRun(repo *baur.Repository, psql storage.Storer, argDetails *
 		ctx,
 		filters,
 		sorters,
+		storage.NoLimit,
 		func(record *storage.TaskRunWithID) error {
 			retrieved++
 			if retrieved == runPosition {
@@ -313,6 +314,7 @@ func getTaskRunByID(repo *baur.Repository, psql storage.Storer, id int) *storage
 		ctx,
 		filters,
 		sorters,
+		storage.NoLimit,
 		func(run *storage.TaskRunWithID) error {
 			taskRun = run
 			return nil

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -240,7 +240,7 @@ func (c *lsRunsCmd) getFilters() []*storage.Filter {
 
 	if c.inputURI != "" {
 		filters = append(filters, &storage.Filter{
-			Field:    storage.FieldURI,
+			Field:    storage.FieldInput,
 			Operator: storage.OpEQ,
 			Value:    c.inputURI,
 		})

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -32,8 +32,8 @@ baur ls runs --csv --after=2018.09.27-11:30 '*'	 list all task runs in csv forma
 baur ls runs --limit=1 calc			 list a single task run of the calc
 						 application
 baur ls runs --has-input=string:master calc	 list task runs of the calc
-						 application that contain an input
-						 of 'string:master'`
+						 application that have a
+						 'string:master' input`
 
 func init() {
 	lsCmd.AddCommand(&newLsRunsCmd().Command)
@@ -42,13 +42,13 @@ func init() {
 type lsRunsCmd struct {
 	cobra.Command
 
-	csv      bool
-	after    flag.DateTimeFlagValue
-	before   flag.DateTimeFlagValue
-	inputURI string
-	sort     *flag.Sort
-	limit    uint
-	quiet    bool
+	csv    bool
+	after  flag.DateTimeFlagValue
+	before flag.DateTimeFlagValue
+	input  string
+	sort   *flag.Sort
+	limit  uint
+	quiet  bool
 
 	app  string
 	task string
@@ -82,7 +82,7 @@ func newLsRunsCmd() *lsRunsCmd {
 		cmd.sort.Usage(term.Highlight))
 
 	cmd.Flags().UintVarP(&cmd.limit, "limit", "l", storage.NoLimit,
-		"Limit the number of runs shown, 0 will show all runs")
+		fmt.Sprintf("Limit the number of runs shown, %s shows all runs", term.Highlight("0")))
 
 	cmd.Flags().VarP(&cmd.after, "after", "a",
 		fmt.Sprintf("Only show runs that were started after this datetime.\nFormat: %s", term.Highlight(flag.DateTimeFormatDescr)))
@@ -90,10 +90,13 @@ func newLsRunsCmd() *lsRunsCmd {
 	cmd.Flags().VarP(&cmd.before, "before", "b",
 		fmt.Sprintf("Only show runs that were started before this datetime.\nFormat: %s", term.Highlight(flag.DateTimeFormatDescr)))
 
-	cmd.Flags().StringVar(&cmd.inputURI, "has-input", "",
-		`Only show runs that include this value as an input.
-File inputs should be specified by their path e.g. /path/to/myfile.txt
-String inputs should be specified with a 'string:' prefix e.g. string:my_input_str`)
+	cmd.Flags().StringVar(&cmd.input, "has-input", "",
+		fmt.Sprintf(
+			`Only show runs that have the given input.
+File inputs are specified their path.
+String inputs are specified with a '%s' prefix, e.g. string:my_input_str.`,
+			term.Highlight("string:")),
+	)
 
 	return &cmd
 }
@@ -238,11 +241,11 @@ func (c *lsRunsCmd) getFilters() []*storage.Filter {
 		})
 	}
 
-	if c.inputURI != "" {
+	if c.input != "" {
 		filters = append(filters, &storage.Filter{
 			Field:    storage.FieldInput,
 			Operator: storage.OpEQ,
-			Value:    c.inputURI,
+			Value:    c.input,
 		})
 	}
 

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -25,12 +25,12 @@ Arguments:
 `
 
 const lsRunsExample = `
-baur ls runs -s duration-desc calc               list task runs of the calc
+baur ls runs -s duration-desc calc		 list task runs of the calc
 						 application, sorted by
 						 run duration
-baur ls runs --csv --after=2018.09.27-11:30 '*'  list all task runs in csv format that
+baur ls runs --csv --after=2018.09.27-11:30 '*'	 list all task runs in csv format that
 						 were started after 2018.09.27 11:30
-baur ls runs --limit=1 calc                      list a single task run of the calc
+baur ls runs --limit=1 calc			 list a single task run of the calc
 						 application`
 
 func init() {

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -144,31 +144,16 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 
 	sorters = append(sorters, &defaultSorter)
 
-	var err error
-	if c.inputStr != "" {
-		err = psql.TaskRunsWithInputURI(
-			ctx,
-			filters,
-			sorters,
-			c.limit,
-			baur.NewInputString(c.inputStr).String(),
-			func(taskRun *storage.TaskRunWithID) error {
-				c.printTaskRun(formatter, taskRun)
-				return nil
-			},
-		)
-	} else {
-		err = psql.TaskRuns(
-			ctx,
-			filters,
-			sorters,
-			c.limit,
-			func(taskRun *storage.TaskRunWithID) error {
-				c.printTaskRun(formatter, taskRun)
-				return nil
-			},
-		)
-	}
+	err := psql.TaskRuns(
+		ctx,
+		filters,
+		sorters,
+		c.limit,
+		func(taskRun *storage.TaskRunWithID) error {
+			c.printTaskRun(formatter, taskRun)
+			return nil
+		},
+	)
 
 	if err != nil {
 		if err == storage.ErrNotExist {
@@ -246,6 +231,15 @@ func (c *lsRunsCmd) getFilters() []*storage.Filter {
 			Field:    storage.FieldStartTime,
 			Operator: storage.OpGT,
 			Value:    c.after.Time,
+		})
+	}
+
+	if c.inputStr != "" {
+		inputStrURI := baur.NewInputString(c.inputStr).String()
+		filters = append(filters, &storage.Filter{
+			Field:    storage.FieldURI,
+			Operator: storage.OpEQ,
+			Value:    inputStrURI,
 		})
 	}
 

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -29,7 +29,9 @@ baur ls runs -s duration-desc calc               list task runs of the calc
 						 application, sorted by
 						 run duration
 baur ls runs --csv --after=2018.09.27-11:30 '*'  list all task runs in csv format that
-						 were started after 2018.09.27 11:30`
+						 were started after 2018.09.27 11:30
+baur ls runs --limit=1 calc                      list a single task run of the calc
+						 application`
 
 func init() {
 	lsCmd.AddCommand(&newLsRunsCmd().Command)
@@ -43,6 +45,7 @@ type lsRunsCmd struct {
 	before   flag.DateTimeFlagValue
 	inputStr string
 	sort     *flag.Sort
+	limit    int
 	quiet    bool
 
 	app  string
@@ -75,6 +78,9 @@ func newLsRunsCmd() *lsRunsCmd {
 
 	cmd.Flags().VarP(cmd.sort, "sort", "s",
 		cmd.sort.Usage(term.Highlight))
+
+	cmd.Flags().IntVarP(&cmd.limit, "limit", "l", storage.NoLimit,
+		"Limit the number of runs shown, 0 will show all runs")
 
 	cmd.Flags().VarP(&cmd.after, "after", "a",
 		fmt.Sprintf("Only show runs that were started after this datetime.\nFormat: %s", term.Highlight(flag.DateTimeFormatDescr)))
@@ -144,6 +150,7 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 			ctx,
 			filters,
 			sorters,
+			c.limit,
 			baur.NewInputString(c.inputStr).String(),
 			func(taskRun *storage.TaskRunWithID) error {
 				c.printTaskRun(formatter, taskRun)
@@ -155,6 +162,7 @@ func (c *lsRunsCmd) run(cmd *cobra.Command, args []string) {
 			ctx,
 			filters,
 			sorters,
+			c.limit,
 			func(taskRun *storage.TaskRunWithID) error {
 				c.printTaskRun(formatter, taskRun)
 				return nil

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -45,7 +45,7 @@ type lsRunsCmd struct {
 	before   flag.DateTimeFlagValue
 	inputStr string
 	sort     *flag.Sort
-	limit    int
+	limit    uint
 	quiet    bool
 
 	app  string
@@ -79,7 +79,7 @@ func newLsRunsCmd() *lsRunsCmd {
 	cmd.Flags().VarP(cmd.sort, "sort", "s",
 		cmd.sort.Usage(term.Highlight))
 
-	cmd.Flags().IntVarP(&cmd.limit, "limit", "l", storage.NoLimit,
+	cmd.Flags().UintVarP(&cmd.limit, "limit", "l", storage.NoLimit,
 		"Limit the number of runs shown, 0 will show all runs")
 
 	cmd.Flags().VarP(&cmd.after, "after", "a",

--- a/storage/filter.go
+++ b/storage/filter.go
@@ -17,7 +17,7 @@ const (
 	FieldDuration
 	FieldStartTime
 	FieldID
-	FieldURI
+	FieldInput
 )
 
 func (f Field) String() string {
@@ -32,7 +32,7 @@ func (f Field) String() string {
 		return "FieldStartTime"
 	case FieldID:
 		return "FieldID"
-	case FieldURI:
+	case FieldInput:
 		return "FieldURI"
 	default:
 		return "FieldUndefined"

--- a/storage/filter.go
+++ b/storage/filter.go
@@ -17,6 +17,7 @@ const (
 	FieldDuration
 	FieldStartTime
 	FieldID
+	FieldURI
 )
 
 func (f Field) String() string {
@@ -31,6 +32,8 @@ func (f Field) String() string {
 		return "FieldStartTime"
 	case FieldID:
 		return "FieldID"
+	case FieldURI:
+		return "FieldURI"
 	default:
 		return "FieldUndefined"
 	}

--- a/storage/postgres/filters_sorters.go
+++ b/storage/postgres/filters_sorters.go
@@ -26,7 +26,7 @@ func columnName(f storage.Field) (string, error) {
 		return "start_timestamp", nil
 	case storage.FieldID:
 		return "task_run_id", nil
-	case storage.FieldURI:
+	case storage.FieldInput:
 		return "uri", nil
 
 	default:

--- a/storage/postgres/filters_sorters.go
+++ b/storage/postgres/filters_sorters.go
@@ -11,7 +11,7 @@ type query struct {
 	BaseQuery string
 	Filters   []*storage.Filter
 	Sorters   []*storage.Sorter
-	Limit     int
+	Limit     uint
 }
 
 func columnName(f storage.Field) (string, error) {

--- a/storage/postgres/filters_sorters.go
+++ b/storage/postgres/filters_sorters.go
@@ -11,6 +11,7 @@ type query struct {
 	BaseQuery string
 	Filters   []*storage.Filter
 	Sorters   []*storage.Sorter
+	Limit     int
 }
 
 func columnName(f storage.Field) (string, error) {
@@ -115,6 +116,14 @@ func (q *query) compileSorterStr() (string, error) {
 	return "ORDER BY " + sorterStr, nil
 }
 
+func (q *query) compileLimitStr() string {
+	if q.Limit == storage.NoLimit {
+		return ""
+	}
+
+	return fmt.Sprintf("LIMIT %d", q.Limit)
+}
+
 // Compile creates the SQL query string and returns it with the arguments for the query
 func (q *query) Compile() (query string, args []interface{}, err error) {
 	if len(q.Filters) == 0 && len(q.Sorters) == 0 {
@@ -131,5 +140,7 @@ func (q *query) Compile() (query string, args []interface{}, err error) {
 		return "", nil, err
 	}
 
-	return fmt.Sprintf("%s %s %s", q.BaseQuery, filterStr, orderStr), args, nil
+	limitStr := q.compileLimitStr()
+
+	return fmt.Sprintf("%s %s %s %s", q.BaseQuery, filterStr, orderStr, limitStr), args, nil
 }

--- a/storage/postgres/filters_sorters.go
+++ b/storage/postgres/filters_sorters.go
@@ -25,6 +25,8 @@ func columnName(f storage.Field) (string, error) {
 		return "start_timestamp", nil
 	case storage.FieldID:
 		return "task_run_id", nil
+	case storage.FieldURI:
+		return "uri", nil
 
 	default:
 		return "", fmt.Errorf("no postgresql mapping for storage field %s exists", f)

--- a/storage/postgres/query.go
+++ b/storage/postgres/query.go
@@ -21,7 +21,7 @@ func (c *Client) TaskRun(ctx context.Context, id int) (*storage.TaskRunWithID, e
 		},
 	}
 
-	err := c.TaskRuns(ctx, idFilter, nil, func(tr *storage.TaskRunWithID) error {
+	err := c.TaskRuns(ctx, idFilter, nil, storage.NoLimit, func(tr *storage.TaskRunWithID) error {
 		taskRun = tr
 
 		return nil
@@ -204,6 +204,7 @@ func (c *Client) TaskRuns(
 	ctx context.Context,
 	filters []*storage.Filter,
 	sorters []*storage.Sorter,
+	limit int,
 	cb func(*storage.TaskRunWithID) error,
 ) error {
 	const queryStr = `
@@ -228,13 +229,14 @@ func (c *Client) TaskRuns(
 	       ) tr
 	  `
 
-	return taskRuns(ctx, queryStr, c.db, filters, sorters, cb)
+	return taskRuns(ctx, queryStr, c.db, filters, sorters, limit, cb)
 }
 
 func (c *Client) TaskRunsWithInputURI(
 	ctx context.Context,
 	filters []*storage.Filter,
 	sorters []*storage.Sorter,
+	limit int,
 	digest string,
 	cb func(*storage.TaskRunWithID) error,
 ) error {
@@ -268,7 +270,7 @@ func (c *Client) TaskRunsWithInputURI(
 		Value:    digest,
 	})
 
-	return taskRuns(ctx, queryStr, c.db, filters, sorters, cb)
+	return taskRuns(ctx, queryStr, c.db, filters, sorters, limit, cb)
 }
 
 func taskRuns(
@@ -277,6 +279,7 @@ func taskRuns(
 	db dbConn,
 	filters []*storage.Filter,
 	sorters []*storage.Sorter,
+	limit int,
 	cb func(*storage.TaskRunWithID) error,
 ) error {
 	var queryReturnedRows bool
@@ -285,6 +288,7 @@ func taskRuns(
 		BaseQuery: queryStr,
 		Filters:   filters,
 		Sorters:   sorters,
+		Limit:     limit,
 	}
 
 	query, args, err := q.Compile()

--- a/storage/postgres/query.go
+++ b/storage/postgres/query.go
@@ -234,7 +234,7 @@ func (c *Client) TaskRuns(
 
 	containsURIFilter := false
 	for _, filter := range filters {
-		if filter.Field == storage.FieldURI {
+		if filter.Field == storage.FieldInput {
 			containsURIFilter = true
 			break
 		}

--- a/storage/postgres/query.go
+++ b/storage/postgres/query.go
@@ -205,7 +205,7 @@ func (c *Client) TaskRuns(
 	ctx context.Context,
 	filters []*storage.Filter,
 	sorters []*storage.Sorter,
-	limit int,
+	limit uint,
 	cb func(*storage.TaskRunWithID) error,
 ) error {
 	const queryTemplate = `

--- a/storage/postgres/query_test.go
+++ b/storage/postgres/query_test.go
@@ -524,7 +524,7 @@ func TestTaskRuns(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			var result []*storage.TaskRunWithID
 
-			err := client.TaskRuns(ctx, testcase.filters, testcase.sorters, func(tr *storage.TaskRunWithID) error {
+			err := client.TaskRuns(ctx, testcase.filters, testcase.sorters, storage.NoLimit, func(tr *storage.TaskRunWithID) error {
 				result = append(result, tr)
 				return nil
 			})

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -78,6 +78,10 @@ type TaskRunWithID struct {
 	TaskRun
 }
 
+const (
+	NoLimit int = 0
+)
+
 // Storer is an interface for storing and retrieving baur task runs
 type Storer interface {
 	Close() error
@@ -92,6 +96,7 @@ type Storer interface {
 
 	TaskRun(ctx context.Context, id int) (*TaskRunWithID, error)
 	// TaskRuns queries the storage for runs that match the filters.
+	// A limit value of 0 will return all results.
 	// The found results are passed in iterative manner to the callback
 	// function. When the callback function returns an error, the iteration
 	// stops.
@@ -99,11 +104,13 @@ type Storer interface {
 	TaskRuns(ctx context.Context,
 		filters []*Filter,
 		sorters []*Sorter,
+		limit int,
 		callback func(*TaskRunWithID) error,
 	) error
 
 	// TaskRunsWithInputURI queries the storage for runs that match the filters
 	// and contain an input with the given URI value.
+	// A limit value of 0 will return all results.
 	// The found results are passed in iterative manner to the callback
 	// function. When the callback function returns an error, the iteration
 	// stops.
@@ -111,6 +118,7 @@ type Storer interface {
 	TaskRunsWithInputURI(ctx context.Context,
 		filters []*Filter,
 		sorters []*Sorter,
+		limit int,
 		uri string,
 		callback func(*TaskRunWithID) error,
 	) error

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -102,6 +102,19 @@ type Storer interface {
 		callback func(*TaskRunWithID) error,
 	) error
 
+	// TaskRunsWithInputURI queries the storage for runs that match the filters
+	// and contain an input with the given URI value.
+	// The found results are passed in iterative manner to the callback
+	// function. When the callback function returns an error, the iteration
+	// stops.
+	// When no matching records exist, the method returns ErrNotExist.
+	TaskRunsWithInputURI(ctx context.Context,
+		filters []*Filter,
+		sorters []*Sorter,
+		uri string,
+		callback func(*TaskRunWithID) error,
+	) error
+
 	Inputs(ctx context.Context, taskRunID int) ([]*Input, error)
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -108,21 +108,6 @@ type Storer interface {
 		callback func(*TaskRunWithID) error,
 	) error
 
-	// TaskRunsWithInputURI queries the storage for runs that match the filters
-	// and contain an input with the given URI value.
-	// A limit value of 0 will return all results.
-	// The found results are passed in iterative manner to the callback
-	// function. When the callback function returns an error, the iteration
-	// stops.
-	// When no matching records exist, the method returns ErrNotExist.
-	TaskRunsWithInputURI(ctx context.Context,
-		filters []*Filter,
-		sorters []*Sorter,
-		limit int,
-		uri string,
-		callback func(*TaskRunWithID) error,
-	) error
-
 	Inputs(ctx context.Context, taskRunID int) ([]*Input, error)
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -79,7 +79,7 @@ type TaskRunWithID struct {
 }
 
 const (
-	NoLimit int = 0
+	NoLimit uint = 0
 )
 
 // Storer is an interface for storing and retrieving baur task runs
@@ -104,7 +104,7 @@ type Storer interface {
 	TaskRuns(ctx context.Context,
 		filters []*Filter,
 		sorters []*Sorter,
-		limit int,
+		limit uint,
 		callback func(*TaskRunWithID) error,
 	) error
 


### PR DESCRIPTION
These changes implement the suggestions made in the [Find most recent build with a specifc input-str](https://github.com/simplesurance/baur/discussions/235) discussion.
A couple of things to note:

- To be able to support filtering by an input URI value I needed to introduce a new query that included the `input.uri` field in the query's inner `SELECT DISTINCT ON` clause. Without adding the `input.uri` field only a single input would be returned by the inner SELECT statement and it may not have been the input we wanted to filter on. If the `input.uri` field was added to the existing query any queries that did not filter by input URI would return a row for each input which is not the desired behaviour. 
- I opted to add a `has-input-str` flag instead of the `has-input` flag mentioned in the discussion. The reason for this is that the user would have to have internal knowledge of baur to know that a "string:" prefix would be added to the input-str values when they are stored in the DB to be able to filter by input-str. The `has-input` flag could still be added later to be able to filter by input file paths but it is not required for the use case in the discussion.

@fho 