### PR TITLE
git: fix: LsFiles() returned empty string as path

### DIFF
--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -176,7 +176,12 @@ func lsFiles(dir string, pathspec []string) ([]string, error) {
 		return nil, res.ExpectSuccess()
 	}
 
-	paths := strings.Split(res.StrOutput(), "\n")
+	out := res.StrOutput()
+	if len(out) == 0 {
+		return []string{}, nil
+	}
+
+	paths := strings.Split(out, "\n")
 
 	return paths, nil
 }

--- a/internal/vcs/git/git_test.go
+++ b/internal/vcs/git/git_test.go
@@ -67,3 +67,18 @@ func TestLsFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestLsFilesNoOutputResolvesToNoPaths(t *testing.T) {
+	tempDir := t.TempDir()
+	gittest.CreateRepository(t, tempDir)
+
+	fname1 := "hello.txt"
+
+	fstest.WriteToFile(t, []byte("1"), filepath.Join(tempDir, fname1))
+	gittest.CommitFilesToGit(t, tempDir)
+
+	paths, err := LsFiles(tempDir, "*.txt")
+
+	require.NoError(t, err)
+	require.Empty(t, paths)
+}


### PR DESCRIPTION
If none of the passed pathspecs that were passed to git.LsFiles() matched files
tracked by the git repository, the function returned a slice with one empty
string element.
This caused that baur commands failed because no digest could be calculated for
the directory.