### PR TITLE
gitpathresolver: fix: error was returned when not all files were git tracked + minor improvement

### DIFF
--- a/cfg/upgrade/v4/v4.go
+++ b/cfg/upgrade/v4/v4.go
@@ -34,7 +34,7 @@ func UpgradeIncludeConfig(old *cfgv0.Include) *cfg.Include {
 		in := &cfg.InputInclude{IncludeID: NewIncludeID}
 
 		if len(old.BuildInput.GitFiles.Paths) > 0 {
-			in.GitFiles = []cfg.GitFileInputs{{Paths: old.BuildInput.GitFiles.Paths}}
+			in.GitFiles = []cfg.GitFileInputs{{Paths: upgradeGitFilePaths(old.BuildInput.GitFiles.Paths)}}
 		}
 
 		if len(old.BuildInput.Files.Paths) > 0 {
@@ -103,6 +103,21 @@ func golangSourcesPathsToQuery(paths []string) []string {
 	return result
 }
 
+func upgradeGitFilePaths(paths []string) []string {
+	result := make([]string, 0, len(paths))
+
+	for _, p := range paths {
+		if p == "." {
+			result = append(result, "**")
+			continue
+		}
+
+		result = append(result, p)
+	}
+
+	return result
+}
+
 // UpgradeAppConfig converts a version 4 app config to version 5.
 // Includes are not upgrades, NewIncludeID is appened to include references.
 func UpgradeAppConfig(old *cfgv0.App) *cfg.App {
@@ -120,7 +135,7 @@ func UpgradeAppConfig(old *cfgv0.App) *cfg.App {
 	}
 
 	if len(old.Build.Input.GitFiles.Paths) > 0 {
-		task.Input.GitFiles = []cfg.GitFileInputs{{Paths: old.Build.Input.GitFiles.Paths}}
+		task.Input.GitFiles = []cfg.GitFileInputs{{Paths: upgradeGitFilePaths(old.Build.Input.GitFiles.Paths)}}
 	}
 
 	if len(old.Build.Input.GolangSources.Environment) > 0 || len(old.Build.Input.GolangSources.Paths) > 0 {

--- a/internal/resolve/gitpath/gitpaths.go
+++ b/internal/resolve/gitpath/gitpaths.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/simplesurance/baur/v1/internal/fs"
 	"github.com/simplesurance/baur/v1/internal/vcs/git"
@@ -46,12 +45,11 @@ func (r *Resolver) Resolve(workingDir string, errorUnmatch bool, globs ...string
 		return resolvedPaths, nil
 	}
 
-	out, err := git.LsFiles(workingDir, resolvedPaths...)
+	relPaths, err := git.LsFiles(workingDir, resolvedPaths...)
 	if err != nil {
 		return nil, fmt.Errorf("git ls-files failed: %w", err)
 	}
 
-	relPaths := strings.Split(out, "\n")
 	res := make([]string, 0, len(relPaths))
 
 	for _, relPath := range relPaths {

--- a/internal/resolve/gitpath/gitpaths.go
+++ b/internal/resolve/gitpath/gitpaths.go
@@ -2,7 +2,6 @@ package gitpath
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/simplesurance/baur/v1/internal/fs"
@@ -11,59 +10,36 @@ import (
 
 // Resolver resolves one or more git glob paths in a git repository by running
 // git ls-files.
-// Glob paths are only resolved to files that are tracked in the repository.
+// Glob paths are only resolved to files that exist in the filesystem and are tracked in the repository.
 type Resolver struct{}
 
 // Resolve resolves the glob paths to absolute file paths by calling git ls-files.
 // workingDir must be a directory that is part of a Git repository.
-// If a resolved file does not exist an error is returned.
-func (r *Resolver) Resolve(workingDir string, errorUnmatch bool, globs ...string) ([]string, error) {
-	var resolvedPaths []string
-
-	for _, glob := range globs {
-		absGlob := filepath.Join(workingDir, glob)
-		// Globs are resolved via the same method then resolve/files
-		// uses. This ensures the same pattern resolves in the same way
-		// for both. git ls-files resolves '*` differently, it also matches directory seperators.
-		paths, err := fs.FileGlob(absGlob)
-		if err != nil {
-			return nil, fmt.Errorf("resolving %q failed: %w", absGlob, err)
-		}
-
-		if len(paths) == 0 {
-			if errorUnmatch {
-				return nil, fmt.Errorf("%q did not match any files: %w", absGlob, os.ErrNotExist)
-			}
-
-			continue
-		}
-
-		resolvedPaths = append(resolvedPaths, paths...)
+// glob must be relative to workingDir.
+// If a glob does not resolve to an existing file in the filesystem or the file
+// is not part of the git repository an empty slice is returned.
+func (r *Resolver) Resolve(workingDir, glob string) ([]string, error) {
+	absGlob := filepath.Join(workingDir, glob)
+	// Globs are resolved via the same method then resolve/files
+	// uses. This ensures the same pattern resolves in the same way
+	// for both. git ls-files resolves '*` differently, it also matches directory seperators.
+	paths, err := fs.FileGlob(absGlob)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q failed: %w", absGlob, err)
 	}
 
-	if len(resolvedPaths) == 0 {
-		return resolvedPaths, nil
+	if len(paths) == 0 {
+		return []string{}, nil
 	}
 
-	relPaths, err := git.LsFiles(workingDir, resolvedPaths...)
+	relPaths, err := git.LsFiles(workingDir, paths...)
 	if err != nil {
 		return nil, fmt.Errorf("git ls-files failed: %w", err)
 	}
 
 	res := make([]string, 0, len(relPaths))
-
 	for _, relPath := range relPaths {
 		absPath := filepath.Join(workingDir, relPath)
-
-		isFile, err := fs.IsFile(absPath)
-		if err != nil {
-			return nil, err
-		}
-
-		if !isFile {
-			continue
-		}
-
 		res = append(res, absPath)
 	}
 

--- a/internal/resolve/gitpath/gitpaths_test.go
+++ b/internal/resolve/gitpath/gitpaths_test.go
@@ -1,0 +1,33 @@
+package gitpath
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1/internal/exec"
+	"github.com/simplesurance/baur/v1/internal/log"
+	"github.com/simplesurance/baur/v1/internal/testutils/fstest"
+	"github.com/simplesurance/baur/v1/internal/testutils/gittest"
+)
+
+func TestGitPathResolverIgnoresUntrackedFiles(t *testing.T) {
+	log.StdLogger.SetOutput(log.NewTestLogOutput(t))
+	exec.DefaultDebugfFn = t.Logf
+
+	gitDir := t.TempDir()
+	gittest.CreateRepository(t, gitDir)
+
+	fstest.WriteToFile(t, []byte("123"), filepath.Join(gitDir, "subdir", "file1.txt"))
+	gittest.CommitFilesToGit(t, gitDir)
+
+	fstest.WriteToFile(t, []byte("123"), filepath.Join(gitDir, "subdir", "file2.txt"))
+
+	gitResolver := &Resolver{}
+	gitResult, err := gitResolver.Resolve(gitDir, filepath.Join("subdir", "*"))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{filepath.Join(gitDir, "subdir", "file1.txt")}, gitResult)
+}

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -41,7 +41,7 @@ func TestFilesAndGitFilesPatternBehaveTheSame(t *testing.T) {
 
 	for _, pattern := range testPatterns {
 		t.Run(pattern, func(t *testing.T) {
-			gitResult, err := gitResolver.Resolve(gitDir, false, pattern)
+			gitResult, err := gitResolver.Resolve(gitDir, pattern)
 			require.NoError(t, err, "gitresolver failed")
 
 			globResult, err := globResolver.Resolve(filepath.Join(gitDir, pattern))

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -80,15 +80,13 @@ func CommitID(dir string) (string, error) {
 }
 
 // LsFiles runs git ls-files in dir, passes args as argument and returns a list
-// of paths . If a patchspec matches no files ErrNotExist is returned.
-// All pathspecs are treated literally, globs are not resolved.
+// of paths. All pathspecs are treated literally, globs are not resolved.
 func LsFiles(dir string, pathspec ...string) ([]string, error) {
 	args := append(
 		[]string{
 			"--noglob-pathspecs",
 			"-c", "core.quotepath=off",
 			"ls-files",
-			"--error-unmatch",
 		},
 		pathspec...)
 


### PR DESCRIPTION
```
       cfg: replace "." Input.GitFile paths with "**"

        Because GitFile input path patterns are now resolved via fs.FileGlob()
        instead of via git, the path "." resolved to 0 files.
        Previously it resolved to all files in the current and all subdirectories.

        Change "." paths to "**" when configs are upgraded. "**" behaves the same then
        then "." previously.

-------------------------------------------------------------------------------
        gitpathresolver: fix: error was returned when not all files were git tracked

        When a glob like "*" was passed to the gitpathresolver and not all of the
        filepaths to that the glob resolved were tracked by git, an error was returned.

        This changed accidentally the previous behavior and is not wanted.
        The resolver should return only files that are in the filesystem **and** tracked
        by Git.

        This is fixed by running the resolver per entry in the Inputs.GitFiles.Path
        field in the app config and not passing "--error-unmatch" to git-ls files.
        The interface of the resolver is made more similar to the FilesResolver.
        It now accepts only a single path instead of a list.
        Checking if an error returned because a glob resolved to 0 files is also done in
        the caller instead of in the resolver.

-------------------------------------------------------------------------------
        git: return slice of files instead of output of the command

        git.LsFiles now splits output of ls-files into a slice of filepaths insteadf of
        returning the output of the command  as string.
        Previously the split was done in the caller, which did not make sense.

```