### PR TITLE
Add password env variable to docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ baur uses a PostgreSQL database to record information about past task runs. The
 quickest way to setup a PostgreSQL for local testing is with docker:
 
 ```sh
-docker run -p 5432:5432 -e POSTGRES_DB=baur -e POSTGRES_PASSWORD=password postgres:latest
+docker run -p 127.0.0.1:5432:5432 -e POSTGRES_DB=baur -e POSTGRES_HOST_AUTH_METHOD=trust postgres:latest
 ```
 
 Afterwards you create your baur repository configuration file.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ baur uses a PostgreSQL database to record information about past task runs. The
 quickest way to setup a PostgreSQL for local testing is with docker:
 
 ```sh
-docker run -p 5432:5432 -e POSTGRES_DB=baur postgres:latest
+docker run -p 5432:5432 -e POSTGRES_DB=baur -e POSTGRES_PASSWORD=password postgres:latest
 ```
 
 Afterwards you create your baur repository configuration file.


### PR DESCRIPTION
Updated readme docker run for postgres as using the example command fails with - 

"Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run"."


