### PR TITLE
flags: show supported instead of enabled fields in fields flag usage

### DIFF
--- a/internal/command/flag/field.go
+++ b/internal/command/flag/field.go
@@ -102,8 +102,12 @@ func (f *Fields) Type() string {
 // Usage returns a usage description, important parts are passed through
 // highlightFn
 func (f *Fields) Usage(highlightFn func(a ...interface{}) string) string {
-	fields := make([]string, len(f.Fields))
-	copy(fields, f.Fields)
+	fields := make([]string, len(f.supportedFields))
+	for k := range f.supportedFields {
+		fields = append(fields, k)
+	}
+
+	sort.Strings(fields)
 
 	for i, f := range fields {
 		fields[i] = highlightFn(f)


### PR DESCRIPTION
The list of supported flags should be shown in the usage output, not the smaller
set of enabled fields.