### PR TITLE
Support specifying multiple upload destinations per output

### DIFF
--- a/cfg/app.go
+++ b/cfg/app.go
@@ -51,12 +51,16 @@ func ExampleApp(name string) *App {
 					File: []FileOutput{
 						{
 							Path: "dist/$APPNAME.tar.xz",
-							S3Upload: S3Upload{
-								Bucket: "go-artifacts/",
-								Key:    "$APPNAME-$GITCOMMIT.tar.xz",
+							S3Upload: []S3Upload{
+								{
+									Bucket: "go-artifacts/",
+									Key:    "$APPNAME-$GITCOMMIT.tar.xz",
+								},
 							},
-							FileCopy: FileCopy{
-								Path: "/mnt/fileserver/build_artifacts/$APPNAME-$GITCOMMIT.tar.xz",
+							FileCopy: []FileCopy{
+								{
+									Path: "/mnt/fileserver/build_artifacts/$APPNAME-$GITCOMMIT.tar.xz",
+								},
 							},
 						},
 					},

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -63,9 +63,11 @@ func ExampleApp(name string) *App {
 					DockerImage: []DockerImageOutput{
 						{
 							IDFile: "$APPNAME-container.id",
-							RegistryUpload: DockerImageRegistryUpload{
-								Repository: "my-company/$APPNAME",
-								Tag:        "$GITCOMMIT",
+							RegistryUpload: []DockerImageRegistryUpload{
+								{
+									Repository: "my-company/$APPNAME",
+									Tag:        "$GITCOMMIT",
+								},
 							},
 						},
 					},

--- a/cfg/app_test.go
+++ b/cfg/app_test.go
@@ -64,7 +64,7 @@ func TestEnsureValidateFailsOnDuplicateTaskNames(t *testing.T) {
 					File: []FileOutput{
 						{
 							Path:     "a.out",
-							FileCopy: FileCopy{Path: "/tmp/"},
+							FileCopy: []FileCopy{{Path: "/tmp/"}},
 						},
 					},
 				},

--- a/cfg/filecopy.go
+++ b/cfg/filecopy.go
@@ -7,11 +7,6 @@ type FileCopy struct {
 	Path string `toml:"path" comment:"Destination directory\n Valid variables: $ROOT, $APPNAME, $GITCOMMIT, $UUID."`
 }
 
-// IsEmpty returns true if FileCopy is empty
-func (f *FileCopy) IsEmpty() bool {
-	return len(f.Path) == 0
-}
-
 func (f *FileCopy) resolve(resolvers resolver.Resolver) error {
 	var err error
 

--- a/cfg/include.go
+++ b/cfg/include.go
@@ -153,9 +153,11 @@ func ExampleInclude(id string) *Include {
 				DockerImage: []DockerImageOutput{
 					{
 						IDFile: "$APPNAME-container.id",
-						RegistryUpload: DockerImageRegistryUpload{
-							Repository: "my-company/$APPNAME",
-							Tag:        "$GITCOMMIT",
+						RegistryUpload: []DockerImageRegistryUpload{
+							{
+								Repository: "my-company/$APPNAME",
+								Tag:        "$GITCOMMIT",
+							},
 						},
 					},
 				},

--- a/cfg/include.go
+++ b/cfg/include.go
@@ -141,12 +141,16 @@ func ExampleInclude(id string) *Include {
 				File: []FileOutput{
 					{
 						Path: "dist/$APPNAME.tar.xz",
-						S3Upload: S3Upload{
-							Bucket: "go-artifacts/",
-							Key:    "$APPNAME-$GITCOMMIT.tar.xz",
+						S3Upload: []S3Upload{
+							{
+								Bucket: "go-artifacts/",
+								Key:    "$APPNAME-$GITCOMMIT.tar.xz",
+							},
 						},
-						FileCopy: FileCopy{
-							Path: "/mnt/fileserver/build_artifacts/$APPNAME-$GITCOMMIT.tar.xz",
+						FileCopy: []FileCopy{
+							{
+								Path: "/mnt/fileserver/build_artifacts/$APPNAME-$GITCOMMIT.tar.xz",
+							},
 						},
 					},
 				},
@@ -179,8 +183,10 @@ func ExampleInclude(id string) *Include {
 					File: []FileOutput{
 						{
 							Path: "a.out",
-							FileCopy: FileCopy{
-								Path: "/artifacts",
+							FileCopy: []FileCopy{
+								{
+									Path: "/artifacts",
+								},
 							},
 						},
 					},

--- a/cfg/includedb_test.go
+++ b/cfg/includedb_test.go
@@ -70,10 +70,12 @@ func outputInclude() OutputIncludes {
 			DockerImage: []DockerImageOutput{
 				{
 					IDFile: "idfile",
-					RegistryUpload: DockerImageRegistryUpload{
-						Registry:   "localhost:123",
-						Repository: "myrepo/calc",
-						Tag:        "latest",
+					RegistryUpload: []DockerImageRegistryUpload{
+						{
+							Registry:   "localhost:123",
+							Repository: "myrepo/calc",
+							Tag:        "latest",
+						},
 					},
 				},
 			},
@@ -428,10 +430,12 @@ func TestTaskInclude(t *testing.T) {
 							DockerImage: []DockerImageOutput{
 								{
 									IDFile: "idfile",
-									RegistryUpload: DockerImageRegistryUpload{
-										Registry:   "registry",
-										Repository: "repo",
-										Tag:        "tag",
+									RegistryUpload: []DockerImageRegistryUpload{
+										{
+											Registry:   "registry",
+											Repository: "repo",
+											Tag:        "tag",
+										},
 									},
 								},
 							},
@@ -451,10 +455,12 @@ func TestTaskInclude(t *testing.T) {
 							DockerImage: []DockerImageOutput{
 								{
 									IDFile: "idfile1",
-									RegistryUpload: DockerImageRegistryUpload{
-										Registry:   "registry1",
-										Repository: "repo1",
-										Tag:        "tag",
+									RegistryUpload: []DockerImageRegistryUpload{
+										{
+											Registry:   "registry1",
+											Repository: "repo1",
+											Tag:        "tag",
+										},
 									},
 								},
 							},
@@ -657,9 +663,15 @@ func TestVarsInIncludeFiles(t *testing.T) {
 				DockerImage: []DockerImageOutput{
 					{
 						IDFile: "$APPNAME",
-						RegistryUpload: DockerImageRegistryUpload{
-							Tag:        "test",
-							Repository: "$APPNAME",
+						RegistryUpload: []DockerImageRegistryUpload{
+							{
+								Tag:        "test",
+								Repository: "$APPNAME",
+							},
+							{
+								Tag:        "latest",
+								Repository: "$APPNAME",
+							},
 						},
 					},
 				},
@@ -722,7 +734,11 @@ func TestVarsInIncludeFiles(t *testing.T) {
 
 		require.Len(t, loadedApp.Tasks[0].Output.DockerImage, 1)
 		require.Equal(t, variableVal, loadedApp.Tasks[0].Output.DockerImage[0].IDFile)
-		require.Equal(t, variableVal, loadedApp.Tasks[0].Output.DockerImage[0].RegistryUpload.Repository)
+		require.Len(t, loadedApp.Tasks[0].Output.DockerImage[0].RegistryUpload, 2)
+		require.Equal(t, variableVal, loadedApp.Tasks[0].Output.DockerImage[0].RegistryUpload[0].Repository)
+		require.Equal(t, "test", loadedApp.Tasks[0].Output.DockerImage[0].RegistryUpload[0].Tag)
+		require.Equal(t, variableVal, loadedApp.Tasks[0].Output.DockerImage[0].RegistryUpload[1].Repository)
+		require.Equal(t, "latest", loadedApp.Tasks[0].Output.DockerImage[0].RegistryUpload[1].Tag)
 
 		require.Len(t, loadedApp.Tasks[0].Output.File, 1)
 		require.Equal(t, variableVal, loadedApp.Tasks[0].Output.File[0].Path)

--- a/cfg/includedb_test.go
+++ b/cfg/includedb_test.go
@@ -82,12 +82,16 @@ func outputInclude() OutputIncludes {
 			File: []FileOutput{
 				{
 					Path: "a.out",
-					FileCopy: FileCopy{
-						Path: "/tmp/a.out",
+					FileCopy: []FileCopy{
+						{
+							Path: "/tmp/a.out",
+						},
 					},
-					S3Upload: S3Upload{
-						Bucket: "mybucket",
-						Key:    "the-binary",
+					S3Upload: []S3Upload{
+						{
+							Bucket: "mybucket",
+							Key:    "the-binary",
+						},
 					},
 				},
 			},
@@ -442,10 +446,12 @@ func TestTaskInclude(t *testing.T) {
 							File: []FileOutput{
 								{
 									Path:     "path",
-									FileCopy: FileCopy{Path: "/tmp/"},
-									S3Upload: S3Upload{
-										Bucket: "bucket",
-										Key:    "dest",
+									FileCopy: []FileCopy{{Path: "/tmp/"}},
+									S3Upload: []S3Upload{
+										{
+											Bucket: "bucket",
+											Key:    "dest",
+										},
 									},
 								},
 							},
@@ -467,10 +473,12 @@ func TestTaskInclude(t *testing.T) {
 							File: []FileOutput{
 								{
 									Path:     "path",
-									FileCopy: FileCopy{Path: "/data/"},
-									S3Upload: S3Upload{
-										Bucket: "bucket1",
-										Key:    "dest1",
+									FileCopy: []FileCopy{{Path: "/data/"}},
+									S3Upload: []S3Upload{
+										{
+											Bucket: "bucket1",
+											Key:    "dest1",
+										},
 									},
 								},
 							},
@@ -598,7 +606,7 @@ func TestTaskIncludeFailsForNonExistingIncludeName(t *testing.T) {
 				File: []FileOutput{
 					{
 						Path:     "path",
-						FileCopy: FileCopy{Path: "/tmp/"},
+						FileCopy: []FileCopy{{Path: "/tmp/"}},
 					},
 				},
 			},
@@ -678,8 +686,9 @@ func TestVarsInIncludeFiles(t *testing.T) {
 				File: []FileOutput{
 					{
 						Path: "$APPNAME",
-						FileCopy: FileCopy{
+						FileCopy: []FileCopy{{
 							Path: "/tmp/f",
+						},
 						},
 					},
 				},

--- a/cfg/s3upload.go
+++ b/cfg/s3upload.go
@@ -10,11 +10,6 @@ type S3Upload struct {
 	Key    string `toml:"key" comment:"Identifier for the object in the bucket. Valid variables: $ROOT, $APPNAME, $UUID, $GITCOMMIT"`
 }
 
-// IsEmpty returns true if S3Upload is empty
-func (s *S3Upload) IsEmpty() bool {
-	return len(s.Bucket) == 0 && len(s.Key) == 0
-}
-
 func (s *S3Upload) resolve(resolvers resolver.Resolver) error {
 	var err error
 
@@ -31,10 +26,6 @@ func (s *S3Upload) resolve(resolvers resolver.Resolver) error {
 
 // validate validates a [[Task.Output.File]] section
 func (s *S3Upload) validate() error {
-	if s.IsEmpty() {
-		return nil
-	}
-
 	if len(s.Key) == 0 {
 		return newFieldError("can not be empty", "destfile")
 	}

--- a/cfg/s3upload.go
+++ b/cfg/s3upload.go
@@ -18,7 +18,7 @@ func (s *S3Upload) resolve(resolvers resolver.Resolver) error {
 	}
 
 	if s.Key, err = resolvers.Resolve(s.Key); err != nil {
-		return fieldErrorWrap(err, "dest_file")
+		return fieldErrorWrap(err, "key")
 	}
 
 	return nil
@@ -27,7 +27,7 @@ func (s *S3Upload) resolve(resolvers resolver.Resolver) error {
 // validate validates a [[Task.Output.File]] section
 func (s *S3Upload) validate() error {
 	if len(s.Key) == 0 {
-		return newFieldError("can not be empty", "destfile")
+		return newFieldError("can not be empty", "key")
 	}
 
 	if len(s.Bucket) == 0 {

--- a/cfg/upgrade/v4/v4.go
+++ b/cfg/upgrade/v4/v4.go
@@ -77,10 +77,12 @@ func UpgradeIncludeConfig(old *cfgv0.Include) *cfg.Include {
 		for _, f := range old.BuildOutput.File {
 			output.File = append(output.File, cfg.FileOutput{
 				Path:     f.Path,
-				FileCopy: cfg.FileCopy{Path: f.FileCopy.Path},
-				S3Upload: cfg.S3Upload{
-					Bucket: f.S3Upload.Bucket,
-					Key:    f.S3Upload.DestFile,
+				FileCopy: []cfg.FileCopy{{Path: f.FileCopy.Path}},
+				S3Upload: []cfg.S3Upload{
+					{
+						Bucket: f.S3Upload.Bucket,
+						Key:    f.S3Upload.DestFile,
+					},
 				},
 			})
 		}
@@ -146,13 +148,26 @@ func UpgradeAppConfig(old *cfgv0.App) *cfg.App {
 	}
 
 	for _, f := range old.Build.Output.File {
+		var fc []cfg.FileCopy
+		var s3 []cfg.S3Upload
+
+		if f.FileCopy.Path != "" {
+			fc = []cfg.FileCopy{{Path: f.FileCopy.Path}}
+		}
+
+		if f.S3Upload.Bucket != "" {
+			s3 = []cfg.S3Upload{
+				{
+					Bucket: f.S3Upload.Bucket,
+					Key:    f.S3Upload.DestFile,
+				},
+			}
+		}
+
 		task.Output.File = append(task.Output.File, cfg.FileOutput{
 			Path:     f.Path,
-			FileCopy: cfg.FileCopy{Path: f.FileCopy.Path},
-			S3Upload: cfg.S3Upload{
-				Bucket: f.S3Upload.Bucket,
-				Key:    f.S3Upload.DestFile,
-			},
+			FileCopy: fc,
+			S3Upload: s3,
 		})
 	}
 

--- a/cfg/upgrade/v4/v4.go
+++ b/cfg/upgrade/v4/v4.go
@@ -63,12 +63,15 @@ func UpgradeIncludeConfig(old *cfgv0.Include) *cfg.Include {
 		for _, di := range old.BuildOutput.DockerImage {
 			output.DockerImage = append(output.DockerImage, cfg.DockerImageOutput{
 				IDFile: di.IDFile,
-				RegistryUpload: cfg.DockerImageRegistryUpload{
-					Registry:   di.RegistryUpload.Registry,
-					Repository: di.RegistryUpload.Repository,
-					Tag:        di.RegistryUpload.Tag,
+				RegistryUpload: []cfg.DockerImageRegistryUpload{
+					{
+						Registry:   di.RegistryUpload.Registry,
+						Repository: di.RegistryUpload.Repository,
+						Tag:        di.RegistryUpload.Tag,
+					},
 				},
-			})
+			},
+			)
 		}
 
 		for _, f := range old.BuildOutput.File {
@@ -132,10 +135,12 @@ func UpgradeAppConfig(old *cfgv0.App) *cfg.App {
 	for _, di := range old.Build.Output.DockerImage {
 		task.Output.DockerImage = append(task.Output.DockerImage, cfg.DockerImageOutput{
 			IDFile: di.IDFile,
-			RegistryUpload: cfg.DockerImageRegistryUpload{
-				Registry:   di.RegistryUpload.Registry,
-				Repository: di.RegistryUpload.Repository,
-				Tag:        di.RegistryUpload.Tag,
+			RegistryUpload: []cfg.DockerImageRegistryUpload{
+				{
+					Registry:   di.RegistryUpload.Registry,
+					Repository: di.RegistryUpload.Repository,
+					Tag:        di.RegistryUpload.Tag,
+				},
 			},
 		})
 	}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -215,12 +215,20 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 	for i, di := range task.Outputs.DockerImage {
 		mustWriteRow(formatter, "", "", "Type:", term.Highlight("Docker Image"))
 		mustWriteRow(formatter, "", "", "IDFile:", term.Highlight(di.IDFile))
-		mustWriteRow(formatter, "", "", "Registry:", term.Highlight(di.RegistryUpload.Registry))
-		mustWriteRow(formatter, "", "", "Repository:", term.Highlight(di.RegistryUpload.Repository))
-		mustWriteRow(formatter, "", "", "Tag:", term.Highlight(di.RegistryUpload.Tag))
+		mustWriteRow(formatter, "", "", "")
+		mustWriteRow(formatter, "", "", term.Underline("Uploads:"), "", "")
+
+		for i, dest := range di.RegistryUpload {
+			mustWriteRow(formatter, "", "", "", "Registry:", term.Highlight(dest.Registry))
+			mustWriteRow(formatter, "", "", "", "Repository:", term.Highlight(dest.Repository))
+			mustWriteRow(formatter, "", "", "", "Tag:", term.Highlight(dest.Tag))
+			if i+1 < len(di.RegistryUpload) {
+				mustWriteRow(formatter, "", "", "", "", "")
+			}
+		}
 
 		if i+1 < len(task.Outputs.DockerImage) {
-			mustWriteRow(formatter, "", "", "", "")
+			mustWriteRow(formatter, "", "", "", "", "")
 		}
 	}
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -222,6 +222,7 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 			mustWriteRow(formatter, "", "", "", "Registry:", term.Highlight(dest.Registry))
 			mustWriteRow(formatter, "", "", "", "Repository:", term.Highlight(dest.Repository))
 			mustWriteRow(formatter, "", "", "", "Tag:", term.Highlight(dest.Tag))
+
 			if i+1 < len(di.RegistryUpload) {
 				mustWriteRow(formatter, "", "", "", "", "")
 			}
@@ -239,14 +240,33 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 
 		mustWriteRow(formatter, "", "", "Type:", term.Highlight("File"))
 		mustWriteRow(formatter, "", "", "Path:", term.Highlight(file.Path))
+		mustWriteRow(formatter, "", "", "")
 
-		if !file.FileCopy.IsEmpty() {
-			mustWriteRow(formatter, "", "", "Filecopy Destination:", term.Highlight(file.FileCopy.Path))
+		mustWriteRow(formatter, "", "", term.Underline("Uploads:"), "", "")
+
+		if len(file.FileCopy) > 0 {
+			for i, fc := range file.FileCopy {
+				mustWriteRow(formatter, "", "", "", "Filecopy Destination:", term.Highlight(fc.Path))
+
+				if i+1 < len(file.FileCopy) {
+					mustWriteRow(formatter, "", "", "", "", "")
+				}
+			}
 		}
 
-		if !file.S3Upload.IsEmpty() {
-			mustWriteRow(formatter, "", "", "S3 Bucket:", term.Highlight(file.S3Upload.Bucket))
-			mustWriteRow(formatter, "", "", "S3 Key:", term.Highlight(file.S3Upload.Key))
+		if len(file.S3Upload) > 0 {
+			if len(file.FileCopy) > 0 {
+				mustWriteRow(formatter, "", "", "", "", "")
+			}
+
+			for i, s3 := range file.S3Upload {
+				mustWriteRow(formatter, "", "", "", "S3 Bucket:", term.Highlight(s3.Bucket))
+				mustWriteRow(formatter, "", "", "", "S3 Key:", term.Highlight(s3.Key))
+
+				if i+1 < len(file.S3Upload) {
+					mustWriteRow(formatter, "", "", "", "", "")
+				}
+			}
 		}
 
 		if i+1 < len(task.Outputs.File) {

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -78,8 +78,10 @@ func (r *Repo) CreateSimpleApp(t *testing.T) *cfg.App {
 					File: []cfg.FileOutput{
 						{
 							Path: "output",
-							FileCopy: cfg.FileCopy{
-								Path: r.FilecopyArtifactDir,
+							FileCopy: []cfg.FileCopy{
+								{
+									Path: r.FilecopyArtifactDir,
+								},
 							},
 						},
 					},

--- a/output.go
+++ b/output.go
@@ -70,30 +70,29 @@ func fileOutputs(task *Task) ([]Output, error) {
 	result := make([]Output, 0, len(task.Outputs.File))
 
 	for _, fileOutput := range task.Outputs.File {
-		var s3Upload *UploadInfoS3
-		var fileCopyUpload *UploadInfoFileCopy
+		var s3Uploads []*UploadInfoS3
+		var fileCopyUploads []*UploadInfoFileCopy
 
-		if fileOutput.S3Upload.IsEmpty() && fileOutput.FileCopy.IsEmpty() {
+		if len(fileOutput.S3Upload) == 0 && len(fileOutput.FileCopy) == 0 {
 			return nil, fmt.Errorf("no upload method for output %q is specified", fileOutput.Path)
 		}
 
-		// TODO: use pointers in the outputfile struct for filecopy and S3 instead of having to provide and use IsEmpty)
-		if !fileOutput.S3Upload.IsEmpty() {
-			s3Upload = &UploadInfoS3{
-				Bucket: fileOutput.S3Upload.Bucket,
-				Key:    fileOutput.S3Upload.Key,
-			}
+		for _, s3 := range fileOutput.S3Upload {
+			s3Uploads = append(s3Uploads, &UploadInfoS3{
+				Bucket: s3.Bucket,
+				Key:    s3.Key,
+			})
 		}
 
-		if !fileOutput.FileCopy.IsEmpty() {
-			fileCopyUpload = &UploadInfoFileCopy{DestinationPath: fileOutput.FileCopy.Path}
+		for _, fc := range fileOutput.FileCopy {
+			fileCopyUploads = append(fileCopyUploads, &UploadInfoFileCopy{DestinationPath: fc.Path})
 		}
 
 		result = append(result, NewOutputFile(
 			fileOutput.Path,
 			filepath.Join(task.Directory, fileOutput.Path),
-			s3Upload,
-			fileCopyUpload,
+			s3Uploads,
+			fileCopyUploads,
 		))
 	}
 

--- a/output.go
+++ b/output.go
@@ -39,15 +39,21 @@ func dockerOutputs(dockerClient DockerInfoClient, task *Task) ([]Output, error) 
 	result := make([]Output, 0, len(task.Outputs.DockerImage))
 
 	for _, dockerOutput := range task.Outputs.DockerImage {
+		uploadInfos := make([]*UploadInfoDocker, 0, len(dockerOutput.RegistryUpload))
+
+		for _, ru := range dockerOutput.RegistryUpload {
+			uploadInfos = append(uploadInfos, &UploadInfoDocker{
+				Registry:   ru.Registry,
+				Repository: ru.Repository,
+				Tag:        ru.Tag,
+			})
+		}
+
 		d, err := NewOutputDockerImageFromIIDFile(
 			dockerClient,
 			dockerOutput.IDFile,
 			filepath.Join(task.Directory, dockerOutput.IDFile),
-			&UploadInfoDocker{
-				Registry:   dockerOutput.RegistryUpload.Registry,
-				Repository: dockerOutput.RegistryUpload.Repository,
-				Tag:        dockerOutput.RegistryUpload.Tag,
-			},
+			uploadInfos,
 		)
 
 		if err != nil {

--- a/outputdockerimage.go
+++ b/outputdockerimage.go
@@ -16,7 +16,7 @@ type DockerInfoClient interface {
 type OutputDockerImage struct {
 	name              string
 	ImageID           string
-	UploadDestination *UploadInfoDocker
+	UploadDestination []*UploadInfoDocker // TODO: rename to plural form
 	dockerClient      DockerInfoClient
 	digest            *digest.Digest
 }
@@ -25,7 +25,7 @@ func NewOutputDockerImageFromIIDFile(
 	dockerClient DockerInfoClient,
 	name,
 	iidfile string,
-	uploadDest *UploadInfoDocker,
+	uploadDest []*UploadInfoDocker,
 ) (*OutputDockerImage, error) {
 	id, err := fs.FileReadLine(iidfile)
 	if err != nil {

--- a/outputfile.go
+++ b/outputfile.go
@@ -8,19 +8,17 @@ import (
 // OutputFile is a file created by a task run.
 type OutputFile struct {
 	*File
-	name string
-	// UploadsS3 can be nil
-	UploadsS3 *UploadInfoS3
-	// UploadsFilecopy can be nil
-	UploadsFilecopy *UploadInfoFileCopy
+	name            string
+	UploadsS3       []*UploadInfoS3
+	UploadsFilecopy []*UploadInfoFileCopy
 }
 
-func NewOutputFile(name, absPath string, s3upload *UploadInfoS3, filecopyUpload *UploadInfoFileCopy) *OutputFile {
+func NewOutputFile(name, absPath string, s3uploads []*UploadInfoS3, filecopyUploads []*UploadInfoFileCopy) *OutputFile {
 	return &OutputFile{
 		name:            name,
 		File:            &File{AbsPath: absPath},
-		UploadsS3:       s3upload,
-		UploadsFilecopy: filecopyUpload,
+		UploadsS3:       s3uploads,
+		UploadsFilecopy: filecopyUploads,
 	}
 }
 

--- a/uploader.go
+++ b/uploader.go
@@ -64,10 +64,10 @@ func (u *Uploader) Upload(output Output, uploadStartCb UploadStartFn, resultCb U
 		}
 
 	case *OutputFile:
-		if o.UploadsFilecopy != nil {
-			uploadStartCb(o, o.UploadsFilecopy)
+		for _, dest := range o.UploadsFilecopy {
+			uploadStartCb(o, dest)
 
-			result, err := u.FileCopy(o)
+			result, err := u.FileCopy(o, dest)
 			if err != nil {
 				return fmt.Errorf("filecopy failed: %w", err)
 			}
@@ -75,10 +75,10 @@ func (u *Uploader) Upload(output Output, uploadStartCb UploadStartFn, resultCb U
 			resultCb(o, result)
 		}
 
-		if o.UploadsS3 != nil {
-			uploadStartCb(o, o.UploadsS3)
+		for _, dest := range o.UploadsS3 {
+			uploadStartCb(o, dest)
 
-			result, err := u.S3(o)
+			result, err := u.S3(o, dest)
 			if err != nil {
 				return fmt.Errorf("s3 upload failed: %w", err)
 			}
@@ -115,10 +115,10 @@ func (u *Uploader) DockerImage(o *OutputDockerImage, dest *UploadInfoDocker) (*U
 	}, nil
 }
 
-func (u *Uploader) FileCopy(o *OutputFile) (*UploadResult, error) {
+func (u *Uploader) FileCopy(o *OutputFile, dest *UploadInfoFileCopy) (*UploadResult, error) {
 	startTime := time.Now()
 
-	destFile := filepath.Join(o.UploadsFilecopy.DestinationPath, filepath.Base(o.AbsPath))
+	destFile := filepath.Join(dest.DestinationPath, filepath.Base(o.AbsPath))
 
 	url, err := u.filecopyUploader.Upload(o.AbsPath, destFile)
 	if err != nil {
@@ -134,10 +134,10 @@ func (u *Uploader) FileCopy(o *OutputFile) (*UploadResult, error) {
 	}, nil
 }
 
-func (u *Uploader) S3(o *OutputFile) (*UploadResult, error) {
+func (u *Uploader) S3(o *OutputFile, dest *UploadInfoS3) (*UploadResult, error) {
 	startTime := time.Now()
 
-	url, err := u.s3client.Upload(o.AbsPath, o.UploadsS3.Bucket, o.UploadsS3.Key)
+	url, err := u.s3client.Upload(o.AbsPath, dest.Bucket, dest.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/uploader.go
+++ b/uploader.go
@@ -52,14 +52,16 @@ func (u *Uploader) Upload(output Output, uploadStartCb UploadStartFn, resultCb U
 			break
 		}
 
-		uploadStartCb(o, o.UploadDestination)
+		for _, dest := range o.UploadDestination {
+			uploadStartCb(o, dest)
 
-		result, err := u.DockerImage(o)
-		if err != nil {
-			return fmt.Errorf("docker upload failed: %w", err)
+			result, err := u.DockerImage(o, dest)
+			if err != nil {
+				return fmt.Errorf("docker upload failed: %w", err)
+			}
+
+			resultCb(o, result)
 		}
-
-		resultCb(o, result)
 
 	case *OutputFile:
 		if o.UploadsFilecopy != nil {
@@ -91,14 +93,14 @@ func (u *Uploader) Upload(output Output, uploadStartCb UploadStartFn, resultCb U
 	return nil
 }
 
-func (u *Uploader) DockerImage(o *OutputDockerImage) (*UploadResult, error) {
+func (u *Uploader) DockerImage(o *OutputDockerImage, dest *UploadInfoDocker) (*UploadResult, error) {
 	startTime := time.Now()
 
 	url, err := u.dockerclient.Upload(
 		o.ImageID,
-		o.UploadDestination.Registry,
-		o.UploadDestination.Repository,
-		o.UploadDestination.Tag,
+		dest.Registry,
+		dest.Repository,
+		dest.Tag,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For the same output multiple upload destinations can now be specified.
So far it was only possible to specify a single upload destination of a kind per output. 

```
        cfg: fix: field name in error messages related to S3Upload.Key field

        When validating the app config failed because of issues with the S3Upload.Key
        field the error message references the field with the name "dest_file" or
        "destfile" instead of key.

        Fix the field name used in the error messages

-------------------------------------------------------------------------------
        cfg: support specifying multiple file upload destinations per output

        The S3Upload and FileCopy fields in the app config are changed to be being
        slices instead of single elements.
        This allows to specify multiple upload destination per output file

-------------------------------------------------------------------------------
        cfg: support specifying multiple docker registries as upload destination

        The RegistryUpload field in the app config is changed to being a slice instead
        of a single element.
        This allows to specify multiple upload destination per docker image.

        To upload the same image to multiple destinations it was required so far to
        define the output multiple times.
```

Closes #128