### PR TITLE
show: fix: upload duration not printed colored

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -367,9 +367,11 @@ func (*showCmd) showBuild(taskRunID int) {
 				"",
 				"",
 				"Upload Duration:",
-				term.FormatDuration(
-					upload.UploadStopTimestamp.Sub(
-						upload.UploadStartTimestamp),
+				term.Highlight(
+					term.FormatDuration(
+						upload.UploadStopTimestamp.Sub(
+							upload.UploadStartTimestamp),
+					),
 				),
 			)
 			mustWriteRow(


### PR DESCRIPTION
All field values were printed highlighted/colored by "baur show" except the
"Upload Duration", also highlight it's value.