### PR TITLE
upload: s3: use default S3ForcePathStyle setting

### DIFF
--- a/internal/upload/s3/s3.go
+++ b/internal/upload/s3/s3.go
@@ -34,10 +34,9 @@ func NewClient(logger Logger) (*Client, error) {
 	}
 
 	cfg := aws.Config{
-		Logger:           aws.LoggerFunc(logger.Debugln),
-		LogLevel:         loglvl,
-		MaxRetries:       aws.Int(DefaultRetries),
-		S3ForcePathStyle: aws.Bool(true),
+		Logger:     aws.LoggerFunc(logger.Debugln),
+		LogLevel:   loglvl,
+		MaxRetries: aws.Int(DefaultRetries),
 	}
 
 	sess, err := session.NewSession(&cfg)

--- a/internal/upload/s3/s3.go
+++ b/internal/upload/s3/s3.go
@@ -50,11 +50,9 @@ func NewClient(logger Logger) (*Client, error) {
 	}, nil
 }
 
-// Upload uploads a file to an s3 bucket, On success it returns the URL to the
+// Upload uploads a file to an s3 bucket, on success it returns the URL to the
 // file.
-// dest must be an URL in the format: s3://<bucket>/<filename>
 func (c *Client) Upload(filepath, bucket, key string) (string, error) {
-
 	f, err := os.Open(filepath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
```
        upload: s3: use default S3ForcePathStyle setting

        There is no reason to enable it, use the default setting

-------------------------------------------------------------------------------
        upload: s3: remove outdated information in godoc

```