### PR TITLE
CI: Update golangci-lint and golang, replace golint with revive linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   test_linux:
     docker:
-      - image: cimg/go:1.16.4
+      - image: cimg/go:1.16.5
         environment:
           GOFLAGS: -mod=vendor
           TEST_RESULTS: /tmp/test-results
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Preparing Test Environment
           command: |
-            choco install golang --version=1.16.4 -y
+            choco install golang --version=1.16.5 -y
             choco install postgresql12 --params '/Password:postgres' -y
             New-Item -ItemType Directory -Force -Path $Env:TEST_RESULTS
 
@@ -105,7 +105,7 @@ jobs:
 
   static_analysis_linux:
     docker:
-      - image: golangci/golangci-lint:v1.40.0
+      - image: golangci/golangci-lint:v1.41.1
 
     working_directory: ~/baur
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
     - errcheck
     - exportloopref
     - goimports
-    - golint
+    - revive
     - gosimple
     - ineffassign
     - misspell

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -20,14 +20,14 @@ type toFileOpts struct {
 type toFileOpt func(*toFileOpts)
 
 // ToFileOptOverwrite overwrite an existing file instead of returning an error
-func ToFileOptOverwrite() toFileOpt { // nolint: golint
+func ToFileOptOverwrite() toFileOpt { // nolint: revive // returns unexported type
 	return func(o *toFileOpts) {
 		o.overwrite = true
 	}
 }
 
 // ToFileOptCommented comment every line in the config
-func ToFileOptCommented() toFileOpt { // nolint: golint
+func ToFileOptCommented() toFileOpt { // nolint: revive // returns unexported type
 	return func(o *toFileOpts) {
 		o.commented = true
 	}

--- a/pkg/cfg/inputinclude.go
+++ b/pkg/cfg/inputinclude.go
@@ -39,11 +39,7 @@ func (in *InputInclude) validate() error {
 		return nil
 	}
 
-	if err := inputValidate(in); err != nil {
-		return err
-	}
-
-	return nil
+	return inputValidate(in)
 }
 
 func (in *InputInclude) clone() *InputInclude {

--- a/pkg/cfg/outputinclude.go
+++ b/pkg/cfg/outputinclude.go
@@ -37,11 +37,7 @@ func (out *OutputInclude) validate() error {
 		return errors.New("no output is defined")
 	}
 
-	if err := outputValidate(out); err != nil {
-		return err
-	}
-
-	return nil
+	return outputValidate(out)
 }
 
 func (out *OutputInclude) clone() *OutputInclude {

--- a/pkg/cfg/taskinclude.go
+++ b/pkg/cfg/taskinclude.go
@@ -49,11 +49,7 @@ func (t *TaskInclude) validate() error {
 		return err
 	}
 
-	if err := taskValidate(t); err != nil {
-		return err
-	}
-
-	return nil
+	return taskValidate(t)
 }
 
 // toTask converts the TaskInclude to a Task.

--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -80,11 +80,7 @@ func scanIDs(rows pgx.Rows, res *[]int) error {
 		*res = append(*res, id)
 	}
 
-	if err := rows.Err(); err != nil {
-		return err
-	}
-
-	return nil
+	return rows.Err()
 }
 
 func insertAppIfNotExist(ctx context.Context, db dbConn, appName string) (int, error) {


### PR DESCRIPTION
```
        remove redundant redundant if ...; err != nil checks

        After switching from golint to revive, some new redundant if err checks were
        found, remove them

-------------------------------------------------------------------------------
        circleci: update golangci-lint and go

        golang 1.16.5
        golangci-lint 1.41.1

-------------------------------------------------------------------------------
        golangci-lint: replace golint with revive

        This fixes:
                WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to:
                The repository of the linter has been archived by the owner.
                Replaced by revive.

```