### PR TITLE
Fix module in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/simplesurance/baur/v1
+module github.com/simplesurance/baur
 
 go 1.15
 


### PR DESCRIPTION
Currently trying to install baur using 
`go install github.com/simplesurance/baur@master`
Fails with the following error due to incorrect package name defined in go.mod
go install github.com/simplesurance/baur@master: github.com/simplesurance/baur@v0.16.1-0.20210316110754-e5ba6940fa93: invalid version: go.mod has malformed module path "github.com/simplesurance/baur/v1" at revision e5ba6940fa93