### PR TITLE
update go & golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
 
   static_analysis_linux:
     docker:
-      - image: golangci/golangci-lint:v1.45.1
+      - image: golangci/golangci-lint:v1.49.0
 
     working_directory: ~/baur
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 parameters:
   go-version:
     type: string
-    default: "1.18"
+    default: "1.19.1"
 
 orbs:
   win: circleci/windows@2.2.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - gosimple
     - ineffassign
     - misspell
+    - nolintlint
     - prealloc
     - revive
     - rowserrcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - goimports
@@ -13,11 +12,9 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - vet
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  build-tags:
+    - dbtest
+
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,18 +3,22 @@ linters:
   enable:
     - errcheck
     - exportloopref
+    - gocritic
     - goimports
-    - revive
+    - goprintffuncname
     - gosimple
     - ineffassign
     - misspell
     - prealloc
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
+    - tenv
     - typecheck
     - unconvert
     - unused
+    - usestdlibvars
     - vet
 
 linters-settings:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simplesurance/baur/v2
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Microsoft/hcsshim v0.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -575,7 +575,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -596,7 +595,6 @@ github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5W
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -959,7 +957,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -1044,7 +1041,6 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064 h1:S25/rfnfsMVgORT4/J61MJ7rdyseOZOyvLIrZEZ7s6s=
 golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1138,8 +1134,6 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1265,7 +1259,6 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210903071746-97244b99971b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1528,7 +1521,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -118,8 +118,7 @@ func baurCSVStatus(t *testing.T, inputStr []string, lookupInputStr string) []*cs
 }
 
 func assertStatusTasks(t *testing.T, r *repotest.Repo, statusOut []*csvStatus, expectedStatus baur.TaskStatus, commit string) {
-	var taskIds []string
-
+	taskIds := make([]string, 0, len(statusOut))
 	for _, task := range statusOut {
 		taskIds = append(taskIds, task.taskID)
 
@@ -206,7 +205,6 @@ func TestRunningPendingTasksWithInputStringChangesStatus(t *testing.T) {
 	commit := strings.TrimSpace(res.StrOutput())
 
 	// run 1, without input-strings
-	runID := "1"
 	runCmd := newRunCmd()
 	runCmd.Command.Run(&runCmd.Command, nil)
 
@@ -219,7 +217,7 @@ func TestRunningPendingTasksWithInputStringChangesStatus(t *testing.T) {
 	assertStatusTasks(t, r, statusOut, baur.TaskStatusExecutionPending, "")
 
 	// run 2, with "feature-x", "feature-y" input strings
-	runID = "3" // 3 instead of 2 becoes the app has 2 task, we build both
+	runID := "3" // 3 instead of 2 becoes the app has 2 task, we build both
 	runCmd = newRunCmd()
 	runCmd.inputStr = inputStr
 	runCmd.Command.Run(&runCmd.Command, nil)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package command
@@ -317,13 +318,7 @@ func TestVarInInclude(t *testing.T) {
 	dbURL, err := dbtest.CreateDB(dbtest.UniqueDBName())
 	require.NoError(t, err)
 
-	oldEnvVal := os.Getenv(envVarPSQLURL)
-	t.Cleanup(func() {
-		os.Setenv(envVarPSQLURL, oldEnvVal)
-	})
-
-	err = os.Setenv(envVarPSQLURL, dbURL)
-	require.NoError(t, err)
+	t.Setenv(envVarPSQLURL, dbURL)
 
 	runInitDb(t)
 

--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package command

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -113,9 +113,9 @@ func newStorageClient(psqlURI string) (storage.Storer, error) {
 	return client, nil
 }
 
-//mustGetPSQLURI returns if it's set the URI from the environment variable
-//envVarPSQLURL, otherwise if it's set the psql uri from the repository config,
-//if it's also not empty prints an error and exits.
+// mustGetPSQLURI returns if it's set the URI from the environment variable
+// envVarPSQLURL, otherwise if it's set the psql uri from the repository config,
+// if it's also not empty prints an error and exits.
 func mustGetPSQLURI(cfg *cfg.Repository) string {
 	uri := getPSQLURI(cfg)
 	if uri == "" {

--- a/internal/command/init_include.go
+++ b/internal/command/init_include.go
@@ -34,7 +34,7 @@ func initInclude(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		filename = args[0]
 		if !strings.HasSuffix(filename, ".toml") {
-			filename = filename + ".toml"
+			filename += ".toml"
 		}
 	} else {
 		filename = defIncludeFilename

--- a/internal/command/ls_inputs_test.go
+++ b/internal/command/ls_inputs_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package command

--- a/internal/command/ls_runs_test.go
+++ b/internal/command/ls_runs_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package command

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -91,7 +91,8 @@ date +%s >> "$runtime_logfile"
 		startTime int64
 		endTime   int64
 	}
-	var taskruntimes []runtime
+
+	taskruntimes := make([]runtime, 0, len(runtimeLogfiles))
 	for _, logfile := range runtimeLogfiles {
 		content, err := os.ReadFile(logfile)
 		require.NoError(t, err)
@@ -143,6 +144,7 @@ echo "greetings from script.sh"
 	}
 
 	err = appCfg.ToFile(filepath.Join(r.Dir, ".app.toml"))
+	require.NoError(t, err)
 
 	doInitDb(t)
 
@@ -185,6 +187,7 @@ exit 1
 	}
 
 	err = appCfg.ToFile(filepath.Join(r.Dir, ".app.toml"))
+	require.NoError(t, err)
 
 	doInitDb(t)
 

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -1,10 +1,11 @@
+//go:build dbtest
 // +build dbtest
 
 package command
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -41,7 +42,7 @@ date +%s >> "$runtime_logfile"
 	var runtimeLogfiles []string
 
 	for i := 0; i < parallelTaskCnt; i++ {
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(r.Dir, fmt.Sprintf("checkscript%d.sh", i)),
 			checkScript,
 			0755,
@@ -92,7 +93,7 @@ date +%s >> "$runtime_logfile"
 	}
 	var taskruntimes []runtime
 	for _, logfile := range runtimeLogfiles {
-		content, err := ioutil.ReadFile(logfile)
+		content, err := os.ReadFile(logfile)
 		require.NoError(t, err)
 		lines := strings.Fields(string(content))
 		require.Len(t, lines, 2, "%s file content: %q, expected to find 2 lines", logfile, string(content))
@@ -120,7 +121,7 @@ func TestRunShowOutput(t *testing.T) {
 
 	scriptPath := filepath.Join(r.Dir, "script.sh")
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		scriptPath, []byte(`#/usr/bin/env bash
 echo "greetings from script.sh"
 	`),
@@ -161,7 +162,7 @@ func TestRunShowOutputOnErrorOutputIsPrintedOnce(t *testing.T) {
 
 	scriptPath := filepath.Join(r.Dir, "script.sh")
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		scriptPath, []byte(`#/usr/bin/env bash
 echo "I will fail!"
 exit 1

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -80,19 +80,18 @@ func (c *showCmd) run(cmd *cobra.Command, args []string) {
 }
 
 func mustWriteStringSliceRows(fmt format.Formatter, header string, indentlvl int, sl []string) {
-	defRowArgs := make([]interface{}, 0, indentlvl+1+1)
+	rowArgs := make([]interface{}, 0, indentlvl+1+1)
 
 	for i := 0; i < indentlvl; i++ {
-		defRowArgs = append(defRowArgs, "")
+		rowArgs = append(rowArgs, "")
 	}
 
 	for i, val := range sl {
-		var rowArgs []interface{}
 
 		if i == 0 {
-			rowArgs = append(defRowArgs, header)
+			rowArgs = append(rowArgs, header)
 		} else {
-			rowArgs = append(defRowArgs, "")
+			rowArgs = append(rowArgs, "")
 		}
 
 		if i+1 < len(sl) {

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package command

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package command
@@ -26,13 +27,7 @@ func TestStatusTaskSpecArgParsing(t *testing.T) {
 	dbURL, err := dbtest.CreateDB(dbtest.UniqueDBName())
 	require.NoError(t, err)
 
-	oldEnvVal := os.Getenv(envVarPSQLURL)
-	t.Cleanup(func() {
-		os.Setenv(envVarPSQLURL, oldEnvVal)
-	})
-
-	err = os.Setenv(envVarPSQLURL, dbURL)
-	require.NoError(t, err)
+	t.Setenv(envVarPSQLURL, dbURL)
 
 	runInitDb(t)
 

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -221,7 +221,8 @@ func TestStatusCombininingFieldAndStatusParameters(t *testing.T) {
 	stdoutBuf, _ := interceptCmdOutput(t)
 	statusCmd := newStatusCmd()
 	statusCmd.SetArgs([]string{"-f", "task-id", "-s", "pending"})
-	statusCmd.Execute()
+	err := statusCmd.Execute()
+	require.NoError(t, err)
 
 	require.Contains(t, stdoutBuf.String(), app.Name)
 }

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/simplesurance/baur/v2/internal/command/term"
@@ -64,9 +64,9 @@ func redirectOutputToLogger(t *testing.T) {
 	exec.DefaultDebugfFn = t.Logf
 
 	oldStdout := stdout
-	stdout = term.NewStream(logwriter.New(t, ioutil.Discard))
+	stdout = term.NewStream(logwriter.New(t, io.Discard))
 	oldStderr := stderr
-	stderr = term.NewStream(logwriter.New(t, ioutil.Discard))
+	stderr = term.NewStream(logwriter.New(t, io.Discard))
 
 	t.Cleanup(func() {
 		exec.DefaultDebugfFn = oldExecDebugFfN

--- a/internal/digest/sha384/sha384_test.go
+++ b/internal/digest/sha384/sha384_test.go
@@ -2,7 +2,6 @@ package sha384_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -92,7 +91,7 @@ func TestAddFile(t *testing.T) {
 		testStrSHA384 = "sha384:63e291131dbf905a7fea3ffa4dbd8a49bee10055242e6ff1eea3c3862aefc33a4eb9580dd0c706d48b9ee861abfdacdf"
 	)
 
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal("creating tempfile failed:", err.Error())
 	}
@@ -122,7 +121,7 @@ func TestAddFile(t *testing.T) {
 }
 
 func TestHashingNonExistingFileFails(t *testing.T) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal("creating tempfile failed:", err.Error())
 	}

--- a/internal/resolve/gosource/gosource_test.go
+++ b/internal/resolve/gosource/gosource_test.go
@@ -53,11 +53,11 @@ func TestResolve(t *testing.T) {
 			require.NoError(t, err)
 
 			for i := range testCfg.Cfg.Environment {
-				testCfg.Cfg.Environment[i] = strings.Replace(testCfg.Cfg.Environment[i], "$WORKDIR", cwd, -1)
+				testCfg.Cfg.Environment[i] = strings.ReplaceAll(testCfg.Cfg.Environment[i], "$WORKDIR", cwd)
 			}
 
 			for i := range testCfg.ExpectedResults {
-				testCfg.ExpectedResults[i] = strings.Replace(testCfg.ExpectedResults[i], "$WORKDIR", cwd, -1)
+				testCfg.ExpectedResults[i] = strings.ReplaceAll(testCfg.ExpectedResults[i], "$WORKDIR", cwd)
 				// The path separators in the test config are Unix style "/", they need to be converted to "\" when running on Windows
 				testCfg.ExpectedResults[i] = filepath.FromSlash(testCfg.ExpectedResults[i])
 			}

--- a/internal/resolve/gosource/gosource_test.go
+++ b/internal/resolve/gosource/gosource_test.go
@@ -3,7 +3,6 @@ package gosource
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func TestResolve(t *testing.T) {
 
 			require.NoError(t, os.Chdir(dir))
 
-			fileContent, err := ioutil.ReadFile(testCfgFilename)
+			fileContent, err := os.ReadFile(testCfgFilename)
 			require.NoError(t, err)
 
 			require.NoError(t, err, json.Unmarshal(fileContent, &testCfg))

--- a/internal/testutils/dbtest/dbtest.go
+++ b/internal/testutils/dbtest/dbtest.go
@@ -52,5 +52,5 @@ func CreateDB(name string) (string, error) {
 
 // UniqueDBName returns a unique postgresql database name.
 func UniqueDBName() string {
-	return "baur_test" + strings.Replace(uuid.New().String(), "-", "", -1)
+	return "baur_test" + strings.ReplaceAll(uuid.New().String(), "-", "")
 }

--- a/internal/testutils/fstest/fstest.go
+++ b/internal/testutils/fstest/fstest.go
@@ -2,7 +2,6 @@
 package fstest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +20,7 @@ func WriteToFile(t *testing.T, data []byte, path string) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(path, data, 0644)
+	err = os.WriteFile(path, data, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -2,7 +2,6 @@ package repotest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -282,7 +281,7 @@ func CreateBaurRepository(t *testing.T, opts ...Opt) *Repo {
 
 	t.Logf("database url: %q", dbURL)
 
-	tempDir, err := ioutil.TempDir("", "baur-filesrc-test")
+	tempDir, err := os.MkdirTemp("", "baur-filesrc-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -113,8 +113,8 @@ func (r *Repo) CreateSimpleApp(t *testing.T) *cfg.App {
 
 	r.AppCfgs = append(r.AppCfgs, &app)
 
-	buildFilePath := filepath.Join(filepath.Join(appDir, buildFile))
-	checkFilePath := filepath.Join(filepath.Join(appDir, checkFile))
+	buildFilePath := filepath.Join(appDir, buildFile)
+	checkFilePath := filepath.Join(appDir, checkFile)
 
 	fstest.WriteToFile(t, []byte(`
 #!/bin/sh
@@ -145,13 +145,16 @@ func (r *Repo) CreateAppWithNoOutputs(t *testing.T, appName string) *cfg.App {
 
 	inputFileName := fmt.Sprintf("%s.txt", appName)
 
-	shell := []string{}
-	if runtime.GOOS == "windows" {
-		shell = []string{"cmd", "/C"}
+	newCommandSlice := func() []string {
+		if runtime.GOOS == "windows" {
+			return []string{"cmd", "/C"}
+		}
+
+		return []string{}
 	}
 
-	buildCommand := append(shell, "echo", "build", appName)
-	testCommand := append(shell, "echo", "test", appName)
+	buildCommand := append(newCommandSlice(), "echo", "build", appName)
+	testCommand := append(newCommandSlice(), "echo", "test", appName)
 
 	app := cfg.App{
 		Name: appName,
@@ -193,7 +196,7 @@ func (r *Repo) CreateAppWithNoOutputs(t *testing.T, appName string) *cfg.App {
 
 	r.AppCfgs = append(r.AppCfgs, &app)
 
-	inputFilePath := filepath.Join(filepath.Join(appDir, inputFileName))
+	inputFilePath := filepath.Join(appDir, inputFileName)
 	fstest.WriteToFile(t, []byte(appName), inputFilePath)
 
 	return &app

--- a/internal/upload/filecopy/filecopy.go
+++ b/internal/upload/filecopy/filecopy.go
@@ -32,7 +32,6 @@ func copyFile(src, dst string) error {
 		return fmt.Errorf("opening %s failed: %w", src, err)
 	}
 
-	// nolint: errcheck
 	defer srcFd.Close()
 
 	srcFi, err := os.Stat(src)

--- a/internal/upload/filecopy/filecopy.go
+++ b/internal/upload/filecopy/filecopy.go
@@ -75,10 +75,8 @@ func (c *Client) Upload(src string, dst string) (string, error) {
 			return "", fmt.Errorf("creating directory %s failed: %w", destDir, err)
 		}
 		c.debugLogFn("filecopy: created directory '%s'", destDir)
-	} else {
-		if !isDir {
-			return "", fmt.Errorf("%s is not a directory", destDir)
-		}
+	} else if !isDir {
+		return "", fmt.Errorf("%s is not a directory", destDir)
 	}
 
 	regFile, err := fs.IsRegularFile(dst)

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -28,8 +28,8 @@ func CommandIsInstalled() bool {
 // - .git/ exists or
 // - the "git" command is in $PATH and "git rev-parse --git-dir" returns exit code 0
 // It returns false if:
-// - .git/ does not exist and the "git" command is not in $PATH or "git
-//   rev-parse --git-dir" exits with code 128
+//   - .git/ does not exist and the "git" command is not in $PATH or "git
+//     rev-parse --git-dir" exits with code 128
 func IsGitDir(dir string) (bool, error) {
 	err := fs.DirsExist(filepath.Join(dir, ".git"))
 	if err == nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,6 +18,7 @@ var (
 
 // rawVersion contains a semantic version string (in https://semver.org
 // format). It is initialized with the content of the ver file.
+//
 //go:embed ver
 var rawVersion string
 

--- a/pkg/baur/baur.go
+++ b/pkg/baur/baur.go
@@ -17,19 +17,15 @@
 // inputs of a task, baur evaluates if a task has been run with the same inputs
 // in the past already. If it has not, it's executions is pending.
 //
-// Basic Workflow
+// # Basic Workflow
 //
-// - Loader: Locate and load a repository configuration file, discover
-// applications and load and parse their configuration files.
-//
-// - TaskStatusEvaluator: Query the storage and determine which applications
-// have not been run before with their current inputs.
-//
-// - TaskRunner: Execute the commands for the tasks that should be run.
-//
-// - Uploader: Uploads the outputs that the tasks produced.
-//
-// - StoreRun: Record the task executions the uploaded outputs in the database.
+//   - Loader: Locate and load a repository configuration file, discover
+//     applications and load and parse their configuration files.
+//   - TaskStatusEvaluator: Query the storage and determine which applications
+//     have not been run before with their current inputs.
+//   - TaskRunner: Execute the commands for the tasks that should be run.
+//   - Uploader: Uploads the outputs that the tasks produced.
+//   - StoreRun: Record the task executions the uploaded outputs in the database.
 package baur
 
 // AppCfgFile is the name of application configuration files.

--- a/pkg/baur/cfgupgrade.go
+++ b/pkg/baur/cfgupgrade.go
@@ -62,7 +62,7 @@ func (u *CfgUpgrader) upgradeAppConfigs(
 		log.Debugf("%s: updated", cfgPath)
 
 		for _, includePath := range appCfg.Build.Includes {
-			path := strings.Replace(includePath, "$ROOT", repoRootDir, -1)
+			path := strings.ReplaceAll(includePath, "$ROOT", repoRootDir)
 			if !filepath.IsAbs(path) {
 				path = filepath.Join(app.Path, path)
 			}

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -67,7 +67,7 @@ func (i *InputResolver) Resolve(ctx context.Context, repositoryDir string, task 
 }
 
 func (i *InputResolver) resolveFileInputs(appDir string, inputs []cfg.FileInputs) ([]string, error) {
-	var result []string // nolint:prealloc
+	var result []string
 
 	for _, in := range inputs {
 		if files := i.cache.GetFileInputs(appDir, &in); files != nil {
@@ -113,7 +113,7 @@ func (i *InputResolver) resolveFileInputs(appDir string, inputs []cfg.FileInputs
 }
 
 func (i *InputResolver) resolveGoSrcInputs(ctx context.Context, appDir string, inputs []cfg.GolangSources) ([]string, error) {
-	var result []string // nolint:prealloc
+	var result []string
 
 	for _, gs := range inputs {
 		if files := i.cache.GetGolangSources(appDir, &gs); files != nil {

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -51,9 +51,11 @@ func NewLoader(repoCfg *cfg.Repository, gitCommitIDFunc func() (string, error), 
 // <APP-SPEC> is:
 //   - <APP-NAME> or
 //   - '*'
+//
 // <TASK-SPEC> is:
 //   - Task Name or
 //   - '*'
+//
 // If no specifier is passed all tasks of all apps are returned.
 // If multiple specifiers match the same task, it's only returned 1x in the returned slice.
 func (a *Loader) LoadTasks(specifier ...string) ([]*Task, error) {

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -351,7 +351,7 @@ func isAppDirectory(dir string) bool {
 }
 
 func findAppConfigs(searchDirs []string, searchDepth int) ([]string, error) {
-	var result []string // nolint:prealloc
+	var result []string
 
 	for _, searchDir := range searchDirs {
 		if err := fs.DirsExist(searchDir); err != nil {

--- a/pkg/baur/loader_specifiers.go
+++ b/pkg/baur/loader_specifiers.go
@@ -29,12 +29,13 @@ type specs struct {
 // - '*' to match all apps and tasks,
 // - <APP-DIR-PATH> path to an application directory containing an .app.toml file,
 // <APP-SPEC>[.<TASK-SPEC>] where:
-//     <APP-SPEC> is:
-//       - <APP-NAME> or
-//       - '*'
-//     <TASK-SPEC> is:
-//       - Task Name or
-//       - '*'
+//
+//	<APP-SPEC> is:
+//	  - <APP-NAME> or
+//	  - '*'
+//	<TASK-SPEC> is:
+//	  - Task Name or
+//	  - '*'
 func parseSpecs(specifiers []string) (*specs, error) {
 	var result specs
 

--- a/pkg/cfg/app.go
+++ b/pkg/cfg/app.go
@@ -2,7 +2,7 @@ package cfg
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -79,7 +79,7 @@ func ExampleApp(name string) *App {
 func AppFromFile(path string) (*App, error) {
 	config := App{}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cfg/app_test.go
+++ b/pkg/cfg/app_test.go
@@ -1,7 +1,6 @@
 package cfg
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +10,7 @@ import (
 )
 
 func Test_ExampleApp_WrittenAndReadCfgIsValid(t *testing.T) {
-	tmpfileFD, err := ioutil.TempFile("", "baur")
+	tmpfileFD, err := os.CreateTemp("", "baur")
 	if err != nil {
 		t.Fatal("opening tmpfile failed: ", err)
 	}

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -20,14 +20,14 @@ type toFileOpts struct {
 type toFileOpt func(*toFileOpts)
 
 // ToFileOptOverwrite overwrite an existing file instead of returning an error
-func ToFileOptOverwrite() toFileOpt { // nolint: revive // returns unexported type
+func ToFileOptOverwrite() toFileOpt { //nolint: revive // returns unexported type
 	return func(o *toFileOpts) {
 		o.overwrite = true
 	}
 }
 
 // ToFileOptCommented comment every line in the config
-func ToFileOptCommented() toFileOpt { // nolint: revive // returns unexported type
+func ToFileOptCommented() toFileOpt { //nolint: revive // returns unexported type
 	return func(o *toFileOpts) {
 		o.commented = true
 	}

--- a/pkg/cfg/include.go
+++ b/pkg/cfg/include.go
@@ -3,7 +3,7 @@ package cfg
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -38,7 +38,7 @@ func (incl *Include) ToFile(filepath string, opts ...toFileOpt) error {
 func IncludeFromFile(path string) (*Include, error) {
 	config := Include{}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cfg/repository.go
+++ b/pkg/cfg/repository.go
@@ -2,7 +2,7 @@ package cfg
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pelletier/go-toml"
 )
@@ -41,7 +41,7 @@ type Discover struct {
 func RepositoryFromFile(cfgPath string) (*Repository, error) {
 	config := Repository{}
 
-	content, err := ioutil.ReadFile(cfgPath)
+	content, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cfg/repository_test.go
+++ b/pkg/cfg/repository_test.go
@@ -1,7 +1,6 @@
 package cfg
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -14,7 +13,7 @@ func Test_ExampleRepository_IsValid(t *testing.T) {
 }
 
 func Test_ExampleRepository_WrittenAndReadCfgIsValid(t *testing.T) {
-	tmpfileFD, err := ioutil.TempFile("", "baur")
+	tmpfileFD, err := os.CreateTemp("", "baur")
 	if err != nil {
 		t.Fatal("opening tmpfile failed: ", err)
 	}

--- a/pkg/cfg/resolver/gotemplate_test.go
+++ b/pkg/cfg/resolver/gotemplate_test.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -25,10 +24,7 @@ func TestResolve(t *testing.T) {
 	const commitID = "commit1231231231"
 	const appName = "my-app-name"
 
-	os.Setenv(envVar, envVarVal)
-	t.Cleanup(func() {
-		os.Unsetenv(envVar)
-	})
+	t.Setenv(envVar, envVarVal)
 
 	testCases := []struct {
 		name           string

--- a/pkg/cfg/upgrade/v4/v4.go
+++ b/pkg/cfg/upgrade/v4/v4.go
@@ -131,7 +131,7 @@ func golangSourcesPathsToQuery(paths []string) []string {
 	result := make([]string, 0, len(paths))
 
 	for _, p := range paths {
-		p = p + "/..."
+		p += "/..."
 		result = append(result, replaceVariables(p))
 	}
 

--- a/pkg/storage/filter.go
+++ b/pkg/storage/filter.go
@@ -96,7 +96,7 @@ func (s Order) String() string {
 	}
 }
 
-//OrderFromStr converts a string to an Order
+// OrderFromStr converts a string to an Order
 func OrderFromStr(s string) (Order, error) {
 	switch strings.ToLower(s) {
 	case "asc":

--- a/pkg/storage/postgres/init_test.go
+++ b/pkg/storage/postgres/init_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package postgres

--- a/pkg/storage/postgres/insert_test.go
+++ b/pkg/storage/postgres/insert_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package postgres

--- a/pkg/storage/postgres/query.go
+++ b/pkg/storage/postgres/query.go
@@ -301,7 +301,7 @@ func (c *Client) TaskRuns(
 	}
 
 	var replacer *strings.Replacer
-	if containsInputStringFilter { // nolint: gocritic // ifElseChain: rewrite if-else to switch statement
+	if containsInputStringFilter { //nolint: gocritic // ifElseChain: rewrite if-else to switch statement
 		replacer = strings.NewReplacer(
 			"{distinct_on}", "task_run.id, input_string.string",
 			"{fields}", "input_string.string AS input_string_val,",

--- a/pkg/storage/postgres/query.go
+++ b/pkg/storage/postgres/query.go
@@ -301,7 +301,7 @@ func (c *Client) TaskRuns(
 	}
 
 	var replacer *strings.Replacer
-	if containsInputStringFilter {
+	if containsInputStringFilter { // nolint: gocritic // ifElseChain: rewrite if-else to switch statement
 		replacer = strings.NewReplacer(
 			"{distinct_on}", "task_run.id, input_string.string",
 			"{fields}", "input_string.string AS input_string_val,",

--- a/pkg/storage/postgres/query_test.go
+++ b/pkg/storage/postgres/query_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package postgres
@@ -481,8 +482,8 @@ func TestTaskRuns(t *testing.T) {
 			},
 			sorters: []*storage.Sorter{
 				{
-					storage.FieldDuration,
-					storage.OrderAsc,
+					Field: storage.FieldDuration,
+					Order: storage.OrderAsc,
 				},
 			},
 			expectedTaskRuns: []*storage.TaskRunWithID{
@@ -508,8 +509,8 @@ func TestTaskRuns(t *testing.T) {
 			},
 			sorters: []*storage.Sorter{
 				{
-					storage.FieldDuration,
-					storage.OrderDesc,
+					Field: storage.FieldDuration,
+					Order: storage.OrderDesc,
 				},
 			},
 			expectedTaskRuns: []*storage.TaskRunWithID{

--- a/pkg/storage/postgres/schema_test.go
+++ b/pkg/storage/postgres/schema_test.go
@@ -1,3 +1,4 @@
+//go:build dbtest
 // +build dbtest
 
 package postgres


### PR DESCRIPTION
```
golangci-lint: enable nolintlint linter and fix found issues

fix the following issues found by nolintlint:
        internal/upload/filecopy/filecopy.go:35:2: directive `// nolint: errcheck` should be written without leading space as `//nolint: errcheck` (nolintlint)
        pkg/baur/inputresolver.go:70:22: directive `// nolint:prealloc` should be written without leading space as `//nolint:prealloc` (nolintlint)
        pkg/baur/inputresolver.go:116:22: directive `// nolint:prealloc` should be written without leading space as `//nolint:prealloc` (nolintlint)
        pkg/baur/loader.go:354:22: directive `// nolint:prealloc` should be written without leading space as `//nolint:prealloc` (nolintlint)

-------------------------------------------------------------------------------
tests: fix: minor issues found by golangci-lint

fix the following issues found by golangci-lint:

  internal/command/status_test.go:224:19: Error return value of `statusCmd.Execute` is not checked (errcheck)
  internal/command/diff_inputs_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  internal/command/ls_inputs_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  internal/command/ls_runs_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  internal/command/show_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  internal/command/command_test.go:121:2: Consider pre-allocating `taskIds` (prealloc)
  internal/command/run_test.go:94:2: Consider pre-allocating `taskruntimes` (prealloc)
  internal/command/command_test.go:209:2: ineffectual assignment to runID (ineffassign)
  internal/command/run_test.go:145:2: ineffectual assignment to err (ineffassign)
  internal/command/run_test.go:187:2: ineffectual assignment to err (ineffassign)
  pkg/storage/postgres/init_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  pkg/storage/postgres/insert_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  pkg/storage/postgres/query_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  pkg/storage/postgres/schema_test.go:1: File is not `goimports`-ed with -local github.com/simplesurance/baur/v2 (goimports)
  pkg/storage/postgres/query_test.go:483:5: composites: *github.com/simplesurance/baur/v2/pkg/storage.Sorter struct literal uses unkeyed fields (govet)
  pkg/storage/postgres/query_test.go:510:5: composites: *github.com/simplesurance/baur/v2/pkg/storage.Sorter struct literal uses unkeyed fields (govet)

-------------------------------------------------------------------------------
tests: use t.setenv instead of os.Setenv

-------------------------------------------------------------------------------
golangci-lint: enable linting of files with dbtest buildtag

-------------------------------------------------------------------------------
fix issues found by gocritic

Fix the following issues:

pkg/storage/postgres/query.go:304:2: ifElseChain: rewrite if-else to switch statement (gocritic)
internal/upload/filecopy/filecopy.go:78:9: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
pkg/cfg/upgrade/v4/v4.go:134:3: assignOp: replace `p = p + "/..."` with `p += "/..."` (gocritic)
internal/testutils/dbtest/dbtest.go:55:23: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(uuid.New().String(), "-", "", -1)` (gocritic)
internal/resolve/gosource/gosource_test.go:56:34: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(testCfg.Cfg.Environment[i], "$WORKDIR", cwd, -1)` (gocritic)
internal/resolve/gosource/gosource_test.go:60:34: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(testCfg.ExpectedResults[i], "$WORKDIR", cwd, -1)` (gocritic)
internal/testutils/repotest/repotest.go:153:18: appendAssign: append result not assigned to the same slice (gocritic)
internal/testutils/repotest/repotest.go:154:17: appendAssign: append result not assigned to the same slice (gocritic)
internal/testutils/repotest/repotest.go:116:19: badCall: suspicious Join on 1 argument (gocritic)
internal/testutils/repotest/repotest.go:117:19: badCall: suspicious Join on 1 argument (gocritic)
internal/testutils/repotest/repotest.go:196:19: badCall: suspicious Join on 1 argument (gocritic)
pkg/baur/cfgupgrade.go:65:12: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(includePath, "$ROOT", repoRootDir, -1)` (gocritic)
internal/command/init_include.go:37:4: assignOp: replace `filename = filename + ".toml"` with `filename += ".toml"` (gocritic)
internal/command/show.go:93:14: appendAssign: append result not assigned to the same slice (gocritic)
internal/command/show.go:95:14: appendAssign: append result not assigned to the same slice (gocritic)

-------------------------------------------------------------------------------
golangci-lint: enable gocritic, goprintffuncname, tenv, usestdlibvars

-------------------------------------------------------------------------------
replace usage of deprecated io/ioutil package

This fixes warnings like:
        "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same
        functionality is now provided by package io or package os, and those
        implementations should be preferred in new code. See the specific
        function documentation for details. (staticcheck)

-------------------------------------------------------------------------------
godoc: use go 1.19 documentation syntax

-------------------------------------------------------------------------------
golangci-lint: disable deprecated linters

This fixes:
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

-------------------------------------------------------------------------------
ci: update golangci-lint to version 1.49

-------------------------------------------------------------------------------
go: set minimum version to 1.19 & tidy go.mod

-------------------------------------------------------------------------------
ci: update go to version 1.19.1

-------------------------------------------------------------------------------
```