### PR TITLE
Improve error handling when discovering apps and tasks

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -46,7 +46,7 @@ func NewLoader(repoCfg *cfg.Repository, gitCommitIDFunc func() (string, error), 
 }
 
 // LoadTasks loads the tasks of apps that match the passed specifier.
-// Specifier format is <APP-SPEC>[.<TASK-SPEC>].
+// Specifier format is (<APP-SPEC>[.<TASK-SPEC>])|PATH
 // <APP-SPEC> is:
 //   - <APP-NAME> or
 //   - '*'

--- a/loader_specifiers.go
+++ b/loader_specifiers.go
@@ -3,6 +3,8 @@ package baur
 import (
 	"fmt"
 	"strings"
+
+	"github.com/simplesurance/baur"
 )
 
 type taskSpec struct {
@@ -44,6 +46,10 @@ func parseSpecs(specifiers []string) (*specs, error) {
 		if isAppDirectory(spec) {
 			result.appDirs = append(result.appDirs, spec)
 			continue
+		}
+
+		if spec == "." {
+			return nil, fmt.Errorf("current directory does not contain an %q file", baur.AppCfgFile)
 		}
 
 		if !strings.Contains(spec, ".") {


### PR DESCRIPTION
```
        fail if <app>.<taskname> was passed as an argument and app has no such task

        If as parameter a <app>.<task> was specified, fail if the app has no task that
        matches the names.
        So far it caused that "baur status" showed an empty list.

-------------------------------------------------------------------------------
        improve error message when "." is passed as arg and no .app.toml file exist

        When "." was passed as argument to e.g. "baur status" it failed with:
        'ERROR: could not find the following apps:'

        Improve the error message, print that the current directory does not contain an
        .app.toml file
```

Closes #253 