### PR TITLE
Fix tests on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,9 @@ jobs:
             $testResultDir = Resolve-Path $Env:TEST_RESULTS
             $testOutputPath = Join-Path $testResultDir "go-test.out"
             $testReportPath = Join-Path $testResultDir "go-test-report.xml"
-            try { go test --tags=dbtest -v -timeout 5m .\... | Tee-Object -FilePath $testOutputPath } `
+            try { go test --tags=dbtest -v -timeout 5m .\... | Tee-Object -FilePath $testOutputPath; $testExitCode = $LastExitCode } `
             finally { Get-Content -Path $testOutputPath | go-junit-report > $testReportPath; `
-            [System.Io.File]::ReadAllText($testReportPath) | Out-File -FilePath $testReportPath -Encoding utf8 }
+            [System.Io.File]::ReadAllText($testReportPath) | Out-File -FilePath $testReportPath -Encoding utf8; Exit $testExitCode }
 
       - store_test_results:
           path: ~\test-results


### PR DESCRIPTION
I noticed that some of the tests have been failing locally but passing on CircleCI. It turns out the `go test` command exit code was not being reported back to CircleCI correctly so the job was passing when it shouldn't have been.

I expect the checks for 5720734 to fail. I will then push up the fixes to the tests that are failing on Windows and the checks should then legitimately pass.

@fho