### PR TITLE
fix: upgrade configs might create empty S3 or filecopy output definitions

### DIFF
--- a/pkg/cfg/filecopy.go
+++ b/pkg/cfg/filecopy.go
@@ -16,3 +16,11 @@ func (f *FileCopy) resolve(resolvers resolver.Resolver) error {
 
 	return nil
 }
+
+func (f *FileCopy) validate() error {
+	if f.Path == "" {
+		return newFieldError("can not be empty", "path")
+	}
+
+	return nil
+}

--- a/pkg/cfg/fileoutput.go
+++ b/pkg/cfg/fileoutput.go
@@ -50,5 +50,12 @@ func (f *FileOutput) validate() error {
 		}
 	}
 
+	for _, fc := range f.FileCopy {
+		err := fc.validate()
+		if err != nil {
+			return fieldErrorWrap(err, "Filecopy")
+		}
+	}
+
 	return nil
 }

--- a/pkg/cfg/upgrade/v4/v4.go
+++ b/pkg/cfg/upgrade/v4/v4.go
@@ -79,15 +79,25 @@ func UpgradeIncludeConfig(old *cfgv0.Include) *cfg.Include {
 		}
 
 		for _, f := range old.BuildOutput.File {
-			output.File = append(output.File, cfg.FileOutput{
-				Path:     replaceVariables(f.Path),
-				FileCopy: []cfg.FileCopy{{Path: replaceVariables(f.FileCopy.Path)}},
-				S3Upload: []cfg.S3Upload{
+			var fc []cfg.FileCopy
+			var s3 []cfg.S3Upload
+
+			if f.FileCopy.Path != "" {
+				fc = []cfg.FileCopy{{Path: replaceVariables(f.FileCopy.Path)}}
+			}
+
+			if f.S3Upload.Bucket != "" {
+				s3 = []cfg.S3Upload{
 					{
 						Bucket: replaceVariables(f.S3Upload.Bucket),
 						Key:    replaceVariables(f.S3Upload.DestFile),
 					},
-				},
+				}
+			}
+			output.File = append(output.File, cfg.FileOutput{
+				Path:     replaceVariables(f.Path),
+				FileCopy: fc,
+				S3Upload: s3,
 			})
 		}
 


### PR DESCRIPTION
```
        upgrade configs: do not create empty S3 and FileCopy output definitions

-------------------------------------------------------------------------------
        cfg: add validation to ensure Filecopy.path fields are not empty

        If a Filecopy.path field is defined in a config to be an empty string, baur will
        now fail with an error.

---------------------------------------
```

This closes #275