### PR TITLE
storage: refactor input string representation

### DIFF
--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -93,7 +93,7 @@ func newLsRunsCmd() *lsRunsCmd {
 	cmd.Flags().StringVar(&cmd.input, "has-input", "",
 		fmt.Sprintf(
 			`Only show runs that have the given input.
-File inputs are specified their path.
+File inputs are specified by their repository relative path.
 String inputs are specified with a '%s' prefix, e.g. string:my_input_str.`,
 			term.Highlight("string:")),
 	)
@@ -242,11 +242,21 @@ func (c *lsRunsCmd) getFilters() []*storage.Filter {
 	}
 
 	if c.input != "" {
-		filters = append(filters, &storage.Filter{
-			Field:    storage.FieldInput,
-			Operator: storage.OpEQ,
-			Value:    c.input,
-		})
+
+		if strings.HasPrefix(c.input, "string:") {
+			filters = append(filters, &storage.Filter{
+				Field:    storage.FieldInputString,
+				Operator: storage.OpEQ,
+				Value:    strings.TrimPrefix(c.input, "string:"),
+			})
+		} else {
+			filters = append(filters, &storage.Filter{
+				Field:    storage.FieldInputFilePath,
+				Operator: storage.OpEQ,
+				Value:    c.input,
+			})
+		}
+
 	}
 
 	return filters

--- a/internal/command/ls_runs_test.go
+++ b/internal/command/ls_runs_test.go
@@ -1,0 +1,53 @@
+// +build dbtest
+
+package command
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v2/internal/testutils/repotest"
+)
+
+func TestLsRunsHasInput(t *testing.T) {
+	initTest(t)
+
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	app := r.CreateSimpleApp(t)
+	runInitDb(t)
+
+	taskID := fmt.Sprintf("%s.%s", app.Name, app.Tasks[0].Name)
+
+	runCmd := newRunCmd()
+	runCmd.inputStr = []string{"hello"}
+	runCmd.Command.Run(&runCmd.Command, []string{taskID})
+
+	stdoutBuf, _ := interceptCmdOutput(t)
+	lsRunsCmd := newLsRunsCmd()
+	lsRunsCmd.csv = true
+
+	relAppCfgPath, err := filepath.Rel(r.Dir, app.FilePath())
+	require.NoError(t, err)
+
+	lsRunsCmd.input = relAppCfgPath
+	lsRunsCmd.Run(&lsRunsCmd.Command, []string{taskID})
+	assert.Contains(t, stdoutBuf.String(), fmt.Sprintf("1,%s,%s,", app.Name, app.Tasks[0].Name))
+
+	lsRunsCmd.input = fmt.Sprintf("string:%s", runCmd.inputStr[0])
+	lsRunsCmd.Run(&lsRunsCmd.Command, []string{taskID})
+	assert.Contains(t, stdoutBuf.String(), fmt.Sprintf("1,%s,%s,", app.Name, app.Tasks[0].Name))
+
+	lsRunsCmd.input = "nonononodoesnotexist"
+	var cmdFailed bool
+
+	exitFunc = func(code int) {
+		cmdFailed = code != 0
+	}
+
+	lsRunsCmd.Run(&lsRunsCmd.Command, []string{taskID})
+	assert.True(t, cmdFailed)
+}

--- a/internal/command/storageinputwrapper.go
+++ b/internal/command/storageinputwrapper.go
@@ -1,28 +1,46 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/simplesurance/baur/v2/internal/digest"
 	"github.com/simplesurance/baur/v2/pkg/baur"
 	"github.com/simplesurance/baur/v2/pkg/storage"
 )
 
-type storageInput struct {
-	input *storage.Input
+type storageInputFile struct {
+	*storage.InputFile
 }
 
-func (i *storageInput) Digest() (*digest.Digest, error) {
-	return digest.FromString(i.input.Digest)
+func (i *storageInputFile) Digest() (*digest.Digest, error) {
+	return digest.FromString(i.InputFile.Digest)
 }
 
-func (i *storageInput) String() string {
-	return i.input.URI
+func (i *storageInputFile) String() string {
+	return i.InputFile.Path
 }
 
-func toBaurInputs(inputs []*storage.Input) []baur.Input {
-	result := make([]baur.Input, 0, len(inputs))
+type storageInputString struct {
+	*storage.InputString
+}
 
-	for _, in := range inputs {
-		result = append(result, &storageInput{input: in})
+func (i *storageInputString) Digest() (*digest.Digest, error) {
+	return digest.FromString(i.InputString.Digest)
+}
+
+func (i *storageInputString) String() string {
+	return fmt.Sprintf("string:%s", i.InputString.String)
+}
+
+func toBaurInputs(inputs *storage.Inputs) []baur.Input {
+	result := make([]baur.Input, 0, len(inputs.Files)+len(inputs.Strings))
+
+	for _, in := range inputs.Files {
+		result = append(result, &storageInputFile{InputFile: in})
+	}
+
+	for _, in := range inputs.Strings {
+		result = append(result, &storageInputString{InputString: in})
 	}
 
 	return result

--- a/pkg/baur/inputfile.go
+++ b/pkg/baur/inputfile.go
@@ -23,8 +23,13 @@ func NewInputFile(repoRootPath, relPath string) *Inputfile {
 	}
 }
 
-// String returns it's string representation
+// String returns RelPath()
 func (f *Inputfile) String() string {
+	return f.repoRelPath
+}
+
+// RelPath returns the path of the file relative to the baur repository root.
+func (f *Inputfile) RelPath() string {
 	return f.repoRelPath
 }
 

--- a/pkg/baur/inputstring.go
+++ b/pkg/baur/inputstring.go
@@ -9,13 +9,13 @@ import (
 
 // InputString represents a string
 type InputString struct {
-	Value  string
+	value  string
 	digest *digest.Digest
 }
 
 // NewInputString returns a new InputString
-func NewInputString(value string) *InputString {
-	return &InputString{Value: value}
+func NewInputString(val string) *InputString {
+	return &InputString{value: val}
 }
 
 // Digest returns the previous calculated digest.
@@ -29,16 +29,21 @@ func (i *InputString) Digest() (*digest.Digest, error) {
 	return i.calcDigest()
 }
 
-// String returns it's string representation
+// String returns it's string representation (string:VAL)
 func (i *InputString) String() string {
-	return fmt.Sprintf("string:%s", i.Value)
+	return fmt.Sprintf("string:%s", i.value)
+}
+
+// Value returns the string that the input represents.
+func (i *InputString) Value() string {
+	return i.value
 }
 
 // CalcDigest calculates the digest of the string, saves it and returns it.
 func (i *InputString) calcDigest() (*digest.Digest, error) {
 	sha := sha384.New()
 
-	err := sha.AddBytes([]byte(i.Value))
+	err := sha.AddBytes([]byte(i.value))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/baur/storage.go
+++ b/pkg/baur/storage.go
@@ -64,30 +64,38 @@ func StoreRun(
 			TotalInputDigest: totalDigest.String(),
 			Result:           result,
 		},
-		Inputs:  storageInputs,
+		Inputs:  *storageInputs,
 		Outputs: storageOutputs,
 	}
 
 	return storer.SaveTaskRun(ctx, &tr)
 }
 
-func inputsToStorageInputs(inputs *Inputs) ([]*storage.Input, error) {
-	result := make([]*storage.Input, 0, len(inputs.Inputs()))
+func inputsToStorageInputs(inputs *Inputs) (*storage.Inputs, error) {
+	var result storage.Inputs
 
 	for _, in := range inputs.Inputs() {
-		// TODO: rename storage.Input.URI to Name?
 		digest, err := in.Digest()
 		if err != nil {
 			return nil, fmt.Errorf("calculating digest of %q failed: %w", in, err)
 		}
 
-		result = append(result, &storage.Input{
-			URI:    in.String(),
-			Digest: digest.String(),
-		})
+		switch v := in.(type) {
+		case *Inputfile:
+			result.Files = append(result.Files, &storage.InputFile{
+				Path:   v.RelPath(),
+				Digest: digest.String(),
+			})
+
+		case *InputString:
+			result.Strings = append(result.Strings, &storage.InputString{
+				String: v.Value(),
+				Digest: digest.String(),
+			})
+		}
 	}
 
-	return result, nil
+	return &result, nil
 }
 
 func toStorageOutputs(uploadResults []*UploadResult) ([]*storage.Output, error) {

--- a/pkg/storage/filter.go
+++ b/pkg/storage/filter.go
@@ -17,7 +17,8 @@ const (
 	FieldDuration
 	FieldStartTime
 	FieldID
-	FieldInput
+	FieldInputString
+	FieldInputFilePath
 )
 
 func (f Field) String() string {
@@ -32,8 +33,8 @@ func (f Field) String() string {
 		return "FieldStartTime"
 	case FieldID:
 		return "FieldID"
-	case FieldInput:
-		return "FieldURI"
+	case FieldInputString:
+		return "FieldInputString"
 	default:
 		return "FieldUndefined"
 	}

--- a/pkg/storage/postgres/filters_sorters.go
+++ b/pkg/storage/postgres/filters_sorters.go
@@ -26,8 +26,10 @@ func columnName(f storage.Field) (string, error) {
 		return "start_timestamp", nil
 	case storage.FieldID:
 		return "task_run_id", nil
-	case storage.FieldInput:
-		return "uri", nil
+	case storage.FieldInputString:
+		return "input_string_val", nil
+	case storage.FieldInputFilePath:
+		return "input_file_path", nil
 
 	default:
 		return "", fmt.Errorf("no postgresql mapping for storage field %s exists", f)

--- a/pkg/storage/postgres/insert_test.go
+++ b/pkg/storage/postgres/insert_test.go
@@ -33,10 +33,12 @@ func TestSaveTaskRun(t *testing.T) {
 						Result:           storage.ResultSuccess,
 						TotalInputDigest: "1234567890",
 					},
-					Inputs: []*storage.Input{
-						{
-							URI:    "main.go",
-							Digest: "45",
+					Inputs: storage.Inputs{
+						Files: []*storage.InputFile{
+							{
+								Path:   "main.go",
+								Digest: "45",
+							},
 						},
 					},
 					Outputs: []*storage.Output{
@@ -73,10 +75,12 @@ func TestSaveTaskRun(t *testing.T) {
 						TotalInputDigest: "1234567890",
 						Result:           storage.ResultSuccess,
 					},
-					Inputs: []*storage.Input{
-						{
-							URI:    "main.go",
-							Digest: "45",
+					Inputs: storage.Inputs{
+						Files: []*storage.InputFile{
+							{
+								Path:   "main.go",
+								Digest: "45",
+							},
 						},
 					},
 				},

--- a/pkg/storage/postgres/query_test.go
+++ b/pkg/storage/postgres/query_test.go
@@ -51,10 +51,12 @@ func TestLatestTaskRunByDigest(t *testing.T) {
 			Result:           storage.ResultSuccess,
 			TotalInputDigest: "1234567890",
 		},
-		Inputs: []*storage.Input{
-			{
-				URI:    "main.go",
-				Digest: "45",
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
 			},
 		},
 		Outputs: []*storage.Output{
@@ -151,10 +153,12 @@ func TestOutputs(t *testing.T) {
 			Result:           storage.ResultSuccess,
 			TotalInputDigest: "1234567890",
 		},
-		Inputs: []*storage.Input{
-			{
-				URI:    "main.go",
-				Digest: "45",
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
 			},
 		},
 		Outputs: []*storage.Output{
@@ -221,19 +225,32 @@ func TestInputs(t *testing.T) {
 			Result:           storage.ResultSuccess,
 			TotalInputDigest: "1234567890",
 		},
-		Inputs: []*storage.Input{
-			{
-				URI:    "main.go",
-				Digest: "45",
-			},
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
 
-			{
-				URI:    "util.go",
-				Digest: "46",
+				{
+					Path:   "util.go",
+					Digest: "46",
+				},
+				{
+					Path:   "file://Makefile",
+					Digest: "47",
+				},
 			},
-			{
-				URI:    "file://Makefile",
-				Digest: "47",
+			Strings: []*storage.InputString{
+				{
+					String: "hello",
+					Digest: "45",
+				},
+
+				{
+					String: "bye",
+					Digest: "46",
+				},
 			},
 		},
 	}
@@ -245,7 +262,8 @@ func TestInputs(t *testing.T) {
 	inputs, err := client.Inputs(ctx, id)
 	require.NoError(t, err)
 
-	assert.Equal(t, run.Inputs, inputs)
+	assert.ElementsMatch(t, run.Inputs.Files, inputs.Files)
+	assert.ElementsMatch(t, run.Inputs.Strings, inputs.Strings)
 }
 
 func TestTaskRun(t *testing.T) {
@@ -265,10 +283,12 @@ func TestTaskRun(t *testing.T) {
 			Result:           storage.ResultSuccess,
 			TotalInputDigest: "1234567890",
 		},
-		Inputs: []*storage.Input{
-			{
-				URI:    "main.go",
-				Digest: "45",
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
 			},
 		},
 		Outputs: []*storage.Output{
@@ -336,10 +356,12 @@ func TestTaskRuns(t *testing.T) {
 			Result:           storage.ResultSuccess,
 			TotalInputDigest: "1234567890",
 		},
-		Inputs: []*storage.Input{
-			{
-				URI:    "main.go",
-				Digest: "45",
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
 			},
 		},
 		Outputs: []*storage.Output{
@@ -551,10 +573,12 @@ func TestTaskRunQueryRunWithoutOutputWithoutVCS(t *testing.T) {
 			Result:           storage.ResultSuccess,
 			TotalInputDigest: "1234567890",
 		},
-		Inputs: []*storage.Input{
-			{
-				URI:    "main.go",
-				Digest: "45",
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
 			},
 		},
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -9,9 +9,19 @@ import (
 // ErrNotExist indicates that a record does not exist
 var ErrNotExist = errors.New("does not exist")
 
-type Input struct {
-	URI    string
+type InputFile struct {
+	Path   string
 	Digest string
+}
+
+type InputString struct {
+	String string
+	Digest string
+}
+
+type Inputs struct {
+	Files   []*InputFile
+	Strings []*InputString
 }
 
 // UploadMethod is the method that was used to upload the object
@@ -23,7 +33,6 @@ const (
 	UploadMethodFileCopy       UploadMethod = "filecopy"
 )
 
-// Upload contains informations about an output upload
 type Upload struct {
 	URI                  string
 	UploadStartTimestamp time.Time
@@ -31,7 +40,6 @@ type Upload struct {
 	Method               UploadMethod
 }
 
-// ArtifactType describes the type of an artifact
 type ArtifactType string
 
 const (
@@ -39,7 +47,6 @@ const (
 	ArtifactTypeFile   ArtifactType = "file"
 )
 
-// Output represents a task output
 type Output struct {
 	Name      string
 	Type      ArtifactType
@@ -48,7 +55,6 @@ type Output struct {
 	Uploads   []*Upload
 }
 
-// Result is the result of a task run
 type Result string
 
 const (
@@ -69,7 +75,7 @@ type TaskRun struct {
 
 type TaskRunFull struct {
 	TaskRun
-	Inputs  []*Input
+	Inputs  Inputs
 	Outputs []*Output
 }
 
@@ -108,6 +114,8 @@ type Storer interface {
 		callback func(*TaskRunWithID) error,
 	) error
 
-	Inputs(ctx context.Context, taskRunID int) ([]*Input, error)
+	// Inputs returns the inputs of a task run. If no records were found,
+	// the method returns ErrNotExist.
+	Inputs(ctx context.Context, taskRunID int) (*Inputs, error)
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
 }


### PR DESCRIPTION
```
        tests: add testcase "baur ls runs --has-input"

-------------------------------------------------------------------------------
        storage: refactor input string representation

        File Input and String Inputs were represented by the same storage struct
        and also stored in the same postgresql table.
        In the input.name db column and in the storage.Input.Name struct field was
        stored for file inputs the path, for string inputs the string with a "string:"
        prefix.
        The input table had a unique constraint for the name and digest column, that was
        used to to a database upsert operation (only insert if records does not exist).
        When long string inputs were specified as parameters for "baur run" it happened
        that the input could not be stored in the table because it was too long to be
        stored in the unique index (index row requires 10032 bytes, maximum size is 8191
        (SQLSTATE 54000)).

        To fix this issue and to have clear struct field and db column names the storage
        representation is refactored.
        Input Files and Input strings are now represented by separate structs and stored
        in separate tables.
        The unique index for the input_string table is only created for the digest field
        and not the string itself anymore. The digest depends only on the string.

```