### PR TITLE
resolve/gosource: add testcase for embedding files in go testcases

### DIFF
--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -156,8 +156,9 @@ func (r *Resolver) resolve(
 		"workdir: %s\n"+
 		"env: %+v\n"+
 		"goenv: %+v\n"+
+		"withTests: %t\n"+
 		"buildFlags: %+v\n",
-		queries, workdir, env, goEnv, buildFlags)
+		queries, workdir, env, goEnv, withTests, buildFlags)
 
 	cfg := &packages.Config{
 		Context:    ctx,

--- a/internal/resolve/gosource/gosource_test.go
+++ b/internal/resolve/gosource/gosource_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/simplesurance/baur/v2/internal/log"
 	"github.com/simplesurance/baur/v2/internal/prettyprint"
 	"github.com/simplesurance/baur/v2/internal/testutils/strtest"
 )
@@ -39,6 +40,8 @@ func TestResolve(t *testing.T) {
 	for _, dir := range testdataDirs {
 		t.Run(dir, func(t *testing.T) {
 			var testCfg testCfg
+
+			log.StdLogger.SetOutput(log.NewTestLogOutput(t))
 
 			require.NoError(t, os.Chdir(dir))
 

--- a/internal/resolve/gosource/testdata/embedded_file/embed_test.go
+++ b/internal/resolve/gosource/testdata/embedded_file/embed_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"testing"
+)
+
+//go:embed hello_test.txt
+var embeddedTestStr string
+
+func TestEmbed(t *testing.T) {
+	fmt.Println(embeddedTestStr)
+}

--- a/internal/resolve/gosource/testdata/embedded_file/hello_test.txt
+++ b/internal/resolve/gosource/testdata/embedded_file/hello_test.txt
@@ -1,0 +1,1 @@
+Hello, baur test!

--- a/internal/resolve/gosource/testdata/embedded_file/test_config.json
+++ b/internal/resolve/gosource/testdata/embedded_file/test_config.json
@@ -1,11 +1,14 @@
 {
 	"Cfg": {
-		"Queries": ["./..."]
+		"Queries": ["./..."],
+		"Tests": true
 	},
 	"ExpectedResults": [
 		"$WORKDIR/main.go",
+		"$WORKDIR/embed_test.go",
 		"$WORKDIR/hello.txt",
 		"$WORKDIR/data/a.txt",
-		"$WORKDIR/data/b.txt"
+		"$WORKDIR/data/b.txt",
+		"$WORKDIR/hello_test.txt"
 	]
 }


### PR DESCRIPTION
```
resolve/gosource: add testcase for embedding files in go testcases

Test in the embedded_file testcase for golang source resolver if files that are
embedded in testcases are also resolved.

-------------------------------------------------------------------------------
resolve/gosource: log withTests setting with debug priority

When running baur with "--verbose" flag, the golang source resolver now also
logs if go testcases are included in the result.

-------------------------------------------------------------------------------
resolve/gosource: redirect log output to test logger in testcases

This ensures that output can be correlated to the correct testcase.
```