### PR TITLE
Smaller misc improvements

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -171,6 +171,10 @@ func (c *runCmd) run(cmd *cobra.Command, args []string) {
 		// the closure is executed
 		ptCopy := pt
 		c.uploadRoutinePool.Queue(func() {
+			// all outputs and uploads of the task are done in the same goroutine, serialized,
+			// this is fine because we always only use a
+			// uploadRoutinePool with 1 worker to run uploads in
+			// parallel only with builds, uploads are not done in parallel
 			c.uploadAndRecord(ctx, ptCopy.task, ptCopy.inputs, outputs, runResult)
 		})
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -243,9 +243,6 @@ func (c *runCmd) uploadAndRecord(
 				size, err := o.Size()
 				exitOnErrf(err, "%s: %s:", task.ID(), output)
 
-				term.FormatDuration(
-					result.Stop.Sub(result.Start),
-				)
 				bps := uint64(math.Round(float64(size) / result.Stop.Sub(result.Start).Seconds()))
 
 				stdout.TaskPrintf(task, "%s uploaded to %s (%s/s)\n",

--- a/output.go
+++ b/output.go
@@ -42,11 +42,7 @@ func dockerOutputs(dockerClient DockerInfoClient, task *Task) ([]Output, error) 
 		uploadInfos := make([]*UploadInfoDocker, 0, len(dockerOutput.RegistryUpload))
 
 		for _, ru := range dockerOutput.RegistryUpload {
-			uploadInfos = append(uploadInfos, &UploadInfoDocker{
-				Registry:   ru.Registry,
-				Repository: ru.Repository,
-				Tag:        ru.Tag,
-			})
+			uploadInfos = append(uploadInfos, &UploadInfoDocker{&ru})
 		}
 
 		d, err := NewOutputDockerImageFromIIDFile(
@@ -55,7 +51,6 @@ func dockerOutputs(dockerClient DockerInfoClient, task *Task) ([]Output, error) 
 			filepath.Join(task.Directory, dockerOutput.IDFile),
 			uploadInfos,
 		)
-
 		if err != nil {
 			return nil, err
 		}
@@ -78,14 +73,11 @@ func fileOutputs(task *Task) ([]Output, error) {
 		}
 
 		for _, s3 := range fileOutput.S3Upload {
-			s3Uploads = append(s3Uploads, &UploadInfoS3{
-				Bucket: s3.Bucket,
-				Key:    s3.Key,
-			})
+			s3Uploads = append(s3Uploads, &UploadInfoS3{&s3})
 		}
 
 		for _, fc := range fileOutput.FileCopy {
-			fileCopyUploads = append(fileCopyUploads, &UploadInfoFileCopy{DestinationPath: fc.Path})
+			fileCopyUploads = append(fileCopyUploads, &UploadInfoFileCopy{&fc})
 		}
 
 		result = append(result, NewOutputFile(

--- a/outputdockerimage.go
+++ b/outputdockerimage.go
@@ -14,11 +14,11 @@ type DockerInfoClient interface {
 
 // OutputDockerImage is a docker image artifact.
 type OutputDockerImage struct {
-	name              string
-	ImageID           string
-	UploadDestination []*UploadInfoDocker // TODO: rename to plural form
-	dockerClient      DockerInfoClient
-	digest            *digest.Digest
+	name               string
+	ImageID            string
+	UploadDestinations []*UploadInfoDocker
+	dockerClient       DockerInfoClient
+	digest             *digest.Digest
 }
 
 func NewOutputDockerImageFromIIDFile(
@@ -38,11 +38,11 @@ func NewOutputDockerImageFromIIDFile(
 	}
 
 	return &OutputDockerImage{
-		name:              name,
-		dockerClient:      dockerClient,
-		ImageID:           id,
-		UploadDestination: uploadDest,
-		digest:            digest,
+		name:               name,
+		dockerClient:       dockerClient,
+		ImageID:            id,
+		UploadDestinations: uploadDest,
+		digest:             digest,
 	}, nil
 }
 

--- a/uploader.go
+++ b/uploader.go
@@ -1,6 +1,7 @@
 package baur
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -49,7 +50,7 @@ func (u *Uploader) Upload(output Output, uploadStartCb UploadStartFn, resultCb U
 	switch o := output.(type) {
 	case *OutputDockerImage:
 		if o.UploadDestination == nil {
-			break
+			return errors.New("uploadDestination is nil")
 		}
 
 		for _, dest := range o.UploadDestination {

--- a/uploader.go
+++ b/uploader.go
@@ -49,11 +49,11 @@ type UploadResultFn func(Output, *UploadResult)
 func (u *Uploader) Upload(output Output, uploadStartCb UploadStartFn, resultCb UploadResultFn) error {
 	switch o := output.(type) {
 	case *OutputDockerImage:
-		if o.UploadDestination == nil {
+		if o.UploadDestinations == nil {
 			return errors.New("uploadDestination is nil")
 		}
 
-		for _, dest := range o.UploadDestination {
+		for _, dest := range o.UploadDestinations {
 			uploadStartCb(o, dest)
 
 			result, err := u.DockerImage(o, dest)

--- a/uploader.go
+++ b/uploader.go
@@ -118,7 +118,7 @@ func (u *Uploader) DockerImage(o *OutputDockerImage, dest *UploadInfoDocker) (*U
 func (u *Uploader) FileCopy(o *OutputFile, dest *UploadInfoFileCopy) (*UploadResult, error) {
 	startTime := time.Now()
 
-	destFile := filepath.Join(dest.DestinationPath, filepath.Base(o.AbsPath))
+	destFile := filepath.Join(dest.Path, filepath.Base(o.AbsPath))
 
 	url, err := u.filecopyUploader.Upload(o.AbsPath, destFile)
 	if err != nil {

--- a/uploadinfo.go
+++ b/uploadinfo.go
@@ -1,6 +1,10 @@
 package baur
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/simplesurance/baur/v1/cfg"
+)
 
 type UploadMethod int
 
@@ -16,8 +20,7 @@ type UploadInfo interface {
 }
 
 type UploadInfoS3 struct {
-	Bucket string
-	Key    string
+	*cfg.S3Upload
 }
 
 func (s *UploadInfoS3) Method() UploadMethod {
@@ -29,9 +32,7 @@ func (s *UploadInfoS3) String() string {
 }
 
 type UploadInfoDocker struct {
-	Registry   string
-	Repository string
-	Tag        string
+	*cfg.DockerImageRegistryUpload
 }
 
 func (d *UploadInfoDocker) Method() UploadMethod {
@@ -47,7 +48,7 @@ func (d *UploadInfoDocker) String() string {
 }
 
 type UploadInfoFileCopy struct {
-	DestinationPath string
+	*cfg.FileCopy
 }
 
 func (f *UploadInfoFileCopy) Method() UploadMethod {
@@ -55,5 +56,5 @@ func (f *UploadInfoFileCopy) Method() UploadMethod {
 }
 
 func (f *UploadInfoFileCopy) String() string {
-	return f.DestinationPath
+	return f.Path
 }

--- a/uploadinfo.go
+++ b/uploadinfo.go
@@ -15,16 +15,11 @@ const (
 )
 
 type UploadInfo interface {
-	Method() UploadMethod
 	String() string
 }
 
 type UploadInfoS3 struct {
 	*cfg.S3Upload
-}
-
-func (s *UploadInfoS3) Method() UploadMethod {
-	return UploadMethodS3
 }
 
 func (s *UploadInfoS3) String() string {
@@ -33,10 +28,6 @@ func (s *UploadInfoS3) String() string {
 
 type UploadInfoDocker struct {
 	*cfg.DockerImageRegistryUpload
-}
-
-func (d *UploadInfoDocker) Method() UploadMethod {
-	return UploadMethodDocker
 }
 
 func (d *UploadInfoDocker) String() string {
@@ -49,10 +40,6 @@ func (d *UploadInfoDocker) String() string {
 
 type UploadInfoFileCopy struct {
 	*cfg.FileCopy
-}
-
-func (f *UploadInfoFileCopy) Method() UploadMethod {
-	return UploadMethodFilecopy
 }
 
 func (f *UploadInfoFileCopy) String() string {


### PR DESCRIPTION
```
        outputdockerimage: rename field UploadDestination field to plural form

        it stores multiple entries, not one

-------------------------------------------------------------------------------
        uploader: return an error when UploadDestination is nil

        The field should never be nil for an OutputDockerImage.

-------------------------------------------------------------------------------
        uploadinfo: remove unused method Method() from UploadInfo interface

-------------------------------------------------------------------------------
        embed cfg struct containing upload informations instead duplicating fields

-------------------------------------------------------------------------------
        run: add comment explaining why all uploads for a task can run in same goroutine

-------------------------------------------------------------------------------
        run: remove useless function call

        term.FormatDuration() is called but it's result was not used, remove the whole
        call

-------------------------------------------------------------------------------
```