### PR TITLE
routines: fix issues in the go-routine pool implementation

### DIFF
--- a/internal/routines/pool.go
+++ b/internal/routines/pool.go
@@ -4,7 +4,9 @@ import (
 	"sync"
 )
 
-// Pool is a FIFO go-routine pool.
+// Pool is a FIFO go-routine work pool.
+// Work can be scheduled and is executed by the first free worker in the pool.
+// Scheduled work is executed in queueing order.
 type Pool struct {
 	wq        []WorkFn
 	terminate bool
@@ -73,8 +75,8 @@ func (p *Pool) popWork() WorkFn {
 		return nil
 	}
 
-	w := p.wq[len(p.wq)-1]
-	p.wq = p.wq[:len(p.wq)-1]
+	w := p.wq[0]
+	p.wq = p.wq[1:]
 
 	return w
 }


### PR DESCRIPTION
```
        routines: fix: race on pool shutdown

        There was a chance that when Wait() and Queue() was called in parallel, that
        the work was not executed before the pool terminated and neither Queue() paniced
        because it was called after the pool terminated.

        Hold the lock while dequeuing work from the queue and checking if p.terminate is
        set.

-------------------------------------------------------------------------------
        routines: fix: work was processed in LIFO instead FIFO order

        The go-routine pool processed work in LIFO instead of FIFO order as it is
        documented.
```