### PR TITLE
support to pass multiple --input-str parameters

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -34,7 +34,7 @@ type diffInputsCmd struct {
 
 	csv      bool
 	quiet    bool
-	inputStr string
+	inputStr []string
 }
 
 const diffInputslongHelp = `
@@ -90,8 +90,8 @@ func newDiffInputsCmd() *diffInputsCmd {
 	cmd.Flags().BoolVarP(&cmd.quiet, "quiet", "q", false,
 		"do not list the inputs that differ")
 
-	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
-		"include a string as input")
+	cmd.Flags().StringArrayVar(&cmd.inputStr, "input-str", nil,
+		"include a string as input, can be specified multiple times")
 
 	return &cmd
 }
@@ -211,7 +211,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 			os.Exit(1)
 		}
 
-		return baur.NewInputs(baur.InputAddStrIfNotEmpty(inputFiles, c.inputStr)), nil
+		return baur.NewInputs(append(baur.AsInputStrings(c.inputStr...), inputFiles...)), nil
 	}
 
 	taskRun := getTaskRun(repo, argDetails)
@@ -225,7 +225,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 	// Convert the inputs from the DB into baur.Input interface implementation
 	baurInputs := toBaurInputs(storageInputs)
 
-	return baur.NewInputs(baur.InputAddStrIfNotEmpty(baurInputs, c.inputStr)), taskRun
+	return baur.NewInputs(append(baur.AsInputStrings(c.inputStr...), baurInputs...)), taskRun
 }
 
 func getTaskRun(repo *baur.Repository, argDetails *diffInputArgDetails) *storage.TaskRunWithID {

--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -298,7 +298,7 @@ func TestCurrentInputsAgainstPreviousRunThatHasDifferentInputsReturnsExitCode2(t
 			doInitDb(t)
 
 			runCmd := newRunCmd()
-			runCmd.inputStr = "an_input"
+			runCmd.inputStr = []string{"an_input"}
 			runCmd.run(&runCmd.Command, []string{appOneWithBuildTask})
 
 			diffInputsCmd := newDiffInputsCmd()
@@ -333,7 +333,7 @@ func TestPreviousRunAgainstAnotherPreviousRunThatHasDifferentInputsReturnsExitCo
 
 			runCmd := newRunCmd()
 			runCmd.run(&runCmd.Command, []string{appOneWithBuildTask})
-			runCmd.inputStr = "an_input"
+			runCmd.inputStr = []string{"an_input"}
 			runCmd.run(&runCmd.Command, []string{appOneWithTestTask})
 
 			diffInputsCmd := newDiffInputsCmd()
@@ -367,11 +367,11 @@ func TestDifferencesOutputWithCorrectState(t *testing.T) {
 
 	originalDigest := r.WriteAdditionalFileContents(t, appOneName, fileName, "original")
 	runCmd := newRunCmd()
-	runCmd.inputStr = "run_one"
+	runCmd.inputStr = []string{"run_one"}
 	runCmd.run(&runCmd.Command, []string{appOneWithBuildTask})
 
 	newDigest := r.WriteAdditionalFileContents(t, appOneName, fileName, "new")
-	runCmd.inputStr = "run_two"
+	runCmd.inputStr = []string{"run_two"}
 	runCmd.run(&runCmd.Command, []string{appOneWithBuildTask})
 
 	stdoutBuf, _ := interceptCmdOutput(t)

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -24,7 +24,7 @@ type lsInputsCmd struct {
 	csv        bool
 	quiet      bool
 	showDigest bool
-	inputStr   string
+	inputStr   []string
 }
 
 func newLsInputsCmd() *lsInputsCmd {
@@ -47,8 +47,8 @@ func newLsInputsCmd() *lsInputsCmd {
 	cmd.Flags().BoolVar(&cmd.showDigest, "digests", false,
 		"show digests")
 
-	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
-		"include a string as input")
+	cmd.Flags().StringArrayVar(&cmd.inputStr, "input-str", nil,
+		"include a string as input, can be specified multiple times")
 
 	return &cmd
 }
@@ -57,7 +57,7 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 	var inputs []baur.Input
 
 	if taskID, err := strconv.Atoi(args[0]); err == nil {
-		if c.inputStr != "" {
+		if len(c.inputStr) != 0 {
 			stderr.Printf("--input-str can only be specified for task-names")
 			os.Exit(1)
 		}
@@ -65,7 +65,7 @@ func (c *lsInputsCmd) run(cmd *cobra.Command, args []string) {
 		inputs = c.mustGetTaskRunInputs(taskID)
 	} else {
 		inputs = c.mustGetTaskInputs(args[0])
-		inputs = baur.InputAddStrIfNotEmpty(inputs, c.inputStr)
+		inputs = append(inputs, baur.AsInputStrings(c.inputStr...)...)
 	}
 
 	sort.Slice(inputs, func(i, j int) bool {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -73,7 +73,7 @@ type runCmd struct {
 	// Cmdline parameters
 	skipUpload     bool
 	force          bool
-	inputStr       string
+	inputStr       []string
 	lookupInputStr string
 
 	// other fields
@@ -102,8 +102,8 @@ func newRunCmd() *runCmd {
 		"skip uploading task outputs and recording the run")
 	cmd.Flags().BoolVarP(&cmd.force, "force", "f", false,
 		"enforce running tasks independent of their status")
-	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
-		"include a string as an input")
+	cmd.Flags().StringArrayVar(&cmd.inputStr, "input-str", nil,
+		"include a string as input, can be specified multiple times")
 	cmd.Flags().StringVar(&cmd.lookupInputStr, "lookup-input-str", "",
 		"if a run can not be found, try to find a run with this value as input-string")
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -47,7 +47,7 @@ type statusCmd struct {
 	csv            bool
 	quiet          bool
 	absPaths       bool
-	inputStr       string
+	inputStr       []string
 	lookupInputStr string
 	buildStatus    flag.TaskStatus
 	fields         *flag.Fields
@@ -97,8 +97,8 @@ func newStatusCmd() *statusCmd {
 	cmd.Flags().VarP(cmd.fields, "fields", "f",
 		cmd.fields.Usage(term.Highlight))
 
-	cmd.Flags().StringVar(&cmd.inputStr, "input-str", "",
-		"include a string as input")
+	cmd.Flags().StringArrayVar(&cmd.inputStr, "input-str", nil,
+		"include a string as input, can be specified multiple times")
 
 	cmd.Flags().StringVar(&cmd.lookupInputStr, "lookup-input-str", "",
 		"if a run can not be found, try to find a run with this value as input-string")

--- a/pkg/baur/input.go
+++ b/pkg/baur/input.go
@@ -7,14 +7,3 @@ type Input interface {
 	Digest() (*digest.Digest, error)
 	String() string
 }
-
-// InputAddStrIfNotEmpty returns a new slice that contains in and str as an
-// InputString object, if str is not an empty string.
-// If it is, in is returned.
-func InputAddStrIfNotEmpty(in []Input, str string) []Input {
-	if str == "" {
-		return in
-	}
-
-	return append(in, NewInputString(str))
-}

--- a/pkg/baur/inputstring.go
+++ b/pkg/baur/inputstring.go
@@ -47,3 +47,14 @@ func (i *InputString) calcDigest() (*digest.Digest, error) {
 
 	return i.digest, nil
 }
+
+// AsInputStrings returns InputStrings for all elements in strs.
+func AsInputStrings(strs ...string) []Input {
+	result := make([]Input, 0, len(strs))
+
+	for _, s := range strs {
+		result = append(result, NewInputString(s))
+	}
+
+	return result
+}

--- a/pkg/baur/taskstatusevaluator.go
+++ b/pkg/baur/taskstatusevaluator.go
@@ -14,7 +14,7 @@ type TaskStatusEvaluator struct {
 	inputResolver *InputResolver
 	store         storage.Storer
 
-	inputStr       string
+	inputStr       []string
 	lookupInputStr string
 }
 
@@ -23,7 +23,7 @@ func NewTaskStatusEvaluator(
 	repositoryDir string,
 	store storage.Storer,
 	inputResolver *InputResolver,
-	inputStr string,
+	inputStr []string,
 	lookupInputStr string,
 ) *TaskStatusEvaluator {
 	return &TaskStatusEvaluator{
@@ -48,8 +48,7 @@ func (t *TaskStatusEvaluator) Status(ctx context.Context, task *Task) (TaskStatu
 		return TaskStatusUndefined, nil, nil, err
 	}
 
-	inputs := NewInputs(InputAddStrIfNotEmpty(inputFiles, t.inputStr))
-
+	inputs := NewInputs(append(AsInputStrings(t.inputStr...), inputFiles...))
 	taskStatus, run, err = t.getTaskStatus(ctx, inputs, task)
 	if err != nil {
 		return TaskStatusUndefined, nil, nil, err
@@ -59,7 +58,7 @@ func (t *TaskStatusEvaluator) Status(ctx context.Context, task *Task) (TaskStatu
 		return taskStatus, inputs, run, err
 	}
 
-	inputsLookupStr := NewInputs(append(inputFiles, NewInputString(t.lookupInputStr)))
+	inputsLookupStr := NewInputs(append(AsInputStrings(t.lookupInputStr), inputFiles...))
 	taskStatus, run, err = t.getTaskStatus(ctx, inputsLookupStr, task)
 	if err != nil {
 		return TaskStatusUndefined, nil, nil, err


### PR DESCRIPTION
The run, status, ls inputs, diff inputs commands now support to be passed multiple
"--input-str" parameters, each specified parameter is added as individual string
input.