### PR TITLE
resolver: use same glob syntax for Glob and GitPath resolver

### DIFF
--- a/inputresolver.go
+++ b/inputresolver.go
@@ -81,7 +81,6 @@ func (i *InputResolver) resolveGitGlobPaths(repositoryRootDir, appDir string, in
 		}
 
 		result = append(result, gitPaths...)
-
 	}
 
 	return result, nil

--- a/internal/resolve/gitpath/gitpaths.go
+++ b/internal/resolve/gitpath/gitpaths.go
@@ -1,6 +1,8 @@
 package gitpath
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -17,13 +19,36 @@ type Resolver struct{}
 // workingDir must be a directory that is part of a Git repository.
 // If a resolved file does not exist an error is returned.
 func (r *Resolver) Resolve(workingDir string, errorUnmatch bool, globs ...string) ([]string, error) {
-	if len(globs) == 0 {
-		return []string{}, nil
+	var resolvedPaths []string
+
+	for _, glob := range globs {
+		absGlob := filepath.Join(workingDir, glob)
+		// Globs are resolved via the same method then resolve/files
+		// uses. This ensures the same pattern resolves in the same way
+		// for both. git ls-files resolves '*` differently, it also matches directory seperators.
+		paths, err := fs.FileGlob(absGlob)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %q failed: %w", absGlob, err)
+		}
+
+		if len(paths) == 0 {
+			if errorUnmatch {
+				return nil, fmt.Errorf("%q did not match any files: %w", absGlob, os.ErrNotExist)
+			}
+
+			continue
+		}
+
+		resolvedPaths = append(resolvedPaths, paths...)
 	}
 
-	out, err := git.LsFiles(workingDir, errorUnmatch, globs...)
+	if len(resolvedPaths) == 0 {
+		return resolvedPaths, nil
+	}
+
+	out, err := git.LsFiles(workingDir, resolvedPaths...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("git ls-files failed: %w", err)
 	}
 
 	relPaths := strings.Split(out, "\n")

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1/internal/exec"
+	"github.com/simplesurance/baur/v1/internal/log"
+	"github.com/simplesurance/baur/v1/internal/resolve/gitpath"
+	"github.com/simplesurance/baur/v1/internal/resolve/glob"
+	"github.com/simplesurance/baur/v1/internal/testutils/fstest"
+	"github.com/simplesurance/baur/v1/internal/testutils/gittest"
+)
+
+func TestFilesAndGitFilesPatternBehaveTheSame(t *testing.T) {
+	log.StdLogger.SetOutput(log.NewTestLogOutput(t))
+	exec.DefaultDebugfFn = t.Logf
+
+	gitDir := t.TempDir()
+
+	fstest.WriteToFile(t, []byte("123"), filepath.Join(gitDir, "subdir", "file1.txt"))
+	fstest.WriteToFile(t, []byte("123"), filepath.Join(gitDir, "subdir", "file2.txt"))
+	fstest.WriteToFile(t, []byte("123"), filepath.Join(gitDir, "sub", "subdir", "file.txt"))
+
+	gittest.CreateRepository(t, gitDir)
+	gittest.CommitFilesToGit(t, gitDir)
+
+	gitResolver := &gitpath.Resolver{}
+	globResolver := &glob.Resolver{}
+
+	testPatterns := []string{
+		filepath.Join("sub", "**"),
+		"subdir*",
+		filepath.Join("subdir", "*"),
+		filepath.Join("subdir", "file*"),
+		filepath.Join("subdir", "file?.txt"),
+	}
+
+	for _, pattern := range testPatterns {
+		t.Run(pattern, func(t *testing.T) {
+			gitResult, err := gitResolver.Resolve(gitDir, false, pattern)
+			require.NoError(t, err, "gitresolver failed")
+
+			globResult, err := globResolver.Resolve(filepath.Join(gitDir, pattern))
+			require.NoError(t, err, "globresolver failed")
+
+			assert.ElementsMatch(t, gitResult, globResult, "gitpath and glob resolver did not resolve to same files for same pattern")
+		})
+	}
+}

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -80,14 +80,17 @@ func CommitID(dir string) (string, error) {
 }
 
 // LsFiles runs git ls-files in dir, passes args as argument and returns the
-// output.
-// If no files match and errorUnmatch is true, ErrNotExist is returned
-func LsFiles(dir string, errorUnmatch bool, arg ...string) (string, error) {
-	args := append([]string{"-c", "core.quotepath=off", "ls-files"}, arg...)
-
-	if errorUnmatch {
-		args = append(args, "--error-unmatch")
-	}
+// output. If a patchspec matches no files ErrNotExist is returned.
+// All pathspecs are treated literally, globs are not resolved.
+func LsFiles(dir string, pathspec ...string) (string, error) {
+	args := append(
+		[]string{
+			"--noglob-pathspecs",
+			"-c", "core.quotepath=off",
+			"ls-files",
+			"--error-unmatch",
+		},
+		pathspec...)
 
 	res, err := exec.Command("git", args...).Directory(dir).Run()
 	if err != nil {


### PR DESCRIPTION
The Glob and GitPath resolvers were processing patterns differently.
For example when a '*' was used as path in the Input.GitFiles section it also matched
directory separators, when '*' was used as path in the Input.Files section it
did not match directory separators.

Ensure paths are resolved the same by resolving globs for both resolvers via fs.Glob().
The GitPath resolver is then passing the paths to "git ls-files" to check if
they are committed to the repository. The "--noglob-pathspecs" parameter is
passed to "git ls-files" to treat all paths literally.

Closes #121
Closes #113 