### PR TITLE
git: fix: discovering input files fails with: argument list too long

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Preparing Test Environment
           command: |
-            choco install golang --version=1.15.4 -y
+            choco install golang --version=1.15.6 -y
             choco install postgresql12 --params '/Password:postgres' -y
             New-Item -ItemType Directory -Force -Path $Env:TEST_RESULTS
 

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -79,9 +79,66 @@ func CommitID(dir string) (string, error) {
 	return commitID, err
 }
 
+// splitArgs counts the number of characters in the elements of args.
+// If more characters then maxArgStrLen accumulated, a slice with all the
+// elements up to the current one is returned as the first return value.
+// The second return value are the remaining elements in args.
+// If less characters then maxArgStrLen are in args, then the unchanged args
+// slice is returned as first element, the second slice is an empty slice.
+func splitArgs(args []string, maxArgStrLen int) ([]string, []string) {
+	var argSize int
+
+	for i, arg := range args {
+		argSize += len(arg)
+		if argSize > maxArgStrLen {
+			return args[:i+1], args[i+1:]
+		}
+	}
+
+	return args, nil
+}
+
 // LsFiles runs git ls-files in dir, passes args as argument and returns a list
 // of paths. All pathspecs are treated literally, globs are not resolved.
 func LsFiles(dir string, pathspec ...string) ([]string, error) {
+	// The maximum size of arguments for exec() on windows is 32767, on
+	// linux it is 1/4 of the stack size which is much higher on most
+	// systems, on macOs it seems to be 256kb
+	// (https://go-review.googlesource.com/c/go/+/229317/3/src/cmd/go/internal/work/exec.go).
+	// 2048 is subtracted as recommended at
+	// https://www.in-ulm.de/~mascheck/various/argmax/ to have some
+	// (little) space for env vars.
+	// The size we use for args might be slightly higher because of the
+	// args that are prepended in lsFiles(). This does not really matter,
+	// cause the reserved space for env vars is only an estimate and much
+	// higher then needed in most scenarios.
+	const maxArgs = 32767 - 2048
+
+	return lsFilesArgSpl(maxArgs, dir, pathspec)
+}
+
+// lsFilesArgSpl exists to be able to test the functionality easier with a
+// smaller argSplitStrLen value.
+func lsFilesArgSpl(argSplitStrLen int, dir string, pathspec []string) ([]string, error) {
+	result := make([]string, 0, len(pathspec))
+
+	for len(pathspec) > 0 {
+		var paths []string
+
+		paths, pathspec = splitArgs(pathspec, argSplitStrLen)
+
+		paths, err := lsFiles(dir, paths)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, paths...)
+	}
+
+	return result, nil
+}
+
+func lsFiles(dir string, pathspec []string) ([]string, error) {
 	args := append(
 		[]string{
 			"--noglob-pathspecs",

--- a/internal/vcs/git/git_test.go
+++ b/internal/vcs/git/git_test.go
@@ -1,0 +1,69 @@
+package git
+
+// The inputresolver_test.go file contains further testcases that test the
+// functionality of the package.
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v1/internal/testutils/fstest"
+	"github.com/simplesurance/baur/v1/internal/testutils/gittest"
+)
+
+func TestSplitArgsMaxBiggerThenFirstElem(t *testing.T) {
+	testArgs := []string{"/etc/", "/tmp/"}
+
+	spl, remaining := splitArgs(testArgs, 2)
+	assert.EqualValues(t, []string{"/etc/"}, spl)
+	assert.EqualValues(t, []string{"/tmp/"}, remaining)
+
+	spl, remaining = splitArgs(remaining, 2)
+	assert.EqualValues(t, []string{"/tmp/"}, spl)
+	assert.Empty(t, remaining)
+
+}
+
+func TestSplitArgsMaxBiggerThenAll(t *testing.T) {
+	testArgs := []string{"/etc/", "/tmp/"}
+
+	spl, remaining := splitArgs(testArgs, 100)
+	assert.EqualValues(t, []string{"/etc/", "/tmp/"}, spl)
+	assert.Empty(t, remaining)
+}
+
+func TestSplitArgsMaxExact(t *testing.T) {
+	testArgs := []string{"/etc/", "/tmp/"}
+
+	spl, remaining := splitArgs(testArgs, 10)
+	assert.EqualValues(t, []string{"/etc/", "/tmp/"}, spl)
+	assert.Empty(t, remaining)
+}
+
+func TestLsFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	gittest.CreateRepository(t, tempDir)
+
+	fname1 := "hello.txt"
+	fname2 := "bye.txt"
+
+	fstest.WriteToFile(t, []byte("1"), filepath.Join(tempDir, fname1))
+	fstest.WriteToFile(t, []byte("2"), filepath.Join(tempDir, fname2))
+	gittest.CommitFilesToGit(t, tempDir)
+
+	for i := 1; i < len(fname1)+len(fname2)+2; i++ {
+		t.Run(fmt.Sprintf("maxArgs%d", i), func(t *testing.T) {
+			res, err := lsFilesArgSpl(1, tempDir, []string{fname1, fname2})
+			require.NoError(t, err)
+			require.ElementsMatch(
+				t,
+				[]string{fname1, fname2},
+				res,
+			)
+		})
+	}
+}


### PR DESCRIPTION
If a lot of files were resolved it could happen that running "git ls-files"
failed with: "/sbin/git: argument list too long".

When the length of the strings of the pathspecs slice that is passed to
git.LsFiles() exceeds a threshold, the function is now splitting the number of
arguments in smaller slices and invokes "git ls-files" for each of it.

As threshold "32767 - 2048" is chosen.
Windows has a limit of 32767
(https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553).

In the exec sycalls the array for the command line arguments and the environment
variables share the same limit. Therefore 2048 is subtracted to reserve some
space for environment variables (as recommended in
https://www.in-ulm.de/~mascheck/various/argmax/).
Modern Linux/Unix systems have a much higher limit for the argument size.

The issue can still happen depending on the OS, e.g. on older Linux systems or
Linux systems with a small stack size.
It's unlikely that baur is used on those system.
The only safe way to set the limit would be to evaluate the max. length during
runtime by running a command and extending the number of parameters until the
error happens. This seems to be over the top for the current usecases of baur.


Closes #256 