### PR TITLE
upload: fix: uploadMethod stored in DB for S3 was FileCopy instead of S3

### DIFF
--- a/pkg/baur/uploader.go
+++ b/pkg/baur/uploader.go
@@ -146,7 +146,7 @@ func (u *Uploader) S3(o *OutputFile, dest *UploadInfoS3) (*UploadResult, error) 
 	return &UploadResult{
 		Start:  startTime,
 		Stop:   time.Now(),
-		Method: UploadMethodFilecopy,
+		Method: UploadMethodS3,
 		Output: o,
 		URL:    url,
 	}, nil


### PR DESCRIPTION
When an output was uploaded to S3, the UploadMethod stored in the database was
FileCopy instead of S3.