### PR TITLE
cfg: check if task or app-names contain reserved characters

### DIFF
--- a/pkg/cfg/app.go
+++ b/pkg/cfg/app.go
@@ -147,8 +147,8 @@ func (a *App) Merge(includedb *IncludeDB, includeSpecResolver Resolver) error {
 // Validate validates the configuration.
 // It should be called after Merge().
 func (a *App) Validate() error {
-	if len(a.Name) == 0 {
-		return newFieldError("can not be empty", "name")
+	if err := validateTaskOrAppName(a.Name); err != nil {
+		return fieldErrorWrap(err, "name")
 	}
 
 	if strings.Contains(a.Name, ".") {

--- a/pkg/cfg/app_test.go
+++ b/pkg/cfg/app_test.go
@@ -39,6 +39,34 @@ func Test_ExampleApp_WrittenAndReadCfgIsValid(t *testing.T) {
 	}
 }
 
+func TestAppNameValidation(t *testing.T) {
+	testcases := []struct {
+		AppName        string
+		ExpectedErrStr string
+	}{
+		{
+			AppName:        "sh.o.p",
+			ExpectedErrStr: "character not allowed",
+		},
+		{
+			AppName:        "sh##",
+			ExpectedErrStr: "character not allowed",
+		},
+		{
+			AppName:        "star***",
+			ExpectedErrStr: "character not allowed",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.AppName, func(t *testing.T) {
+			a := ExampleApp(tc.AppName)
+			err := a.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.ExpectedErrStr)
+		})
+	}
+}
+
 func TestEnsureValidateFailsOnDuplicateTaskNames(t *testing.T) {
 	taskInclFilename := "tasks.toml"
 

--- a/pkg/cfg/taskdef.go
+++ b/pkg/cfg/taskdef.go
@@ -57,8 +57,8 @@ func taskValidate(t taskDef) error {
 		return newFieldError("can not be empty", "command")
 	}
 
-	if t.GetName() == "" {
-		return newFieldError("name can not be empty", "name")
+	if err := validateTaskOrAppName(t.GetName()); err != nil {
+		return fieldErrorWrap(err, "name")
 	}
 
 	if strings.Contains(t.GetName(), ".") {

--- a/pkg/cfg/tasks_test.go
+++ b/pkg/cfg/tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppsWithoutAnyTasksAreValid(t *testing.T) {
@@ -11,4 +12,37 @@ func TestAppsWithoutAnyTasksAreValid(t *testing.T) {
 
 	err := app.Validate()
 	assert.NoError(t, err)
+}
+
+func TestTaskNameValidation(t *testing.T) {
+	testcases := []struct {
+		TaskName       string
+		ExpectedErrStr string
+	}{
+		{
+			TaskName:       "sh.o.p",
+			ExpectedErrStr: "character not allowed",
+		},
+		{
+			TaskName:       "sh##",
+			ExpectedErrStr: "character not allowed",
+		},
+		{
+			TaskName:       "star***",
+			ExpectedErrStr: "character not allowed",
+		},
+		{
+			TaskName:       "",
+			ExpectedErrStr: "can not be empty",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.TaskName, func(t *testing.T) {
+			a := ExampleApp("shop")
+			a.Tasks[0].Name = tc.TaskName
+			err := a.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.ExpectedErrStr)
+		})
+	}
 }

--- a/pkg/cfg/validation.go
+++ b/pkg/cfg/validation.go
@@ -1,0 +1,27 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var forbiddenNameRunes = [...]rune{
+	'.',
+	'*',
+	'#',
+}
+
+func validateTaskOrAppName(name string) error {
+	if len(name) == 0 {
+		return errors.New("can not be empty")
+	}
+
+	for _, r := range forbiddenNameRunes {
+		if strings.ContainsRune(name, r) {
+			return fmt.Errorf("'%c' character not allowed in name", r)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The configuration file validation will now fail if an app or task name contains
a reserved character that has a special meaning on the cmdline or in values of
other configuration fields.