### PR TITLE
init app: fix wrong template variable names in generated example config

### DIFF
--- a/pkg/cfg/app.go
+++ b/pkg/cfg/app.go
@@ -47,12 +47,12 @@ func ExampleApp(name string) *App {
 							S3Upload: []S3Upload{
 								{
 									Bucket: "go-artifacts/",
-									Key:    "{{ .appname }}-{{ .gitcommit }}.tar.xz",
+									Key:    "{{ .AppName }}-{{ gitCommit }}.tar.xz",
 								},
 							},
 							FileCopy: []FileCopy{
 								{
-									Path: "/mnt/fileserver/build_artifacts/{{ .appname }}-{{ .gitcommit }}.tar.xz",
+									Path: "/mnt/fileserver/build_artifacts/{{ .AppName }}-{{ gitCommit }}.tar.xz",
 								},
 							},
 						},
@@ -62,8 +62,8 @@ func ExampleApp(name string) *App {
 							IDFile: "{{ .appname }}-container.id",
 							RegistryUpload: []DockerImageRegistryUpload{
 								{
-									Repository: "my-company/{{ .appname }}",
-									Tag:        "{{ ENV BRANCH_NAME }}-{{ .gitcommit }}",
+									Repository: "my-company/{{ .AppName }}",
+									Tag:        "{{ ENV BRANCH_NAME }}-{{ gitCommit }}",
 								},
 							},
 						},


### PR DESCRIPTION
When "baur init app" was run the generated app config contained invalid template
variables.
The variables use the syntax of baur v1 which are not supported anymore.

Update the baur template variables in the generated example config to match the
baur v2 equivalents.