### PR TITLE
loader: fix: a task spec with only a wildcard for the app loaded all tasks

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -76,18 +76,16 @@ type csvStatus struct {
 	commit string
 }
 
-// baurCSVStatus runs "baur status --csv" and returns the result.
-func baurCSVStatus(t *testing.T, inputStr []string, lookupInputStr string) []*csvStatus {
+// baurCSVStatusCmd runs the statusCmd, parses the CSV result and returns it.
+// cmd.csv is set to true
+func baurCSVStatusCmd(t *testing.T, cmd *statusCmd) []*csvStatus {
 	t.Helper()
 
 	stdoutBuf, _ := interceptCmdOutput(t)
 
-	statusCmd := newStatusCmd()
-	statusCmd.csv = true
-	statusCmd.inputStr = inputStr
-	statusCmd.lookupInputStr = lookupInputStr
-
-	statusCmd.Command.Run(&statusCmd.Command, nil)
+	cmd.csv = true
+	err := cmd.Execute()
+	require.NoError(t, err)
 
 	statusOut, err := csv.NewReader(stdoutBuf).ReadAll()
 	require.NoError(t, err)
@@ -104,6 +102,18 @@ func baurCSVStatus(t *testing.T, inputStr []string, lookupInputStr string) []*cs
 	}
 
 	return result
+}
+
+// baurCSVStatus runs "baur status --csv" and returns the result.
+func baurCSVStatus(t *testing.T, inputStr []string, lookupInputStr string) []*csvStatus {
+	t.Helper()
+
+	statusCmd := newStatusCmd()
+	statusCmd.csv = true
+	statusCmd.inputStr = inputStr
+	statusCmd.lookupInputStr = lookupInputStr
+
+	return baurCSVStatusCmd(t, statusCmd)
 }
 
 func assertStatusTasks(t *testing.T, r *repotest.Repo, statusOut []*csvStatus, expectedStatus baur.TaskStatus, commit string) {

--- a/internal/command/testdata/multitasks/.baur.toml
+++ b/internal/command/testdata/multitasks/.baur.toml
@@ -1,0 +1,17 @@
+
+# Internal field, version of baur configuration format
+config_version = 5
+
+[Database]
+
+  # PostgreSQL database Connection string (https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
+  # The setting is overwritten by the environment variable BAUR_POSTGRESQL_URL.
+  postgresql_url = "postgres://postgres@localhost:5434/baur?sslmode=disable"
+
+[Discover]
+
+  # Directories in which applications (.app.toml files) are discovered
+  application_dirs = ["."]
+
+  # Descend at most search_depth levels to find application configs
+  search_depth = 2

--- a/internal/command/testdata/multitasks/app3/.app.toml
+++ b/internal/command/testdata/multitasks/app3/.app.toml
@@ -1,0 +1,26 @@
+name = "app3"
+
+[[Task]]
+  name = "build"
+  command = [ "./build.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+
+[[Task]]
+  name = "check"
+  command = [ "./check.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+[[Task]]
+  name = "test"
+  command = [ "sh", "-c", "echo test successful" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]

--- a/internal/command/testdata/multitasks/app3/build.sh
+++ b/internal/command/testdata/multitasks/app3/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/app3/check.sh
+++ b/internal/command/testdata/multitasks/app3/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/dir1/app1/.app.toml
+++ b/internal/command/testdata/multitasks/dir1/app1/.app.toml
@@ -1,0 +1,26 @@
+name = "app1"
+
+[[Task]]
+  name = "build"
+  command = [ "./build.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+
+[[Task]]
+  name = "check"
+  command = [ "./check.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+[[Task]]
+  name = "test"
+  command = [ "sh", "-c", "echo test successful" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]

--- a/internal/command/testdata/multitasks/dir1/app1/build.sh
+++ b/internal/command/testdata/multitasks/dir1/app1/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/dir1/app1/check.sh
+++ b/internal/command/testdata/multitasks/dir1/app1/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/dir1/app2/.app.toml
+++ b/internal/command/testdata/multitasks/dir1/app2/.app.toml
@@ -1,0 +1,26 @@
+name = "app2"
+
+[[Task]]
+  name = "build"
+  command = [ "./build.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+
+[[Task]]
+  name = "check"
+  command = [ "./check.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+[[Task]]
+  name = "test"
+  command = [ "sh", "-c", "echo test successful" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]

--- a/internal/command/testdata/multitasks/dir1/app2/build.sh
+++ b/internal/command/testdata/multitasks/dir1/app2/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/dir1/app2/check.sh
+++ b/internal/command/testdata/multitasks/dir1/app2/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/dir2/app4/.app.toml
+++ b/internal/command/testdata/multitasks/dir2/app4/.app.toml
@@ -1,0 +1,18 @@
+name = "app4"
+
+[[Task]]
+  name = "compile"
+  command = [ "./build.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]
+
+
+[[Task]]
+  name = "lint"
+  command = [ "./check.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]

--- a/internal/command/testdata/multitasks/dir2/app4/build.sh
+++ b/internal/command/testdata/multitasks/dir2/app4/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/testdata/multitasks/dir2/app4/check.sh
+++ b/internal/command/testdata/multitasks/dir2/app4/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "$0 successful"

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -19,8 +19,15 @@ func interceptCmdOutput(t *testing.T) (stdoutBuf, stderrBuf *bytes.Buffer) {
 	var bufStdout bytes.Buffer
 	var bufStderr bytes.Buffer
 
+	oldStdout := stdout
 	stdout = term.NewStream(logwriter.New(t, &bufStdout))
+	oldStderr := stderr
 	stderr = term.NewStream(logwriter.New(t, &bufStderr))
+
+	t.Cleanup(func() {
+		stdout = oldStdout
+		stderr = oldStderr
+	})
 
 	return &bufStdout, &bufStderr
 }
@@ -53,6 +60,7 @@ func redirectOutputToLogger(t *testing.T) {
 	// parallel running tests
 	oldLogOut := log.StdLogger.GetOutput()
 	log.StdLogger.SetOutput(log.NewTestLogOutput(t))
+	log.StdLogger.EnableDebug(true)
 
 	oldExecDebugFfN := exec.DefaultDebugfFn
 	exec.DefaultDebugfFn = t.Logf

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -289,7 +289,7 @@ func (a *Loader) tasks(taskSpecs []*taskSpec) ([]*Task, error) {
 }
 
 func (a *Loader) apps(specs *specs) ([]*App, error) {
-	if specs.all || specs.allApps {
+	if specs.all {
 		return a.allApps()
 	}
 

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -227,7 +227,7 @@ func (a *Loader) appPath(appConfigPath string) (*App, error) {
 	return a.fromCfg(appCfg)
 }
 
-func appTask(app *App, taskName string) *Task {
+func appTaskByName(app *App, taskName string) *Task {
 	for _, task := range app.Tasks() {
 		if task.Name == taskName {
 			return task
@@ -268,7 +268,7 @@ func (a *Loader) tasks(taskSpecs []*taskSpec) ([]*Task, error) {
 
 	for _, app := range apps {
 		for _, spec := range taskSpecMap[app.Name] {
-			task := appTask(app, spec)
+			task := appTaskByName(app, spec)
 			if task == nil {
 				return nil, fmt.Errorf("app %q has no task %q", app, spec)
 			}
@@ -279,7 +279,7 @@ func (a *Loader) tasks(taskSpecs []*taskSpec) ([]*Task, error) {
 		// taskSpecs that match all apps are optional,
 		// e.g. it's ok if **not** all apps have a task called "check"
 		for _, spec := range taskSpecMap["*"] {
-			if task := appTask(app, spec); task != nil {
+			if task := appTaskByName(app, spec); task != nil {
 				result = append(result, task)
 			}
 		}

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -109,11 +109,16 @@ func (a *Loader) LoadApps(specifier ...string) ([]*App, error) {
 }
 
 // appNames discovers and loads the apps with the given names.
+// If no names are passed, a nil []*App slice is returned.
 func (a *Loader) appNames(names ...string) ([]*App, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
 	namesMap := make(map[string]struct{}, len(names))
 	result := make([]*App, 0, len(names))
 
-	a.logger.Debugf("loader: loading app %q", names)
+	a.logger.Debugf("loader: loading the following apps by name: %+v", names)
 
 	for _, name := range names {
 		namesMap[name] = struct{}{}

--- a/pkg/baur/loader_specifiers.go
+++ b/pkg/baur/loader_specifiers.go
@@ -18,9 +18,7 @@ func (t *taskSpec) String() string {
 
 type specs struct {
 	// all is true if all tasks of all apps are matched
-	all bool
-	// allApps is true if >=1 spec matches all apps
-	allApps   bool
+	all       bool
 	appDirs   []string
 	appNames  []string
 	taskSpecs []*taskSpec
@@ -43,7 +41,6 @@ func parseSpecs(specifiers []string) (*specs, error) {
 	for _, spec := range specifiers {
 		if spec == "*" {
 			result.all = true
-			result.allApps = true
 			return &result, nil
 		}
 
@@ -73,7 +70,6 @@ func parseSpecs(specifiers []string) (*specs, error) {
 			taskName := spl[1]
 
 			if appName == "*" {
-				result.allApps = true
 				if taskName == "*" {
 					result.all = true
 


### PR DESCRIPTION
```
  loader: fix: a task spec with only a wildcard for the app loaded all tasks

        If a task specification was passed to "baur status" or "baur run" that consisted
        of a wildcard for the app and a specific task-name like '*.build', all tasks for
        all apps were loaded,  instead of only all tasks matching the task-name.

        Fix it by removing the specs.allApps fields.
        It is not necessary because if a spec is parsed with an non-empty task part an
        element for it is added to specs.taskSpecs and it will then be loaded by
        Loader.tasks().

-------------------------------------------------------------------------------
        loader: rename appTask() to appTaskByName()

        The new name should be more clear

-------------------------------------------------------------------------------
        loader: improve debug log message

        - return early in appNames() when no names were passed.
          Passing no names is supported behavior and used in multiple places, so far the
          function was nothing because all code blocks were run in for-loops over an
          empty slice in the case.
          Adding an if-check at the beginning makes it easier to figure out what happens
          in the case and prevents that we log a debug message about loading no apps by
          name

-------------------------------------------------------------------------------
        testcases: improve status command testcase

        - verify in the testcases if the expected tasks were returned from "baur status"
        - add testcase that passes multiple different testspecs to "baur status"
        - improve testcase names

-------------------------------------------------------------------------------
        tests: interceptCmdOutput: reset stdout, stderr when test finishes

        This fixes the same issue then 7b76d65, when the following testcase did not
        call interceptCmdOutput() or initTest() the output was written to the logger of
        a previous testcase and vanished.
```