### PR TITLE
diff inputs: add --input-string inputs only to first specified task/run

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -74,7 +74,7 @@ baur diff inputs calc.build calc.build^ - Compare current inputs and the one
 func newDiffInputsCmd() *diffInputsCmd {
 	cmd := diffInputsCmd{
 		Command: cobra.Command{
-			Use:     "inputs <APP_NAME.TASK_NAME[^]|RUN_ID>...",
+			Use:     "inputs <APP_NAME.TASK_NAME[^]|RUN_ID> <APP_NAME.TASK_NAME[^]|RUN_ID>",
 			Short:   "list inputs that differ between two task-runs",
 			Long:    strings.TrimSpace(diffInputslongHelp),
 			Example: strings.TrimSpace(diffInputsExample),

--- a/pkg/baur/inputs.go
+++ b/pkg/baur/inputs.go
@@ -23,6 +23,18 @@ func (in *Inputs) Inputs() []Input {
 	return in.inputs
 }
 
+// Add adds elements in inputs to in and returns *in
+func (in *Inputs) Add(inputs []Input) *Inputs {
+	if len(inputs) == 0 {
+		return in
+	}
+
+	in.inputs = append(in.inputs, inputs...)
+	in.digest = nil
+
+	return in
+}
+
 // Digest returns a summarized digest over all Inputs.
 // On the first call the digest is calculated, on subsequent calls the stored digest is returned.
 func (in *Inputs) Digest() (*digest.Digest, error) {


### PR DESCRIPTION
```
        diff inputs: add --input-string inputs only to first specified task/run

        When the "input-string" parameter was passed to "baur diff inputs", the input
        string was added to both targets that were specified.
        Both runs always had the additional input string and therefore could not differ
        regarding the string input.

        Change the behavior to addd the string input that is specified as parameter only
        to the first target specified by the arguments.

-------------------------------------------------------------------------------
        diff inputs: clarify arguments in usage description
```