### PR TITLE
fix TestDifferencesOutputWithCorrectState test fails on windows

### DIFF
--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -93,7 +93,7 @@ func findAllDirsNoDups(result map[string]struct{}, path string) error {
 	return nil
 }
 
-// findAllDirs returns recursively all diretories in path, including the
+// findAllDirs returns recursively all directories in path, including the
 // passed path dir
 func findAllDirs(path string) ([]string, error) {
 	resultMap := map[string]struct{}{}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -214,3 +214,18 @@ func BackupFile(filepath string) error {
 
 	return os.Rename(filepath, bakFilePath)
 }
+
+// RealPath resolves all symlinks and returns the absolute path.
+func RealPath(path string) (string, error) {
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving symlinks in path failed: %w", err)
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("computing absolute path of %q failed: %w", path, err)
+	}
+
+	return absPath, nil
+}

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/simplesurance/baur/v2/internal/digest"
+	"github.com/simplesurance/baur/v2/internal/fs"
 	"github.com/simplesurance/baur/v2/internal/testutils/dbtest"
 	"github.com/simplesurance/baur/v2/internal/testutils/fstest"
 	"github.com/simplesurance/baur/v2/pkg/baur"
@@ -287,6 +288,11 @@ func CreateBaurRepository(t *testing.T, opts ...Opt) *Repo {
 	tempDir, err := os.MkdirTemp("", "baur-filesrc-test")
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	tempDir, err = fs.RealPath(tempDir)
+	if err != nil {
+		t.Fatalf("canonicalizing temp dir path %q failed: %s", tempDir, err)
 	}
 
 	if !options.keepTmpDir {

--- a/pkg/baur/repository.go
+++ b/pkg/baur/repository.go
@@ -34,7 +34,7 @@ func NewRepository(cfgPath string) (*Repository, error) {
 	repoCfg, err := cfg.RepositoryFromFile(realCfgPath)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"reading repository config %s failed: %w", realCfgPath, err)
+			"reading repository config %q failed: %w", realCfgPath, err)
 	}
 
 	err = repoCfg.Validate()


### PR DESCRIPTION
```
repository: use consistent path representation in error message

The error messages returned from NewRepository sometimes quoted the path
sometimes they did not, always quote it.

-------------------------------------------------------------------------------
fix TestDifferencesOutputWithCorrectState failed on Windows

In the Windows CI machine os.MkdirTemp() returned a short DOS Path to the temp
directory used as repository directory.
When input files were resolved, the long path to the repository directory was
used.
This caused that the paths used different representations of the same directory
in TestDifferencesOutputWithCorrectState(), comparing their string
representation failed, they were not equal.

This is the same issue that was fixed in commit
"repository: use canonicalized repo and cfg path" for the Repository struct.

-------------------------------------------------------------------------------
repository: use canonicalized repo and cfg path

When the baur repository was in a path containing a symlink, path to input files
were not relative to the realpath of the repository directory.
For example:

/tmp/baur-repo/inputfile
/tmp/baur-repo-symlink -> /tmp/baur-repo (symlink)

If baur was invoked in /tmp/baur-repo-symlink, input files path were like:
"../../tmp/baur-repo/inputfile, instead of "./inputfile".

Depending on if baur was invoked in the realpath or the path containing a
symlink, the input file paths differ and could cause unnecessary rebuilds.

This is fixed by evaluating all symlinks and using the absolute path of the
configuration file path passed to baur.NewRepository()

-------------------------------------------------------------------------------
fs: fix typo in findAllDirs godoc

-------------------------------------------------------------------------------
```