### PR TITLE
Support referencing environment variables in app config files

### DIFF
--- a/cfg/app.go
+++ b/cfg/app.go
@@ -70,7 +70,7 @@ func ExampleApp(name string) *App {
 							RegistryUpload: []DockerImageRegistryUpload{
 								{
 									Repository: "my-company/$APPNAME",
-									Tag:        "$GITCOMMIT",
+									Tag:        "{{ ENV BRANCH_NAME }}-$GITCOMMIT",
 								},
 							},
 						},

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -50,27 +50,27 @@ func ExampleApp(name string) *App {
 				Output: Output{
 					File: []FileOutput{
 						{
-							Path: "dist/$APPNAME.tar.xz",
+							Path: "dist/{{ .appname }}.tar.xz",
 							S3Upload: []S3Upload{
 								{
 									Bucket: "go-artifacts/",
-									Key:    "$APPNAME-$GITCOMMIT.tar.xz",
+									Key:    "{{ .appname }}-{{ .gitcommit }}.tar.xz",
 								},
 							},
 							FileCopy: []FileCopy{
 								{
-									Path: "/mnt/fileserver/build_artifacts/$APPNAME-$GITCOMMIT.tar.xz",
+									Path: "/mnt/fileserver/build_artifacts/{{ .appname }}-{{ .gitcommit }}.tar.xz",
 								},
 							},
 						},
 					},
 					DockerImage: []DockerImageOutput{
 						{
-							IDFile: "$APPNAME-container.id",
+							IDFile: "{{ .appname }}-container.id",
 							RegistryUpload: []DockerImageRegistryUpload{
 								{
-									Repository: "my-company/$APPNAME",
-									Tag:        "{{ ENV BRANCH_NAME }}-$GITCOMMIT",
+									Repository: "my-company/{{ .appname }}",
+									Tag:        "{{ ENV BRANCH_NAME }}-{{ .gitcommit }}",
 								},
 							},
 						},

--- a/cfg/app.go
+++ b/cfg/app.go
@@ -15,7 +15,7 @@ import (
 // App stores an application configuration.
 type App struct {
 	Name     string   `toml:"name" comment:"Name of the application"`
-	Includes []string `toml:"includes" comment:"Task-includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory.\n. Valid variables: $ROOT."`
+	Includes []string `toml:"includes" comment:"Task-includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory."`
 	Tasks    Tasks    `toml:"Task"`
 
 	filepath string

--- a/cfg/dockerimageoutput.go
+++ b/cfg/dockerimageoutput.go
@@ -8,7 +8,7 @@ import (
 
 // DockerImageOutput describes where a docker container is uploaded to.
 type DockerImageOutput struct {
-	IDFile         string                      `toml:"idfile" comment:"Path to a file that is created by the [Task.Command] and contains the image ID of the produced image (docker build --iidfile).\n Valid variables: $ROOT, $APPNAME"`
+	IDFile         string                      `toml:"idfile" comment:"Path to a file that is created by the [Task.Command] and contains the image ID of the produced image (docker build --iidfile)."`
 	RegistryUpload []DockerImageRegistryUpload `comment:"Registry and repository the image is uploaded to"`
 }
 

--- a/cfg/dockerimageregistryupload.go
+++ b/cfg/dockerimageregistryupload.go
@@ -7,12 +7,16 @@ import (
 // DockerImageRegistryUpload stores information about a Docker image upload.
 type DockerImageRegistryUpload struct {
 	Registry   string `toml:"registry" comment:"Registry address in the format <HOST>:[<PORT>]. If it's empty the default from the docker agent is used."`
-	Repository string `toml:"repository" comment:"Repository name, Valid variables: $APPNAME"`
-	Tag        string `toml:"tag" comment:"Tag that is applied to the image.\n Valid variables: $APPNAME, $UUID, $GITCOMMIT"`
+	Repository string `toml:"repository" comment:"Repository name"`
+	Tag        string `toml:"tag" comment:"Tag that is applied to the image."`
 }
 
 func (d *DockerImageRegistryUpload) Resolve(resolvers resolver.Resolver) error {
 	var err error
+
+	if d.Registry, err = resolvers.Resolve(d.Registry); err != nil {
+		return fieldErrorWrap(err, "registry")
+	}
 
 	if d.Repository, err = resolvers.Resolve(d.Repository); err != nil {
 		return fieldErrorWrap(err, "repository")

--- a/cfg/filecopy.go
+++ b/cfg/filecopy.go
@@ -4,7 +4,7 @@ import "github.com/simplesurance/baur/v1/cfg/resolver"
 
 // FileCopy describes a filesystem location where a task output is copied to.
 type FileCopy struct {
-	Path string `toml:"path" comment:"Destination directory\n Valid variables: $ROOT, $APPNAME, $GITCOMMIT, $UUID."`
+	Path string `toml:"path" comment:"Destination directory"`
 }
 
 func (f *FileCopy) resolve(resolvers resolver.Resolver) error {

--- a/cfg/fileinputs.go
+++ b/cfg/fileinputs.go
@@ -8,7 +8,7 @@ import (
 
 // FileInputs stores glob paths to inputs of a task.
 type FileInputs struct {
-	Paths    []string `toml:"paths" comment:"Relative path to source files.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively.\n Valid variables: $ROOT, $APPNAME, $GITCOMMIT."`
+	Paths    []string `toml:"paths" comment:"Relative path to source files.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively."`
 	Optional bool     `toml:"optional" comment:"If true, baur will not fail if a Path does not resolve to a file."`
 }
 

--- a/cfg/fileoutput.go
+++ b/cfg/fileoutput.go
@@ -6,7 +6,7 @@ import (
 
 // FileOutput describes where a file output is stored.
 type FileOutput struct {
-	Path     string     `toml:"path" comment:"Path relative to the application directory.\n Valid variables: $ROOT, $APPNAME, $GITCOMMIT."`
+	Path     string     `toml:"path" comment:"Path relative to the application directory."`
 	FileCopy []FileCopy `comment:"Copy the file to a local directory."`
 	S3Upload []S3Upload `comment:"Upload the file to S3."`
 }

--- a/cfg/gitfileinputs.go
+++ b/cfg/gitfileinputs.go
@@ -5,7 +5,7 @@ import "github.com/simplesurance/baur/v1/cfg/resolver"
 // GitFileInputs describes source files that are in the git repository by git
 // pathnames
 type GitFileInputs struct {
-	Paths    []string `toml:"paths" comment:"Relative paths to source files.\n Only files tracked by Git that are not in the .gitignore file are matched.\n The same patterns that git ls-files supports can be used.\n Valid variables: $ROOT, $APPNAME."`
+	Paths    []string `toml:"paths" comment:"Relative paths to source files.\n Only files tracked by Git that are not in the .gitignore file are matched.\n The same patterns that git ls-files supports can be used."`
 	Optional bool     `toml:"optional" comment:"If true, baur will not fail if a Path does not resolve to a file."`
 }
 

--- a/cfg/golangsources.go
+++ b/cfg/golangsources.go
@@ -6,8 +6,8 @@ import (
 
 // GolangSources specifies inputs for Golang Applications
 type GolangSources struct {
-	Queries     []string `toml:"queries" comment:"Queries specify the source files or packages of which the dependencies are resolved.\n Format:\n \tfile=<RELATIVE-PATH>\n \tfileglob=<GLOB-PATTERN>\t -> Supports double-star\n \tEverything else is passed directly to underlying build tool (go list by default).\n \tSee also the patterns described at:\n \t<https://github.com/golang/tools/blob/bc8aaaa29e0665201b38fa5cb5d47826788fa249/go/packages/doc.go#L17>.\n Files from Golang's stdlib are ignored.\n Valid variables: $ROOT, $APPNAME."`
-	Environment []string `toml:"environment" comment:"Environment to use when discovering Golang source files.\n Variables from the current environment are not used.\n These shoul be environment variables understood by the Golang tools, like GOPATH, GOFLAGS, etc.\n If empty the default Go environment is used.\n Valid variables: $ROOT, $APPNAME"`
+	Queries     []string `toml:"queries" comment:"Queries specify the source files or packages of which the dependencies are resolved.\n Format:\n \tfile=<RELATIVE-PATH>\n \tfileglob=<GLOB-PATTERN>\t -> Supports double-star\n \tEverything else is passed directly to underlying build tool (go list by default).\n \tSee also the patterns described at:\n \t<https://github.com/golang/tools/blob/bc8aaaa29e0665201b38fa5cb5d47826788fa249/go/packages/doc.go#L17>.\n Files from Golang's stdlib are ignored."`
+	Environment []string `toml:"environment" comment:"Environment to use when discovering Golang source files.\n Variables from the current environment are not used.\n These shoul be environment variables understood by the Golang tools, like GOPATH, GOFLAGS, etc.\n If empty the default Go environment is used"`
 	BuildFlags  []string `toml:"build_flags" comment:"List of command-line flags to be passed through to the build system's query tool."`
 	Tests       bool     `toml:"tests" comment:"If true queries are resolved to test files, otherwise testfiles are ignored."`
 }

--- a/cfg/include.go
+++ b/cfg/include.go
@@ -140,27 +140,27 @@ func ExampleInclude(id string) *Include {
 				IncludeID: id + "_output",
 				File: []FileOutput{
 					{
-						Path: "dist/$APPNAME.tar.xz",
+						Path: "dist/{{ .appname }}.tar.xz",
 						S3Upload: []S3Upload{
 							{
 								Bucket: "go-artifacts/",
-								Key:    "$APPNAME-$GITCOMMIT.tar.xz",
+								Key:    "{{ .appname }}-{{ .gitcommit }}.tar.xz",
 							},
 						},
 						FileCopy: []FileCopy{
 							{
-								Path: "/mnt/fileserver/build_artifacts/$APPNAME-$GITCOMMIT.tar.xz",
+								Path: "/mnt/fileserver/build_artifacts/{{ .appname }}-{{ .gitcommit }}.tar.xz",
 							},
 						},
 					},
 				},
 				DockerImage: []DockerImageOutput{
 					{
-						IDFile: "$APPNAME-container.id",
+						IDFile: "{{ .appname }}-container.id",
 						RegistryUpload: []DockerImageRegistryUpload{
 							{
-								Repository: "my-company/$APPNAME",
-								Tag:        "$GITCOMMIT",
+								Repository: "my-company/{{ .appname }}",
+								Tag:        "{{ .gitcommit }}",
 							},
 						},
 					},

--- a/cfg/includedb_test.go
+++ b/cfg/includedb_test.go
@@ -659,7 +659,7 @@ func TestVarsInIncludeFiles(t *testing.T) {
 				IncludeID: inputInclID,
 				Files: []FileInputs{
 					{
-						Paths: []string{"$APPNAME"},
+						Paths: []string{"{{ .appname }}"},
 					},
 				},
 			},
@@ -670,22 +670,22 @@ func TestVarsInIncludeFiles(t *testing.T) {
 				IncludeID: outputInclID,
 				DockerImage: []DockerImageOutput{
 					{
-						IDFile: "$APPNAME",
+						IDFile: "{{ .appname }}",
 						RegistryUpload: []DockerImageRegistryUpload{
 							{
 								Tag:        "test",
-								Repository: "$APPNAME",
+								Repository: "{{ .appname }}",
 							},
 							{
 								Tag:        "latest",
-								Repository: "$APPNAME",
+								Repository: "{{ .appname }}",
 							},
 						},
 					},
 				},
 				File: []FileOutput{
 					{
-						Path: "$APPNAME",
+						Path: "{{ .appname }}",
 						FileCopy: []FileCopy{{
 							Path: "/tmp/f",
 						},
@@ -698,7 +698,7 @@ func TestVarsInIncludeFiles(t *testing.T) {
 			{
 				IncludeID: taskInclID,
 				Name:      "check",
-				Command:   []string{"$APPNAME"},
+				Command:   []string{"{{ .appname }}"},
 			},
 		},
 	}
@@ -730,7 +730,7 @@ func TestVarsInIncludeFiles(t *testing.T) {
 	for i, loadedApp := range loadedApps {
 		variableVal := fmt.Sprintf("var%d", i)
 
-		err = loadedApp.Resolve(&resolver.StrReplacement{Old: "$APPNAME", New: variableVal})
+		err = loadedApp.Resolve(&resolver.StrReplacement{Old: "{{ .appname }}", New: variableVal})
 		require.NoError(t, err)
 
 		require.Len(t, loadedApp.Tasks, 2)

--- a/cfg/resolver/envvar.go
+++ b/cfg/resolver/envvar.go
@@ -1,0 +1,33 @@
+package resolver
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type EnvVar struct{}
+
+var envVarRe = regexp.MustCompile(`{{ env ([\w-]+) }}`)
+
+func (*EnvVar) Resolve(in string) (string, error) {
+	matches := envVarRe.FindAllStringSubmatch(in, -1)
+	for _, m := range matches {
+		if len(m) != 2 {
+			return "", fmt.Errorf("invalid cfg env variable: '%v'", m)
+		}
+
+		fullVar := m[0]
+		envVarName := m[1]
+
+		envVal, exist := os.LookupEnv(envVarName)
+		if !exist {
+			return "", fmt.Errorf("environment variable %q is referenced by %q but is undefined", fullVar, envVarName)
+		}
+
+		in = strings.Replace(in, fullVar, envVal, 1)
+	}
+
+	return in, nil
+}

--- a/cfg/resolver/envvar_test.go
+++ b/cfg/resolver/envvar_test.go
@@ -12,8 +12,8 @@ func TestEnvVarResolve(t *testing.T) {
 	const envVar = "_baurTestEnvVar"
 	const envVarVal = "hello123"
 
-	testStr := fmt.Sprintf("test {{ env %s }} {{ env %s }} bye", envVar, envVar)
-	expectedResult := fmt.Sprintf("test %s %s bye", envVarVal, envVarVal)
+	testStr := fmt.Sprintf("test {{ env %s }} {{ env %s }}bye", envVar, envVar)
+	expectedResult := fmt.Sprintf("test %s %sbye", envVarVal, envVarVal)
 
 	resolver := &EnvVar{}
 

--- a/cfg/resolver/envvar_test.go
+++ b/cfg/resolver/envvar_test.go
@@ -1,0 +1,28 @@
+package resolver
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvVarResolve(t *testing.T) {
+	const envVar = "_baurTestEnvVar"
+	const envVarVal = "hello123"
+
+	testStr := fmt.Sprintf("test {{ env %s }} {{ env %s }} bye", envVar, envVar)
+	expectedResult := fmt.Sprintf("test %s %s bye", envVarVal, envVarVal)
+
+	resolver := &EnvVar{}
+
+	os.Setenv(envVar, envVarVal)
+	t.Cleanup(func() {
+		os.Unsetenv(envVar)
+	})
+
+	res, err := resolver.Resolve(testStr)
+	require.NoError(t, err)
+	require.Equal(t, expectedResult, res)
+}

--- a/cfg/resolver/uuidvar_test.go
+++ b/cfg/resolver/uuidvar_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestUUIDVar(t *testing.T) {
-	r := &UUIDVar{Old: "$UUID"}
+	r := &UUIDVar{Old: "{{ .uuid }}"}
 
-	result, err := r.Resolve("$UUID")
+	result, err := r.Resolve("{{ .uuid }}")
 	assert.NoError(t, err)
 
 	matched, err := regexp.MatchString(`(?i)^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$`, result)

--- a/cfg/s3upload.go
+++ b/cfg/s3upload.go
@@ -6,8 +6,8 @@ import (
 
 // S3Upload contains S3 upload information
 type S3Upload struct {
-	Bucket string `toml:"bucket" comment:"Bucket name, valid variables: $APPNAME, $UUID, $GITCOMMIT"`
-	Key    string `toml:"key" comment:"Identifier for the object in the bucket. Valid variables: $ROOT, $APPNAME, $UUID, $GITCOMMIT"`
+	Bucket string `toml:"bucket" comment:"Bucket name"`
+	Key    string `toml:"key" comment:"Identifier for the object in the bucket."`
 }
 
 func (s *S3Upload) resolve(resolvers resolver.Resolver) error {

--- a/cfg/task.go
+++ b/cfg/task.go
@@ -8,7 +8,7 @@ import (
 type Task struct {
 	Name     string   `toml:"name" comment:"Identifies the task, currently the name must be 'build'."`
 	Command  []string `toml:"command" comment:"Command to execute.\n The first element is the command, the following it's arguments.\n If the command element contains no path seperators,\n the path is looked up via the $PATH environment variable."`
-	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory.\n Valid variables: $ROOT."`
+	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory."`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
 	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`
 

--- a/cfg/taskinclude.go
+++ b/cfg/taskinclude.go
@@ -10,7 +10,7 @@ type TaskInclude struct {
 
 	Name     string   `toml:"name" comment:"Identifies the task, currently the name must be 'build'."`
 	Command  []string `toml:"command" comment:"Command to execute. The first element is the command, the following it's arguments.\n If the command element contains no path seperators, it's paths is tried to be looked up via the $PATH environment variable."`
-	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the include file location.\n Valid variables: $ROOT"`
+	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the include file location."`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
 	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`
 

--- a/cfg_resolvers.go
+++ b/cfg_resolvers.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	rootVarName      = "$ROOT"
-	appVarName       = "$APPNAME"
-	uuidVarname      = "$UUID"
-	gitCommitVarname = "$GITCOMMIT"
+	rootVarName      = "{{ .root }}"
+	appVarName       = "{{ .appname }}"
+	uuidVarname      = "{{ .uuid }}"
+	gitCommitVarname = "{{ .gitcommit }}"
 )
 
 // DefaultAppCfgResolvers returns the default set of resolvers that is applied on application configs.
@@ -39,6 +39,10 @@ func DefaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string
 // IncludeCfgVarResolvers returns the default resolvers for variables in the
 // Includes field in config files.
 func IncludeCfgVarResolvers(rootPath, appName string) resolver.Resolver {
+	// TODO: do we really need to distinguish between resolvers for include directives and all other fields?
+	// We should be able to use the the same set of resolvers for all
+	// fields. If somebody wants to use {{ .gitcommit }} in their include
+	// path, they have to cope with it. :-)
 	return resolver.List{
 		&resolver.StrReplacement{Old: appVarName, New: appName},
 		&resolver.StrReplacement{Old: rootVarName, New: rootPath},

--- a/cfg_resolvers.go
+++ b/cfg_resolvers.go
@@ -32,6 +32,7 @@ func DefaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string
 
 			},
 		},
+		&resolver.EnvVar{},
 	}
 }
 
@@ -41,5 +42,6 @@ func IncludeCfgVarResolvers(rootPath, appName string) resolver.Resolver {
 	return resolver.List{
 		&resolver.StrReplacement{Old: appVarName, New: appName},
 		&resolver.StrReplacement{Old: rootVarName, New: rootPath},
+		&resolver.EnvVar{},
 	}
 }

--- a/internal/command/testdata/var_in_include/app1/.app.toml
+++ b/internal/command/testdata/var_in_include/app1/.app.toml
@@ -1,3 +1,3 @@
 name = "app1"
 
-includes = ["$ROOT/tasks.toml#build"]
+includes = ["{{ .root }}/tasks.toml#build"]

--- a/internal/command/testdata/var_in_include/app2/.app.toml
+++ b/internal/command/testdata/var_in_include/app2/.app.toml
@@ -1,3 +1,3 @@
 name = "app2"
 
-includes = ["$ROOT/tasks.toml#build"]
+includes = ["{{ .root }}/tasks.toml#build"]

--- a/internal/command/testdata/var_in_include/inputs.toml
+++ b/internal/command/testdata/var_in_include/inputs.toml
@@ -10,6 +10,5 @@
     # Relative path to source files.
     # Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)
     # and ** is supported to match files recursively.
-    # Valid variables: $ROOT, $APPNAME, $GITCOMMIT.
-    paths = ["$APPNAME.txt"]
+    paths = ["{{ .appname }}.txt"]
 

--- a/internal/command/testdata/var_in_include/tasks.toml
+++ b/internal/command/testdata/var_in_include/tasks.toml
@@ -1,5 +1,5 @@
 [[Task]]
   include_id = "build"
-  includes = ["$ROOT/inputs.toml#input"]
+  includes = ["{{ .root }}/inputs.toml#input"]
   name = "build"
-  command = ["more", "$APPNAME.txt"]
+  command = ["more", "{{ .appname }}.txt"]

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -59,7 +59,7 @@ func IsGitDir(dir string) (bool, error) {
 		return false, nil
 	}
 
-	return false, fmt.Errorf("executing %q in %q exited with code $d, expeted 0 or 128",
+	return false, fmt.Errorf("executing %q in %q exited with code $d, expected 0 or 128",
 		result.Command, result.ExitCode)
 }
 


### PR DESCRIPTION
This PR adds support to use the values of environment variables in fields of app config files.

Because the current syntax for variables (e.g. `$ROOT`) did not have a character that marks the end of the variable name it was not possible to do it with the syntax.
The syntax for all variables is changed to use the common template syntax.
- `$ROOT` became `{{ .root }}`,
- `$APPNAME` became `{{ .appname }}', etc.
- The cfg upgrader is changed to replace all variables in config fields in the old syntax with the new one.

The syntax also provides the opportunity to switch to using to text/template` template engine of the go stdlib and provide more templating/variable options.

The value of environment variables can be specified via `{{ env <VARIABLE-NAME> }}`.
For example `{{ env SHELL }}`  is replaced with the value of the `$SHELL` environment variable.

More details can be found in the commit messages.

This PR is based on #245 and should be merged afterwards.

Closes #89 