### PR TITLE
usage: fix fields flag documentation

### DIFF
--- a/internal/command/flag/field.go
+++ b/internal/command/flag/field.go
@@ -102,7 +102,7 @@ func (f *Fields) Type() string {
 // Usage returns a usage description, important parts are passed through
 // highlightFn
 func (f *Fields) Usage(highlightFn func(a ...interface{}) string) string {
-	fields := make([]string, len(f.supportedFields))
+	fields := make([]string, 0, len(f.supportedFields))
 	for k := range f.supportedFields {
 		fields = append(fields, k)
 	}


### PR DESCRIPTION
The usage output showed for flag fields documentation a text like:
	"where FIELD is one of: , , , , , , app-name, git-commit"

That those " ," character sequences are shown was introduced in commit f30a5a9.
A slice was accidentally preallocated with a size instead of a capacity
argument, this caused the empty slice elements.

