### PR TITLE
ci: update to go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 parameters:
   go-version:
     type: string
-    default: "1.17"
+    default: "1.18"
 
 orbs:
   win: circleci/windows@2.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
 
   static_analysis_linux:
     docker:
-      - image: golangci/golangci-lint:v1.41.1
+      - image: golangci/golangci-lint:v1.45.1
 
     working_directory: ~/baur
     steps:


### PR DESCRIPTION
- Update the tools used in CI to go 1.18
- The minimum required version in the go.mod file will be set to 1.18, when 1.18 features are used