### PR TITLE
inputresolver: fix: paths skipped in slice if previous elemen did not exist

### DIFF
--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -91,7 +91,7 @@ func (i *InputResolver) resolveFileInputs(appDir string, inputs []cfg.FileInputs
 
 			if err != nil {
 				if in.Optional && errors.Is(err, os.ErrNotExist) {
-					return result, nil
+					continue
 				}
 
 				return nil, err

--- a/pkg/baur/inputresolver_test.go
+++ b/pkg/baur/inputresolver_test.go
@@ -293,3 +293,27 @@ func TestFilesOptional(t *testing.T) {
 		})
 	}
 }
+
+func TestPathsAfterMissingOptionalOneAreNotIgnored(t *testing.T) {
+	const fname = "hello"
+
+	tempDir := t.TempDir()
+	r := NewCachingInputResolver()
+	fstest.WriteToFile(t, []byte("123"), filepath.Join(tempDir, fname))
+
+	result, err := r.Resolve(context.Background(), tempDir, &Task{
+		Directory: tempDir,
+		UnresolvedInputs: &cfg.Input{
+			Files: []cfg.FileInputs{
+				{
+					Paths:    []string{"doesnotexist", fname},
+					Optional: true,
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, fname, result[0].String())
+}


### PR DESCRIPTION
If a FileInput list was defined as optional and one element resolved to 0 files
all following elements in the list were skipped and not resolved to any files.

Continue resolving the following element in the slice instead of returning from
the function