### PR TITLE
cfg: improve comments in example configuration files

### DIFF
--- a/pkg/cfg/fileinputs.go
+++ b/pkg/cfg/fileinputs.go
@@ -6,8 +6,8 @@ import (
 
 // FileInputs stores glob paths to inputs of a task.
 type FileInputs struct {
-	Paths          []string `toml:"paths" comment:"Relative path to source files.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively."`
-	Optional       bool     `toml:"optional" comment:"Do not fail if a Path resolves to 0 files."`
+	Paths          []string `toml:"paths" comment:"Glob patterns that match files.\n All Paths are relative to the application directory.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively."`
+	Optional       bool     `toml:"optional" comment:"When optional is true a path pattern that matches 0 files will not cause an error."`
 	GitTrackedOnly bool     `toml:"git_tracked_only" comment:"Only resolve to files that are part of the Git repository."`
 }
 

--- a/pkg/cfg/golangsources.go
+++ b/pkg/cfg/golangsources.go
@@ -2,9 +2,9 @@ package cfg
 
 // GolangSources specifies inputs for Golang Applications
 type GolangSources struct {
-	Queries     []string `toml:"queries" comment:"Queries specify the source files or packages of which the dependencies are resolved.\n Format:\n \tfile=<RELATIVE-PATH>\n \tfileglob=<GLOB-PATTERN>\t -> Supports double-star\n \tEverything else is passed directly to underlying build tool (go list by default).\n \tSee also the patterns described at:\n \t<https://github.com/golang/tools/blob/bc8aaaa29e0665201b38fa5cb5d47826788fa249/go/packages/doc.go#L17>.\n Files from Golang's stdlib are ignored."`
-	Environment []string `toml:"environment" comment:"Environment when running the go packages tool."`
-	BuildFlags  []string `toml:"build_flags" comment:"List of command-line flags to be passed through to the build system's query tool."`
+	Queries     []string `toml:"queries" comment:"Go package queries, the source files of matching packages and\n their imported packages are resolved to files.\n Format:\n \tfile=<RELATIVE-PATH>\n \tfileglob=<GLOB-PATTERN>\t -> Supports double-star\n \tEverything else is passed to the Go query tool (go list by default).\n \tSee also the patterns described at:\n \t<https://github.com/golang/tools/blob/bc8aaaa29e0665201b38fa5cb5d47826788fa249/go/packages/doc.go#L17>.\n Files from Golang's stdlib are ignored."`
+	Environment []string `toml:"environment" comment:"Environment when running the go query tool."`
+	BuildFlags  []string `toml:"build_flags" comment:"List of command-line flags to be passed through to the Go query tool."`
 	Tests       bool     `toml:"tests" comment:"If true queries are resolved to test files, otherwise testfiles are ignored."`
 }
 

--- a/pkg/cfg/inputinclude.go
+++ b/pkg/cfg/inputinclude.go
@@ -6,7 +6,7 @@ import (
 
 // InputInclude is a reusable Input definition.
 type InputInclude struct {
-	IncludeID string `toml:"include_id" comment:"Identifier"`
+	IncludeID string `toml:"include_id" comment:"identifier of the include"`
 
 	Files         []FileInputs
 	GolangSources []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`

--- a/pkg/cfg/task.go
+++ b/pkg/cfg/task.go
@@ -4,8 +4,8 @@ package cfg
 type Task struct {
 	Name     string   `toml:"name" comment:"Task name"`
 	Command  []string `toml:"command" comment:"Command to execute.\n The first element is the command, the following its arguments."`
-	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the application directory."`
-	Input    Input    `toml:"Input" comment:"Inputs that are tracked to detect if a task needs to be run."`
+	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format FILEPATH#INCLUDE_ID>.\n Paths are relative to the application directory."`
+	Input    Input    `toml:"Input" comment:"Inputs are tracked, when they change the task is rerun."`
 	Output   Output   `toml:"Output" comment:"Artifacts produced by the Task.command and their upload destinations."`
 
 	// multiple include sections of the same file can be included, use a map

--- a/pkg/cfg/taskinclude.go
+++ b/pkg/cfg/taskinclude.go
@@ -8,7 +8,7 @@ import (
 type TaskInclude struct {
 	IncludeID string `toml:"include_id" comment:"identifier of the include"`
 
-	Name     string   `toml:"name"`
+	Name     string   `toml:"name" comment:"Task name"`
 	Command  []string `toml:"command" comment:"Command to execute. The first element is the command, the following its arguments.\n If the command element contains no path seperators, its path is looked up via the $PATH environment variable."`
 	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the include file location."`
 	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`


### PR DESCRIPTION
Improve the comments in the configuration files that can be generated via
"baur init"