### PR TITLE
Small improvements, address most TODO notes

### DIFF
--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -39,7 +39,10 @@ func init() {
 func initDb(cmd *cobra.Command, args []string) {
 	var dbURL string
 
-	if len(args) == 0 {
+	if len(args) == 1 {
+		dbURL = args[0]
+	} else {
+
 		repo, err := findRepository()
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -53,9 +56,7 @@ func initDb(cmd *cobra.Command, args []string) {
 			exitFunc(1)
 		}
 
-		dbURL = repo.Cfg.Database.PGSQLURL
-	} else {
-		dbURL = args[0]
+		dbURL = mustGetPSQLURI(repo.Cfg)
 	}
 
 	storageClt, err := newStorageClient(dbURL)

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -53,7 +53,7 @@ func initDb(cmd *cobra.Command, args []string) {
 			exitFunc(1)
 		}
 
-		dbURL = repo.PSQLURL
+		dbURL = repo.Cfg.Database.PGSQLURL
 	} else {
 		dbURL = args[0]
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -211,8 +211,6 @@ func (c *runCmd) runTask(task *baur.Task) *baur.RunResult {
 			result.ExitCode,
 			result.StrOutput())
 
-		// TODO: record the result as failed if run exitCode is != 0
-		// except when a flag like --errors-are-fatal is passed
 		exitFunc(1)
 	}
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -79,7 +79,6 @@ func newStatusCmd() *statusCmd {
 	cmd.Flags().BoolVar(&cmd.absPaths, "abs-path", false,
 		"Show absolute instead of relative paths")
 
-	// TODO: refactor buildStatus struct
 	cmd.Flags().VarP(&cmd.buildStatus, "status", "s",
 		cmd.buildStatus.Usage(term.Highlight))
 

--- a/pkg/baur/baur.go
+++ b/pkg/baur/baur.go
@@ -1,7 +1,7 @@
 package baur
 
-// AppCfgFile contains the name of application configuration files
+// AppCfgFile is the name of application configuration files
 const AppCfgFile = ".app.toml"
 
-// RepositoryCfgFile contains the name of the repository configuration file.
+// RepositoryCfgFile is the name of the repository configuration file.
 const RepositoryCfgFile = ".baur.toml"

--- a/pkg/baur/cfg_resolvers.go
+++ b/pkg/baur/cfg_resolvers.go
@@ -14,8 +14,8 @@ const (
 	gitCommitVarname = "{{ .gitcommit }}"
 )
 
-// DefaultAppCfgResolvers returns the default set of resolvers that is applied on application configs.
-func DefaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string, error)) resolver.Resolver {
+// defaultAppCfgResolvers returns the default set of resolvers that is applied on application configs.
+func defaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string, error)) resolver.Resolver {
 	return resolver.List{
 		&resolver.StrReplacement{Old: appVarName, New: appName},
 		&resolver.StrReplacement{Old: rootVarName, New: rootPath},

--- a/pkg/baur/cfg_resolvers.go
+++ b/pkg/baur/cfg_resolvers.go
@@ -35,17 +35,3 @@ func DefaultAppCfgResolvers(rootPath, appName string, gitCommitFn func() (string
 		&resolver.EnvVar{},
 	}
 }
-
-// IncludeCfgVarResolvers returns the default resolvers for variables in the
-// Includes field in config files.
-func IncludeCfgVarResolvers(rootPath, appName string) resolver.Resolver {
-	// TODO: do we really need to distinguish between resolvers for include directives and all other fields?
-	// We should be able to use the the same set of resolvers for all
-	// fields. If somebody wants to use {{ .gitcommit }} in their include
-	// path, they have to cope with it. :-)
-	return resolver.List{
-		&resolver.StrReplacement{Old: appVarName, New: appName},
-		&resolver.StrReplacement{Old: rootVarName, New: rootPath},
-		&resolver.EnvVar{},
-	}
-}

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -309,14 +309,13 @@ func (a *Loader) apps(specs *specs) ([]*App, error) {
 }
 
 func (a *Loader) fromCfg(appCfg *cfg.App) (*App, error) {
-	includeResolvers := IncludeCfgVarResolvers(a.repositoryRoot, appCfg.Name)
+	resolvers := DefaultAppCfgResolvers(a.repositoryRoot, appCfg.Name, a.gitCommitIDFunc)
 
-	err := appCfg.Merge(a.includeDB, includeResolvers)
+	err := appCfg.Merge(a.includeDB, resolvers)
 	if err != nil {
 		return nil, fmt.Errorf("merging includes failed: %w", err)
 	}
 
-	resolvers := DefaultAppCfgResolvers(a.repositoryRoot, appCfg.Name, a.gitCommitIDFunc)
 	err = appCfg.Resolve(resolvers)
 	if err != nil {
 		return nil, fmt.Errorf("resolving variables in config failed: %w", err)

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -165,7 +165,7 @@ func (a *Loader) allApps() ([]*App, error) {
 	result := make([]*App, 0, len(a.appConfigPaths))
 
 	for _, path := range a.appConfigPaths {
-		app, err := a.AppPath(path)
+		app, err := a.appPath(path)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", path, err)
 		}
@@ -186,14 +186,14 @@ func (a *Loader) allTasks(apps []*App) []*Task {
 	return result
 }
 
-// AppDirs load apps from the given directories.
-func (a *Loader) AppDirs(dirs ...string) ([]*App, error) {
+// appDirs load apps from the given directories.
+func (a *Loader) appDirs(dirs ...string) ([]*App, error) {
 	result := make([]*App, 0, len(dirs))
 
 	for _, dir := range dirs {
 		cfgPath := filepath.Join(dir, AppCfgFile)
 
-		app, err := a.AppPath(cfgPath)
+		app, err := a.appPath(cfgPath)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", cfgPath, err)
 		}
@@ -204,8 +204,8 @@ func (a *Loader) AppDirs(dirs ...string) ([]*App, error) {
 	return result, nil
 }
 
-// AppPath loads the app from the config file.
-func (a *Loader) AppPath(appConfigPath string) (*App, error) {
+// appPath loads the app from the config file.
+func (a *Loader) appPath(appConfigPath string) (*App, error) {
 	a.logger.Debugf("loader: loading app from %q", appConfigPath)
 
 	appConfigPath, err := filepath.Abs(appConfigPath)
@@ -290,7 +290,7 @@ func (a *Loader) apps(specs *specs) ([]*App, error) {
 	result := make([]*App, 0, len(specs.appDirs)+len(specs.appNames))
 
 	for _, path := range specs.appDirs {
-		apps, err := a.AppDirs(path)
+		apps, err := a.appDirs(path)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", path, err)
 		}
@@ -309,7 +309,7 @@ func (a *Loader) apps(specs *specs) ([]*App, error) {
 }
 
 func (a *Loader) fromCfg(appCfg *cfg.App) (*App, error) {
-	resolvers := DefaultAppCfgResolvers(a.repositoryRoot, appCfg.Name, a.gitCommitIDFunc)
+	resolvers := defaultAppCfgResolvers(a.repositoryRoot, appCfg.Name, a.gitCommitIDFunc)
 
 	err := appCfg.Merge(a.includeDB, resolvers)
 	if err != nil {

--- a/pkg/baur/repository.go
+++ b/pkg/baur/repository.go
@@ -15,8 +15,6 @@ type Repository struct {
 	CfgPath     string
 	Cfg         *cfg.Repository
 	SearchDepth int
-	// TODO: remove PSQLURL
-	PSQLURL string
 }
 
 // FindRepositoryCfg searches for a repository config file. The search starts in
@@ -58,7 +56,6 @@ func NewRepository(cfgPath string) (*Repository, error) {
 		CfgPath:     cfgPath,
 		Path:        repoPath,
 		SearchDepth: repoCfg.Discover.SearchDepth,
-		PSQLURL:     repoCfg.Database.PGSQLURL,
 	}
 
 	return &r, nil

--- a/pkg/baur/storage.go
+++ b/pkg/baur/storage.go
@@ -43,12 +43,12 @@ func StoreRun(
 		return -1, err
 	}
 
-	storageInputs, err := InputsToStorageInputs(inputs)
+	storageInputs, err := inputsToStorageInputs(inputs)
 	if err != nil {
 		return -1, err
 	}
 
-	storageOutputs, err := ToStorageOutputs(uploads)
+	storageOutputs, err := toStorageOutputs(uploads)
 	if err != nil {
 		return -1, err
 	}
@@ -71,7 +71,7 @@ func StoreRun(
 	return storer.SaveTaskRun(ctx, &tr)
 }
 
-func InputsToStorageInputs(inputs *Inputs) ([]*storage.Input, error) {
+func inputsToStorageInputs(inputs *Inputs) ([]*storage.Input, error) {
 	result := make([]*storage.Input, 0, len(inputs.Inputs()))
 
 	for _, in := range inputs.Inputs() {
@@ -90,7 +90,7 @@ func InputsToStorageInputs(inputs *Inputs) ([]*storage.Input, error) {
 	return result, nil
 }
 
-func ToStorageOutputs(uploadResults []*UploadResult) ([]*storage.Output, error) {
+func toStorageOutputs(uploadResults []*UploadResult) ([]*storage.Output, error) {
 	resultMap := make(map[Output]*storage.Output)
 
 	for _, uploadResult := range uploadResults {

--- a/pkg/cfg/dockerimageoutput.go
+++ b/pkg/cfg/dockerimageoutput.go
@@ -2,8 +2,6 @@ package cfg
 
 import "github.com/simplesurance/baur/v1/pkg/cfg/resolver"
 
-//TODO: make RegistryUpload a pointer so we do not have to check if its empty
-
 // DockerImageOutput describes where a docker container is uploaded to.
 type DockerImageOutput struct {
 	IDFile         string                      `toml:"idfile" comment:"Path to a file that is created by the [Task.Command] and contains the image ID of the produced image (docker build --iidfile)."`

--- a/pkg/cfg/input.go
+++ b/pkg/cfg/input.go
@@ -36,7 +36,6 @@ func (in *Input) resolve(resolvers resolver.Resolver) error {
 			return fieldErrorWrap(err, "GoLangSources")
 		}
 
-		// TODO is this needed? If not why not?
 		in.GolangSources[i] = gs
 	}
 
@@ -56,8 +55,6 @@ func inputValidate(i InputDef) error {
 			return fieldErrorWrap(err, "GolangSources")
 		}
 	}
-
-	// TODO: add validation for gitfiles section
 
 	return nil
 }

--- a/pkg/cfg/inputinclude.go
+++ b/pkg/cfg/inputinclude.go
@@ -1,6 +1,8 @@
 package cfg
 
-import "github.com/simplesurance/baur/v1/internal/deepcopy"
+import (
+	"github.com/simplesurance/baur/v1/internal/deepcopy"
+)
 
 // InputInclude is a reusable Input definition.
 type InputInclude struct {
@@ -44,7 +46,7 @@ func (in *InputInclude) clone() *InputInclude {
 	var clone InputInclude
 
 	deepcopy.MustCopy(in, &clone)
-	// TODO why is filepath assignment manually and not cloned?
+	// filepath is assigned manually because filepath is a private field, MustCopy() only clones exported fields
 	clone.filepath = in.filepath
 
 	return &clone

--- a/pkg/storage/postgres/query_test.go
+++ b/pkg/storage/postgres/query_test.go
@@ -134,10 +134,6 @@ func TestOutputs_ReturnsErrNotExist(t *testing.T) {
 	assert.Nil(t, outputs)
 }
 
-// TODO: Write Tests for:
-// - Outputs()
-// - Inputs()
-
 func TestOutputs(t *testing.T) {
 	client, cleanupFn := newTestClient(t)
 	defer cleanupFn()


### PR DESCRIPTION
```
        unexport some function, improve godoc

-------------------------------------------------------------------------------
        cfg: do not use different set of variable resolvers for include fields

        For resolving variables in config files 2 different sets of resolvers were used:
        - for the "Includes" field in config only resolvers for ' {{ .app }, {{ .root }}
          and {{ .env <VARNAME> }}
        - all available for all other field

        Remove the exception for the "Includes" field, use the same set of resolvers
        then for all other fields. This simplifies the  code a bit and does not have any
        real disadvantages.

        This means {{ .gitcommit }} and  {{ .uuid }} variables can now be used in the
        "Include" field, there is no valid usecase for it though.

-------------------------------------------------------------------------------
        init db: fix: BAUR_POSTGRESQL_URL env variable is ignored

        Use the URL from the BAUR_POSTGRESQL_URL env variable if it is set and
        the url is not specified as commandline argument.

        The commands behavior is documented like this in the usage output but
        it was ignoring the BAUR_POSTGRESQL_URL env variable.

-------------------------------------------------------------------------------
        repository: remove duplicated PSQLURL field

        Remove the Repository.PSQLURL field.
        The information can be retrieved from Repository.Cfg instead.
        There is no reason to duplicate it.

-------------------------------------------------------------------------------
        remove obsolete todo notes

-------------------------------------------------------------------------------
        commands: improve usage output

        - rename the SPEC argument to TARGET and document it in the long help output of
          "baur run" and "baur status"
        - in the usage output use angel-brackets only for required arguments, this is
          the standard according to https://en.wikipedia.org/wiki/Usage_message
        - Use an underscore instead of a hyphen to separate words in usage argument
          specifiers
```