### PR TITLE
tests: reset log, stdout, stderr streams when a test finishes

### DIFF
--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -48,8 +48,24 @@ func initTest(t *testing.T) {
 }
 
 func redirectOutputToLogger(t *testing.T) {
+	// FIXME: when tests are run in parallel this will cause unexpected
+	// results, global package vars are modified that would affect all
+	// parallel running tests
+	oldLogOut := log.StdLogger.GetOutput()
 	log.StdLogger.SetOutput(log.NewTestLogOutput(t))
+
+	oldExecDebugFfN := exec.DefaultDebugfFn
 	exec.DefaultDebugfFn = t.Logf
+
+	oldStdout := stdout
 	stdout = term.NewStream(logwriter.New(t, ioutil.Discard))
+	oldStderr := stderr
 	stderr = term.NewStream(logwriter.New(t, ioutil.Discard))
+
+	t.Cleanup(func() {
+		log.StdLogger.SetOutput(oldLogOut)
+		exec.DefaultDebugfFn = oldExecDebugFfN
+		stdout = oldStdout
+		stderr = oldStderr
+	})
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -50,7 +50,7 @@ func (l *Logger) Debugln(v ...interface{}) {
 		return
 	}
 
-	l.getOutput().Println(v...)
+	l.GetOutput().Println(v...)
 }
 
 // Debugf logs a debug message to stdout.
@@ -60,10 +60,11 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 		return
 	}
 
-	l.getOutput().Printf(format, v...)
+	l.GetOutput().Printf(format, v...)
 }
 
-func (l *Logger) getOutput() Output {
+// GetOutput returns the output to which log messages are written.
+func (l *Logger) GetOutput() Output {
 	l.outputLock.Lock()
 	defer l.outputLock.Unlock()
 


### PR DESCRIPTION
When a testcase was calling redirectOutputToLogger() and the following executed
testcase wasn't, all it's output was redirected to the logger for the first
testcase.

These log messages could be lost or associated with the wrong testcase.

Fix it by resetting the log streams that were changed to their previous values
when the test finished execution.