### PR TITLE
storage: create unique input table index over URI md5 hash

### DIFF
--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -152,7 +152,7 @@ func insertInputIfNotExist(ctx context.Context, db dbConn, inputs []*storage.Inp
 	   VALUES
 `
 	const stmt2 = `
-	       ON CONFLICT ON CONSTRAINT input_uri_digest_uniq
+	       ON CONFLICT (MD5(uri), digest)
 	       DO UPDATE SET id=input.id
 	RETURNING id
 	`

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -65,9 +65,10 @@ CREATE TABLE task_run (
 CREATE TABLE input (
 	id serial PRIMARY KEY,
 	uri text NOT NULL,
-	digest text NOT NULL,
-	CONSTRAINT input_uri_digest_uniq UNIQUE (uri, digest)
+	digest text NOT NULL
 );
+
+CREATE UNIQUE INDEX input_uri_digest_uniq ON input (MD5(uri), digest);
 
 CREATE TABLE task_run_input (
 	task_run_id integer NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,


### PR DESCRIPTION
When very long "--input-strings" were passed to the "baur run" command, storing
the run in the database failed with:
	index row requires 10032 bytes, maximum size is 8191 (SQLSTATE 54000)

The input table has a unique constraint for the URI and digest field.
When very long input strings are used the 8181B limit for the size of a column
in the index is reached.

Use the md hash of the URI in the index instead of it's raw string value. This
prevents that we hit the limit.

Because only a -rc version was released for this version, no migrations will be
provided.
A 2.0.0-rc1 db can be migrated to use the new index manually via:
	ALTER TABLE input DROP CONSTRAINT input_uri_digest_uniq;
	CREATE UNIQUE INDEX input_uri_digest_uniq ON input (MD5(uri), digest);