### PR TITLE
run: only log "waiting for uploads to finish" when "-s" was not passed

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -148,7 +148,10 @@ func (c *runCmd) run(cmd *cobra.Command, args []string) {
 	c.storage = mustNewCompatibleStorage(repo)
 	defer c.storage.Close()
 
-	c.uploadRoutinePool = routines.NewPool(1) // run 1 upload in parallel with builds
+	if !c.skipUpload {
+		c.uploadRoutinePool = routines.NewPool(1) // run 1 upload in parallel with builds
+	}
+
 	c.taskRunnerRoutinePool = routines.NewPool(c.taskRunnerGoRoutines)
 	c.taskRunner = baur.NewTaskRunner()
 
@@ -233,8 +236,11 @@ func (c *runCmd) run(cmd *cobra.Command, args []string) {
 
 	c.taskRunnerRoutinePool.Wait()
 
-	stdout.Println("task execution finished, waiting for uploads to finish...")
-	c.uploadRoutinePool.Wait()
+	if !c.skipUpload {
+		stdout.Println("task execution finished, waiting for uploads to finish...")
+		c.uploadRoutinePool.Wait()
+	}
+
 	stdout.PrintSep()
 	stdout.Printf("finished in: %s\n",
 		term.FormatDuration(


### PR DESCRIPTION
```
        run: only log "waiting for uploads to finish" when "-s" was not passed

        When the --skip-upload parameter was passed to "baur run", it was printing to
        the console "task execution finished, waiting for uploads to finish...".
        Despite it did not upload anything.

        - Only print this message and call uploadRoutinePool.Wait() when the cmdline
          parameter "--skip-upload" is not passed.
        - only create the uploadRoutinePool pool if c.skipUpload is false, if it is true
          it is not used

```