### PR TITLE
run: add parameter --show-task-output

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -222,14 +222,25 @@ func (c *runCmd) runTask(task *baur.Task) *baur.RunResult {
 	if result.Result.ExitCode != 0 {
 		statusStr := term.RedHighlight("failed")
 
-		stderr.Printf("%s: execution %s (%s), command exited with code %d, output:\n%s\n",
-			task,
-			statusStr,
-			term.FormatDuration(
-				result.StopTime.Sub(result.StartTime),
-			),
-			result.ExitCode,
-			result.StrOutput())
+		if c.showOutput {
+			stderr.Printf("%s: execution %s (%s), command exited with code %d\n",
+				task,
+				statusStr,
+				term.FormatDuration(
+					result.StopTime.Sub(result.StartTime),
+				),
+				result.ExitCode,
+			)
+		} else {
+			stderr.Printf("%s: execution %s (%s), command exited with code %d, output:\n%s\n",
+				task,
+				statusStr,
+				term.FormatDuration(
+					result.StopTime.Sub(result.StartTime),
+				),
+				result.ExitCode,
+				result.StrOutput())
+		}
 
 		exitFunc(1)
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/baur/v2/internal/command/term"
+	"github.com/simplesurance/baur/v2/internal/exec"
 	"github.com/simplesurance/baur/v2/internal/log"
 	"github.com/simplesurance/baur/v2/internal/routines"
 	"github.com/simplesurance/baur/v2/internal/upload/docker"
@@ -76,6 +77,7 @@ type runCmd struct {
 	inputStr       []string
 	lookupInputStr string
 	taskRunners    uint
+	showOutput     bool
 
 	// other fields
 	storage      storage.Storer
@@ -110,6 +112,10 @@ func newRunCmd() *runCmd {
 		"if a run can not be found, try to find a run with this value as input-string")
 	cmd.Flags().UintVarP(&cmd.taskRunners, "parallel-runs", "p", 1,
 		"specifies the max. number of tasks to run in parallel")
+	cmd.Flags().BoolVarP(&cmd.showOutput, "show-task-output", "o", false,
+		"show the output of tasks, if disabled the output is only shown "+
+			"when task execution failed",
+	)
 
 	return &cmd
 }
@@ -165,6 +171,10 @@ func (c *runCmd) run(cmd *cobra.Command, args []string) {
 	} else {
 		stdout.Printf("Running %d/%d task(s) with status %s\n\n",
 			len(pendingTasks), len(tasks), term.ColoredTaskStatus(baur.TaskStatusExecutionPending))
+	}
+
+	if c.showOutput {
+		exec.DefaultDebugfFn = stdout.Printf
 	}
 
 	for _, pt := range pendingTasks {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -22,7 +22,6 @@ func TestRunSimultaneously(t *testing.T) {
 	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
 
 	parallelTaskCnt := 6
-	apps := make([]*cfg.App, parallelTaskCnt)
 
 	// checkScript is exected by the tasks, it logs the start and end
 	// timestamp of the script to file.
@@ -48,8 +47,6 @@ date +%s >> "$runtime_logfile"
 			0755,
 		)
 		require.NoError(t, err)
-
-		apps[i] = r.CreateAppWithNoOutputs(t, fmt.Sprintf("myapp-%d", i))
 
 		logfile := filepath.Join(r.Dir, fmt.Sprintf("runtimelog-task-%d", i))
 		runtimeLogfiles = append(runtimeLogfiles, logfile)

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -149,7 +149,7 @@ func (c *Cmd) Run() (*Result, error) {
 	}
 	cmd.Stderr = cmd.Stdout
 
-	c.debugfFn(c.debugfPrefix+"running '%s' in directory '%s'", cmdString(cmd), cmd.Dir)
+	c.debugfFn(c.debugfPrefix+"running '%s' in directory '%s'\n", cmdString(cmd), cmd.Dir)
 	err = cmd.Start()
 	if err != nil {
 		return nil, err
@@ -159,13 +159,12 @@ func (c *Cmd) Run() (*Result, error) {
 	firstline := true
 	in := bufio.NewScanner(outReader)
 	for in.Scan() {
+		c.debugfFn(c.debugfPrefix + in.Text() + "\n")
 		if firstline {
 			firstline = false
 		} else {
 			outBuf.WriteRune('\n')
 		}
-
-		c.debugfFn(c.debugfPrefix + in.Text())
 
 		outBuf.Write(in.Bytes())
 	}
@@ -182,7 +181,7 @@ func (c *Cmd) Run() (*Result, error) {
 		return nil, err
 	}
 
-	c.debugfFn(c.debugfPrefix+"command terminated with exitCode: %d", exitCode)
+	c.debugfFn(c.debugfPrefix+"command terminated with exitCode: %d\n", exitCode)
 
 	result := Result{
 		Command:  cmdString(cmd),


### PR DESCRIPTION
Add a new cmdline parameter to "baur" run, that if passed prints the stdout and
stderr output of executes commands to the console.

This was only possible by passing the "--verbose" parameter so far, which also
printed tons of other noisy output.

Closes #140 

Related: https://github.com/simplesurance/baur/issues/328