### PR TITLE
gosourceresolver: do not return files that are in the GOCACHE directory

### DIFF
--- a/internal/resolve/gosource/goenv.go
+++ b/internal/resolve/gosource/goenv.go
@@ -9,6 +9,7 @@ import (
 )
 
 type goEnv struct {
+	// GoCache is empty when the GOCACHE value is "off"
 	GoCache    string
 	GoModCache string
 	GoRoot     string
@@ -35,6 +36,10 @@ func getGoEnv(env []string) (*goEnv, error) {
 		return nil, fmt.Errorf("go env returned an GOROOT variable, the variable must be set")
 	}
 
+	if result.GoCache == "off" {
+		result.GoCache = ""
+	}
+
 	// the variables can contain e.g. trailing directory seperators, when
 	// they were set manually to such a value, to ensure this does not
 	// cause issues when using them for path replacements later, clean all
@@ -42,7 +47,10 @@ func getGoEnv(env []string) (*goEnv, error) {
 	result.GoModCache = filepath.Clean(result.GoModCache)
 	result.GoRoot = filepath.Clean(result.GoRoot)
 	result.GoPath = filepath.Clean(result.GoPath)
-	result.GoCache = filepath.Clean(result.GoCache)
+
+	if result.GoCache != "" {
+		result.GoCache = filepath.Clean(result.GoCache)
+	}
 
 	return &result, nil
 }

--- a/internal/resolve/gosource/goenv.go
+++ b/internal/resolve/gosource/goenv.go
@@ -9,6 +9,7 @@ import (
 )
 
 type goEnv struct {
+	GoCache    string
 	GoModCache string
 	GoRoot     string
 	GoPath     string
@@ -41,6 +42,7 @@ func getGoEnv(env []string) (*goEnv, error) {
 	result.GoModCache = filepath.Clean(result.GoModCache)
 	result.GoRoot = filepath.Clean(result.GoRoot)
 	result.GoPath = filepath.Clean(result.GoPath)
+	result.GoCache = filepath.Clean(result.GoCache)
 
 	return &result, nil
 }

--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -237,6 +237,11 @@ func withoutStdblibPackages(result *[]string, env *goEnv, paths []string) error 
 		if err != nil {
 			return err
 		}
+
+		if strings.Contains(abs, env.GoCache) {
+			continue
+		}
+
 		// use HasPrefix() + Replace() to ensure we only replace the
 		// path if is the prefix
 		if strings.HasPrefix(abs, env.GoModCache) {

--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -238,7 +238,7 @@ func withoutStdblibPackages(result *[]string, env *goEnv, paths []string) error 
 			return err
 		}
 
-		if strings.Contains(abs, env.GoCache) {
+		if strings.HasPrefix(abs, env.GoCache) {
 			continue
 		}
 

--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -238,7 +238,11 @@ func withoutStdblibPackages(result *[]string, env *goEnv, paths []string) error 
 			return err
 		}
 
-		if strings.HasPrefix(abs, env.GoCache) {
+		if len(env.GoCache) > 0 && strings.HasPrefix(abs, env.GoCache) {
+			continue
+		}
+
+		if strings.HasPrefix(abs, env.GoRoot) {
 			continue
 		}
 
@@ -246,10 +250,6 @@ func withoutStdblibPackages(result *[]string, env *goEnv, paths []string) error 
 		// path if is the prefix
 		if strings.HasPrefix(abs, env.GoModCache) {
 			abs = strings.Replace(abs, env.GoModCache, "$GOMODCACHE", 1)
-		}
-
-		if strings.HasPrefix(abs, env.GoRoot) {
-			continue
 		}
 
 		*result = append(*result, abs)

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -79,9 +79,66 @@ func CommitID(dir string) (string, error) {
 	return commitID, err
 }
 
+func splitArgs(args []string, maxArgStrLen int) [][]string {
+	var result [][]string
+
+	argSize := 0
+	for i, arg := range args {
+		argSize += len(arg)
+	}
+}
+
 // LsFiles runs git ls-files in dir, passes args as argument and returns a list
 // of paths. All pathspecs are treated literally, globs are not resolved.
 func LsFiles(dir string, pathspec ...string) ([]string, error) {
+	// The maximum size of arguments for exec() on windows is 32767, on
+	// linux it is 1/4 of the stack size which is much higher on most
+	// systems, on macOs it seems to be 256kb
+	// (https://go-review.googlesource.com/c/go/+/229317/3/src/cmd/go/internal/work/exec.go).
+	// 2048 is subtracted as recommended at
+	// https://www.in-ulm.de/~mascheck/various/argmax/ to have some
+	// (little) space for env vars.
+	// The size we use for args might be slightly higher because of the
+	// args that are prepended in lsFiles().  This does not really matter,
+	// cause the reservered space for env vars is only an estimate and much
+	// higher then needed  in most scenarios.
+	const maxArgs = 32767 - 2048
+	result := make([]string, 0, len(pathspec))
+
+	for len(pathspec) > 0 {
+		var paths []string
+
+		argSize := 0
+		for i, arg := range pathspec {
+			argSize += len(arg)
+			if argSize > maxArgs {
+				paths = pathspec[:i-1]
+				pathspec = pathspec[i-1:]
+
+				fmt.Println("SPLIT")
+				break
+			}
+		}
+
+		fmt.Printf("ARGSIZE: %d", argSize)
+		if argSize <= maxArgs {
+			// no split needed,
+			paths = pathspec
+			pathspec = nil
+		}
+
+		paths, err := lsFiles(dir, paths)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, paths...)
+	}
+
+	return result, nil
+}
+
+func lsFiles(dir string, pathspec []string) ([]string, error) {
 	args := append(
 		[]string{
 			"--noglob-pathspecs",
@@ -89,6 +146,7 @@ func LsFiles(dir string, pathspec ...string) ([]string, error) {
 			"ls-files",
 		},
 		pathspec...)
+	fmt.Printf("LSFILES ARG CNT: %d\n", len(args))
 
 	res, err := exec.Command("git", args...).Directory(dir).Run()
 	if err != nil {


### PR DESCRIPTION
When a go test already run before, the gosourceresolver was returning paths
from the local GOCACHE directory.

Do not return files that are in the GOCACHE directory. We only want to return
source code files. Files in GOCACHE depend on the source files and are
regenerated reproducible for the same source files. They do not need to be
tracked as inputs.


Closes #254 