### PR TITLE
ci: update golang and golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   test_linux:
     docker:
-      - image: circleci/golang:1.15.4
+      - image: circleci/golang:1.15.6
         environment:
           GOFLAGS: -mod=vendor
           TEST_RESULTS: /tmp/test-results
@@ -93,7 +93,7 @@ jobs:
 
   build_linux:
     docker:
-      - image: circleci/golang:1.15.4
+      - image: circleci/golang:1.15.6
 
     working_directory: ~/baur
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   static_analysis_linux:
     docker:
-      - image: golangci/golangci-lint:v1.32.2
+      - image: golangci/golangci-lint:v1.35.2
 
     working_directory: ~/baur
     steps:


### PR DESCRIPTION
Use:
- go 1.15.6
- golangci-lint: 1.35.2