### PR TITLE
Fix tests failing on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,9 @@ jobs:
             $testResultDir = Resolve-Path $Env:TEST_RESULTS
             $testOutputPath = Join-Path $testResultDir "go-test.out"
             $testReportPath = Join-Path $testResultDir "go-test-report.xml"
-            try { go test --tags=dbtest -v -timeout 5m .\... | Tee-Object -FilePath $testOutputPath } `
+            try { go test --tags=dbtest -v -timeout 5m .\... | Tee-Object -FilePath $testOutputPath; $testExitCode = $LastExitCode } `
             finally { Get-Content -Path $testOutputPath | go-junit-report > $testReportPath; `
-            [System.Io.File]::ReadAllText($testReportPath) | Out-File -FilePath $testReportPath -Encoding utf8 }
+            [System.Io.File]::ReadAllText($testReportPath) | Out-File -FilePath $testReportPath -Encoding utf8; Exit $testExitCode }
 
       - store_test_results:
           path: ~\test-results

--- a/internal/command/ls_inputs_test.go
+++ b/internal/command/ls_inputs_test.go
@@ -4,6 +4,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,8 +40,8 @@ func TestLsInputsTaskAndRunInputsAreTheSame(t *testing.T) {
 	err = lsInputsCmd.Execute()
 	require.NoError(t, err)
 
-	appInputFile := fmt.Sprintf("%s/%s.txt", app.Name, app.Name)
-	appTomlFile := fmt.Sprintf("%s/%s", app.Name, baur.AppCfgFile)
+	appInputFile := fmt.Sprintf("%s%c%s.txt", app.Name, os.PathSeparator, app.Name)
+	appTomlFile := fmt.Sprintf("%s%c%s", app.Name, os.PathSeparator, baur.AppCfgFile)
 
 	lsTaskRunOutput := stdout.String()
 	assert.Contains(t, lsTaskRunOutput, appInputFile)

--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -130,6 +130,16 @@ func whitelistedEnv() []string {
 		env = append(env, "home="+home)
 	}
 
+	// windows: LocalAppData is used to determine default GOCACHE dir
+	if appData, exist := os.LookupEnv("LocalAppData"); exist {
+		env = append(env, "LocalAppData="+appData)
+	}
+
+	// windows: USERPROFILE is used to determine default GOPATH
+	if userprofile, exist := os.LookupEnv("USERPROFILE"); exist {
+		env = append(env, "USERPROFILE="+userprofile)
+	}
+
 	return env
 }
 

--- a/internal/resolve/gosource/gosource_test.go
+++ b/internal/resolve/gosource/gosource_test.go
@@ -3,7 +3,6 @@ package gosource
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,15 +14,6 @@ import (
 	"github.com/simplesurance/baur/v1/internal/prettyprint"
 	"github.com/simplesurance/baur/v1/internal/testutils/strtest"
 )
-
-func containsGoPath(envs []string) bool {
-	for _, env := range envs {
-		if strings.Contains(env, "GOPATH") {
-			return true
-		}
-	}
-	return false
-}
 
 func TestResolve(t *testing.T) {
 	const testCfgFilename = "test_config.json"
@@ -59,14 +49,6 @@ func TestResolve(t *testing.T) {
 
 			cwd, err := os.Getwd()
 			require.NoError(t, err)
-
-			if os.Getenv("GOCACHE") == "" {
-				os.Setenv("GOCACHE", t.TempDir())
-			}
-
-			if !containsGoPath(testCfg.Cfg.Environment) {
-				testCfg.Cfg.Environment = append(testCfg.Cfg.Environment, fmt.Sprintf("GOPATH=%s", os.Getenv("GOPATH")))
-			}
 
 			for i := range testCfg.Cfg.Environment {
 				testCfg.Cfg.Environment[i] = strings.Replace(testCfg.Cfg.Environment[i], "$WORKDIR", cwd, -1)

--- a/internal/resolve/gosource/gosource_test.go
+++ b/internal/resolve/gosource/gosource_test.go
@@ -3,6 +3,7 @@ package gosource
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,6 +15,15 @@ import (
 	"github.com/simplesurance/baur/v1/internal/prettyprint"
 	"github.com/simplesurance/baur/v1/internal/testutils/strtest"
 )
+
+func containsGoPath(envs []string) bool {
+	for _, env := range envs {
+		if strings.Contains(env, "GOPATH") {
+			return true
+		}
+	}
+	return false
+}
 
 func TestResolve(t *testing.T) {
 	const testCfgFilename = "test_config.json"
@@ -49,6 +59,14 @@ func TestResolve(t *testing.T) {
 
 			cwd, err := os.Getwd()
 			require.NoError(t, err)
+
+			if os.Getenv("GOCACHE") == "" {
+				os.Setenv("GOCACHE", t.TempDir())
+			}
+
+			if !containsGoPath(testCfg.Cfg.Environment) {
+				testCfg.Cfg.Environment = append(testCfg.Cfg.Environment, fmt.Sprintf("GOPATH=%s", os.Getenv("GOPATH")))
+			}
 
 			for i := range testCfg.Cfg.Environment {
 				testCfg.Cfg.Environment[i] = strings.Replace(testCfg.Cfg.Environment[i], "$WORKDIR", cwd, -1)


### PR DESCRIPTION
I noticed that some of the tests have been failing locally but passing on CircleCI. It turns out the go test command exit code was not being reported back to CircleCI correctly so the job was passing when it shouldn't have been.
![image](https://user-images.githubusercontent.com/20102859/103605479-d5688a00-4f78-11eb-987d-460dc1a05f41.png)


I expect the checks for 5720734 to fail. I will then push up the fixes to the tests that are failing on Windows and the checks should then legitimately pass.

@fho