### PR TITLE
inputresolver: cache glob file results per path

### DIFF
--- a/pkg/cfg/fileinputs.go
+++ b/pkg/cfg/fileinputs.go
@@ -6,6 +6,9 @@ import (
 
 // FileInputs stores glob paths to inputs of a task.
 type FileInputs struct {
+	// if attributes are added/removed or modified, the input resolver
+	// cache *must* be adapted to ensure that the caching logic respects
+	// the attribute change.
 	Paths          []string `toml:"paths" comment:"Glob patterns that match files.\n All Paths are relative to the application directory.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively."`
 	Optional       bool     `toml:"optional" comment:"When optional is true a path pattern that matches 0 files will not cause an error."`
 	GitTrackedOnly bool     `toml:"git_tracked_only" comment:"Only resolve to files that are part of the Git repository."`

--- a/pkg/cfg/golangsources.go
+++ b/pkg/cfg/golangsources.go
@@ -2,6 +2,9 @@ package cfg
 
 // GolangSources specifies inputs for Golang Applications
 type GolangSources struct {
+	// if attributes are added/removed or modified, the input resolver
+	// cache *must* be adapted to ensure that the caching logic respects
+	// the attribute change.
 	Queries     []string `toml:"queries" comment:"Go package queries, the source files of matching packages and\n their imported packages are resolved to files.\n Format:\n \tfile=<RELATIVE-PATH>\n \tfileglob=<GLOB-PATTERN>\t -> Supports double-star\n \tEverything else is passed to the Go query tool (go list by default).\n \tSee also the patterns described at:\n \t<https://github.com/golang/tools/blob/bc8aaaa29e0665201b38fa5cb5d47826788fa249/go/packages/doc.go#L17>.\n Files from Golang's stdlib are ignored."`
 	Environment []string `toml:"environment" comment:"Environment when running the go query tool."`
 	BuildFlags  []string `toml:"build_flags" comment:"List of command-line flags to be passed through to the Go query tool."`


### PR DESCRIPTION
```
inputresolver: cache glob file results per path

An FileInput section in a config file, can contain multile Path specifications.
The input resolver cache was caching results for a while FileInput section.
Each path in a FileInput section was resolved separately though.

Multiple apps can have FileInputs sections that contain the same path with the
same options.
To improve caching, cache the results per path of a FileInput.

-------------------------------------------------------------------------------
cfg: add reminder comment to inputfile structs

Add a comment to remind the person who might modify the attributes of Inputs
specification in the future, to adapt the inputresolver cache also.

-------------------------------------------------------------------------------
```

merge after https://github.com/simplesurance/baur/pull/362