### PR TITLE
commands: improve usage output

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -42,10 +42,10 @@ List the difference of inputs between tasks or task-runs.
 
 An argument can either reference a task or a task-run.
 If a task is specified the current inputs of the task in the filesystem are
-compared. A task is specified in the format <APP-NAME>.<TASK-NAME>.
+compared. A task is specified in the format APP_NAME.TASK_NAME.
 A past task-run that was recorded in the database can be specified by:
 - it's run-id,
-- or by the git-like syntax <APP-NAME>.<TASK-NAME>^, the number of ^ characters
+- or by the git-like syntax APP_NAME.TASK_NAME^, the number of ^ characters
   specify the run-id, ^ refers the last recorded run, '^^' the run before the
   last, and so on
 
@@ -74,7 +74,7 @@ baur diff inputs calc.build calc.build^ - Compare current inputs and the one
 func newDiffInputsCmd() *diffInputsCmd {
 	cmd := diffInputsCmd{
 		Command: cobra.Command{
-			Use:     "inputs <APP-NAME>.<TASK-NAME>[^]...|<RUN-ID> <APP-NAME>.<TASK-NAME>[^]...|<RUN-ID>",
+			Use:     "inputs <APP_NAME.TASK_NAME[^]|RUN_ID>...",
 			Short:   "list inputs that differ between two task-runs",
 			Long:    strings.TrimSpace(diffInputslongHelp),
 			Example: strings.TrimSpace(diffInputsExample),
@@ -98,7 +98,7 @@ func newDiffInputsCmd() *diffInputsCmd {
 
 // diffArgs returns an error in the following scenarios:
 // - there is less than or greater than 2 args specified
-// - either arg is not in the format <APP-NAME>.<TASK-NAME> or a numeric value
+// - either arg is not in the format APP-NAME.TASK-AME> or a numeric value
 func diffArgs() cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -8,12 +8,23 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/simplesurance/baur/v1/internal/command/term"
 	"github.com/simplesurance/baur/v1/internal/format"
 	"github.com/simplesurance/baur/v1/internal/log"
 	"github.com/simplesurance/baur/v1/internal/vcs"
 	"github.com/simplesurance/baur/v1/pkg/baur"
 	"github.com/simplesurance/baur/v1/pkg/storage"
 	"github.com/simplesurance/baur/v1/pkg/storage/postgres"
+)
+
+var targetHelp = fmt.Sprintf(`%s is in the format %s
+Examples:
+- 'shop' matches all tasks of the app named shop
+- 'shop.*' or 'shop' matches all tasks of the app named shop
+- '*.build' matches tasks named build of all applications
+- '*.*' matches all tasks of all applications`,
+	term.Highlight("TARGET"),
+	term.Highlight("(APP_NAME|*)[.TASK_NAME|*]"),
 )
 
 // envVarPSQLURL contains the name of an environment variable in that the

--- a/internal/command/init_app.go
+++ b/internal/command/init_app.go
@@ -24,7 +24,7 @@ const initAppExample = `
 baur init app shop-ui	create an application config with the app name set to shop-ui`
 
 var initAppCmd = &cobra.Command{
-	Use:     "app [APP-NAME]",
+	Use:     "app [APP_NAME]",
 	Short:   "create an application config file in the current directory",
 	Long:    strings.TrimSpace(initAppLongHelp),
 	Example: strings.TrimSpace(initAppExample),

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -24,7 +24,7 @@ by setting the '%s' environment variable.`,
 	term.Highlight(envVarPSQLURL))
 
 var initDbCmd = &cobra.Command{
-	Use:     "db [POSTGRES-URL]",
+	Use:     "db [POSTGRES_URL]",
 	Short:   "create baur tables in a PostgreSQL database",
 	Example: strings.TrimSpace(initDbExample),
 	Long:    strings.TrimSpace(initDbLongHelp),

--- a/internal/command/init_include.go
+++ b/internal/command/init_include.go
@@ -21,7 +21,7 @@ Create an include config file.
 If no FILENAME argument is passed, the filename will be '` + defIncludeFilename + `'.`
 
 var initIncludeCmd = &cobra.Command{
-	Use:   "include [<FILENAME>]",
+	Use:   "include [FILENAME]",
 	Short: "create an include config file",
 	Long:  strings.TrimSpace(initIncludeLongHelp),
 	Run:   initInclude,

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -36,7 +36,7 @@ type lsAppsCmd struct {
 func newLsAppsCmd() *lsAppsCmd {
 	cmd := lsAppsCmd{
 		Command: cobra.Command{
-			Use:   "apps [<APP-NAME>|<PATH>]...",
+			Use:   "apps [APP_NAME|APP_DIR]...",
 			Short: "list applications",
 			Args:  cobra.ArbitraryArgs,
 		},

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -30,7 +30,7 @@ type lsInputsCmd struct {
 func newLsInputsCmd() *lsInputsCmd {
 	cmd := lsInputsCmd{
 		Command: cobra.Command{
-			Use:   "inputs (<APP-NAME>.<TASK-NAME>)|<TASK-RUN-ID>",
+			Use:   "inputs APP_NAME.TASK_NAME|RUN_ID APP_NAME.TASK_NAME|RUN_ID",
 			Short: "list inputs of a task or task run",
 			Args:  cobra.ExactArgs(1),
 		},

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -28,7 +28,7 @@ func init() {
 func newLsOutputsCmd() *lsOutputsCmd {
 	cmd := lsOutputsCmd{
 		Command: cobra.Command{
-			Use:   "outputs <TASK-RUN-ID>",
+			Use:   "outputs <RUN_ID>",
 			Short: "list outputs of a task run",
 			Args:  cobra.ExactArgs(1),
 		},
@@ -52,7 +52,7 @@ func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
 
 	taskRunID, err := strconv.Atoi(args[0])
 	if err != nil {
-		stderr.Printf("'%s' is not a numeric task run ID", args[0])
+		stderr.Printf("'%s' is not a numeric task run ID\n", args[0])
 		exitFunc(1)
 	}
 

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -19,7 +19,7 @@ const lsRunsLongHelp = `
 List recorded task runs.
 
 Arguments:
-	'*' can be passed as <APP-NAME> or <TASK-NAME> argument to match
+	'*' can be passed as APP_NAME or TASK_NAME argument to match
 	all Apps or Tasks.
 `
 
@@ -57,7 +57,7 @@ type lsRunsCmd struct {
 func newLsRunsCmd() *lsRunsCmd {
 	cmd := lsRunsCmd{
 		Command: cobra.Command{
-			Use:     "runs <APP-NAME>[.<TASK-NAME>]",
+			Use:     "runs <APP_NAME[.TASK_NAME]>",
 			Short:   "list recorded task runs",
 			Long:    strings.TrimSpace(lsRunsLongHelp),
 			Example: strings.TrimSpace(lsRunsExample),

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -23,12 +23,17 @@ import (
 const runExample = `
 baur run auth				run all tasks of the auth application, upload the produced outputs
 baur run calc.check			run the check task of the calc application and upload the produced outputs
+baur run *.build			run all tasks named build of the all applications and upload the produced outputs
 baur run --force			run and upload all tasks of applications, independent of their status
 `
 
 var runLongHelp = fmt.Sprintf(`
 Execute tasks of applications.
-By default all tasks of all applications with status %s are run.
+
+If no argument is specified all tasks of all applications with status %s are run.
+
+Arguments:
+%s
 
 The following Environment Variables are supported:
     %s
@@ -45,6 +50,7 @@ The following Environment Variables are supported:
     %s
 `,
 	term.ColoredTaskStatus(baur.TaskStatusExecutionPending),
+	targetHelp,
 
 	term.Highlight(envVarPSQLURL),
 
@@ -83,7 +89,7 @@ type runCmd struct {
 func newRunCmd() *runCmd {
 	cmd := runCmd{
 		Command: cobra.Command{
-			Use:     "run [<SPEC>|<PATH>]...",
+			Use:     "run [TARGET|APP_DIR]...",
 			Short:   "run tasks",
 			Long:    runLongHelp,
 			Example: strings.TrimSpace(runExample),

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -21,7 +21,7 @@ Show information about an application or task run.
 
 If the name or path of an application directory is passed,
 application information are shown.
-If a numeric task-run ID is passed, information about the
+If a numeric task run ID is passed, information about the
 recorded task run are shown.
 `
 
@@ -43,7 +43,7 @@ type showCmd struct {
 func newShowCmd() *showCmd {
 	cmd := showCmd{
 		Command: cobra.Command{
-			Use:     "show <APP-NAME>|<APP-PATH>|<APP-NAME.TASK-NAME>|<TASK-RUN-ID>",
+			Use:     "show <APP_DIR|APP_NAME[.TASK_NAME]|RUN_ID>",
 			Short:   "show information about apps or recorded task runs",
 			Args:    cobra.ExactArgs(1),
 			Long:    strings.TrimSpace(showLongHelp),

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -28,6 +28,13 @@ const (
 	statusGitCommitParam  = "git-commit"
 )
 
+var statusLongHelp = fmt.Sprintf(
+	`List the task status in the repository.
+
+Arguments:
+%s`,
+	targetHelp)
+
 func init() {
 	rootCmd.AddCommand(&newStatusCmd().Command)
 }
@@ -47,8 +54,9 @@ type statusCmd struct {
 func newStatusCmd() *statusCmd {
 	cmd := statusCmd{
 		Command: cobra.Command{
-			Use:   "status [<SPEC>|<PATH>]...",
+			Use:   "status [TARGET|APP_DIR]...",
 			Short: "list status of tasks",
+			Long:  statusLongHelp,
 			Args:  cobra.ArbitraryArgs,
 		},
 


### PR DESCRIPTION
- rename the SPEC argument to TARGET and document it in the long help output of
  "baur run" and "baur status"
- in the usage output use angel-brackets only for required arguments, this is
  the standard according to https://en.wikipedia.org/wiki/Usage_message
- Use an underscore instead of a hyphen to separate words in usage argument
  specifiers