### PR TITLE
status: support to show the application name

### DIFF
--- a/internal/command/flag/buildstatus.go
+++ b/internal/command/flag/buildstatus.go
@@ -49,7 +49,7 @@ func (b *TaskStatus) Set(val string) error {
 
 // Type returns the format description of the flag
 func (b *TaskStatus) Type() string {
-	return "<STATUS>"
+	return "STATUS"
 }
 
 // Usage returns a usage description, important parts are passed through

--- a/internal/command/flag/datetime.go
+++ b/internal/command/flag/datetime.go
@@ -46,5 +46,5 @@ func (v *DateTimeFlagValue) Set(timeStr string) error {
 
 // Type returns the value description string
 func (*DateTimeFlagValue) Type() string {
-	return "<datetime>"
+	return "DATETIME"
 }

--- a/internal/command/flag/field.go
+++ b/internal/command/flag/field.go
@@ -83,7 +83,7 @@ func (f *Fields) Set(val string) error {
 		fieldStr := strings.TrimSpace(strings.ToLower(str))
 
 		if _, exist := f.supportedFields[fieldStr]; !exist {
-			return errors.New("<FIELD> must be one of " + f.ValidValues())
+			return errors.New("FIELD must be one of " + f.ValidValues())
 		}
 
 		setFields = append(setFields, fieldStr)
@@ -96,7 +96,7 @@ func (f *Fields) Set(val string) error {
 
 // Type returns the format description
 func (f *Fields) Type() string {
-	return "<FIELD>[,<FIELD>]..."
+	return "FIELD[,FIELD]..."
 }
 
 // Usage returns a usage description, important parts are passed through

--- a/internal/command/flag/sort.go
+++ b/internal/command/flag/sort.go
@@ -56,7 +56,7 @@ func (s *Sort) Set(sortStr string) error {
 
 // Type returns the format description
 func (s *Sort) Type() string {
-	return "<FIELD>-<ORDER>"
+	return "FIELD-ORDER"
 }
 
 // Usage returns a usage description, important parts are passed through
@@ -75,5 +75,5 @@ where %s is one of: %s,
 and %s one of: %s, %s`,
 		highlightFn(s.Type()),
 		highlightFn("FIELD"), strings.Join(fields, ", "),
-		highlightFn("<ORDER>"), highlightFn(storage.OrderAsc.String()), highlightFn(storage.OrderDesc.String())))
+		highlightFn("ORDER"), highlightFn(storage.OrderAsc.String()), highlightFn(storage.OrderDesc.String())))
 }

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -41,10 +41,16 @@ func newLsAppsCmd() *lsAppsCmd {
 			Args:  cobra.ArbitraryArgs,
 		},
 
-		fields: flag.NewFields([]string{
-			lsAppNameParam,
-			lsAppPathParam,
-		}),
+		fields: flag.MustNewFields(
+			[]string{
+				lsAppNameParam,
+				lsAppPathParam,
+			},
+			[]string{
+				lsAppNameParam,
+				lsAppPathParam,
+			},
+		),
 	}
 
 	cmd.Run = cmd.run

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -18,8 +18,8 @@ import (
 const (
 	statusAppNameHeader   = "Application Name"
 	statusAppNameParam    = "app-name"
-	statusNameHeader      = "Task ID"
-	statusNameParam       = "task-id"
+	statusTaskIDHeader    = "Task ID"
+	statusTaskIDParam     = "task-id"
 	statusPathHeader      = "Path"
 	statusPathParam       = "path"
 	statusStatusHeader    = "Status"
@@ -65,14 +65,14 @@ func newStatusCmd() *statusCmd {
 		fields: flag.MustNewFields(
 			[]string{
 				statusAppNameParam,
-				statusNameParam,
+				statusTaskIDParam,
 				statusPathParam,
 				statusRunIDParam,
 				statusStatusParam,
 				statusGitCommitParam,
 			},
 			[]string{
-				statusNameParam,
+				statusTaskIDParam,
 				statusPathParam,
 				statusRunIDParam,
 				statusStatusParam,
@@ -113,8 +113,8 @@ func (c *statusCmd) statusCreateHeader() []string {
 		switch f {
 		case statusAppNameParam:
 			headers = append(headers, statusAppNameHeader)
-		case statusNameParam:
-			headers = append(headers, statusNameHeader)
+		case statusTaskIDParam:
+			headers = append(headers, statusTaskIDHeader)
 		case statusPathParam:
 			headers = append(headers, statusPathHeader)
 		case statusStatusParam:
@@ -236,7 +236,7 @@ func (c *statusCmd) statusAssembleRow(repositoryDir string, task *baur.Task, tas
 		case statusAppNameParam:
 			row = append(row, task.AppName)
 
-		case statusNameParam:
+		case statusTaskIDParam:
 			row = append(row, task.ID())
 
 		case statusPathParam:

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -60,13 +60,22 @@ func newStatusCmd() *statusCmd {
 			Args:  cobra.ArbitraryArgs,
 		},
 
-		fields: flag.NewFields([]string{
-			statusNameParam,
-			statusPathParam,
-			statusRunIDParam,
-			statusStatusParam,
-			statusGitCommitParam,
-		}),
+		fields: flag.MustNewFields(
+			[]string{
+				statusNameParam,
+				statusPathParam,
+				statusRunIDParam,
+				statusStatusParam,
+				statusGitCommitParam,
+			},
+			[]string{
+				statusNameParam,
+				statusPathParam,
+				statusRunIDParam,
+				statusStatusParam,
+				statusGitCommitParam,
+			},
+		),
 	}
 	cmd.Run = cmd.run
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -16,6 +16,8 @@ import (
 )
 
 const (
+	statusAppNameHeader   = "Application Name"
+	statusAppNameParam    = "app-name"
 	statusNameHeader      = "Task ID"
 	statusNameParam       = "task-id"
 	statusPathHeader      = "Path"
@@ -62,6 +64,7 @@ func newStatusCmd() *statusCmd {
 
 		fields: flag.MustNewFields(
 			[]string{
+				statusAppNameParam,
 				statusNameParam,
 				statusPathParam,
 				statusRunIDParam,
@@ -108,6 +111,8 @@ func (c *statusCmd) statusCreateHeader() []string {
 
 	for _, f := range c.fields.Fields {
 		switch f {
+		case statusAppNameParam:
+			headers = append(headers, statusAppNameHeader)
 		case statusNameParam:
 			headers = append(headers, statusNameHeader)
 		case statusPathParam:
@@ -228,6 +233,9 @@ func (c *statusCmd) statusAssembleRow(repositoryDir string, task *baur.Task, tas
 
 	for _, f := range c.fields.Fields {
 		switch f {
+		case statusAppNameParam:
+			row = append(row, task.AppName)
+
 		case statusNameParam:
 			row = append(row, task.ID())
 

--- a/internal/command/upgrade_configs_test.go
+++ b/internal/command/upgrade_configs_test.go
@@ -57,7 +57,7 @@ func TestUpgrade(t *testing.T) {
 	stdoutBuf.Truncate(0)
 	statusCmd := newStatusCmd()
 	statusCmd.csv = true
-	statusCmd.fields = &flag.Fields{Fields: []string{statusNameParam}}
+	statusCmd.fields = &flag.Fields{Fields: []string{statusTaskIDParam}}
 	statusCmd.Command.Run(&statusCmd.Command, nil)
 
 	taskIDs := strings.Split(strings.TrimSpace(stdoutBuf.String()), "\n")


### PR DESCRIPTION
Add a new option for the "--fields" parameter of "baur status" to show the application name in the printed table.
By default the commands does not show the application name.
This required to support specifying different default values for the flag then the supported ones.
```

        usage: remove wrong angle-brackets in usage output

        angle-brackets should be only used for required parameters, remove using
        angle-brackets in the help output in other contexts

-------------------------------------------------------------------------------
        status: fix constants names storing task-id field option

        The constants names should make it clear to which cmdline parameter field option
        they belong.

        Rename:
                statusNameHeader -> statusTaskIDHeader
                statusNameParam -> statusTaskIDParam

-------------------------------------------------------------------------------
        status: support to show the application name

        Add a new option for the "--fields" parameter of "baur status" to show the
        application name in the printed table.

-------------------------------------------------------------------------------
        flags: support to specify a default value for flag fields

        The Fields flag now supports to specify it's initial default value.
        So far the default value was always the same then the supported fields.
        This allows to support fields for the "baur status" and "baur ls apps"
        command that are not shown by default.

        In the usage output the supported fields are now also always printed in the same
        order.
        Previously the order differed from invocation to invocation.

```