### PR TITLE
inputfile: hash each file only once

### DIFF
--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -206,8 +206,9 @@ func (r *Repo) CreateAppWithNoOutputs(t *testing.T, appName string) *cfg.App {
 func (r *Repo) WriteAdditionalFileContents(t *testing.T, appName, fileName, contents string) *digest.Digest {
 	t.Helper()
 
-	file := baur.NewInputFile(r.Dir, filepath.Join(appName, fileName))
-	fstest.WriteToFile(t, []byte(contents), file.AbsPath())
+	absPath := filepath.Join(r.Dir, appName, fileName)
+	file := baur.NewInputFile(absPath, filepath.Join(appName, fileName))
+	fstest.WriteToFile(t, []byte(contents), absPath)
 
 	digest, err := file.CalcDigest()
 	if err != nil {

--- a/pkg/baur/inputfile.go
+++ b/pkg/baur/inputfile.go
@@ -1,8 +1,6 @@
 package baur
 
 import (
-	"path/filepath"
-
 	"github.com/simplesurance/baur/v2/internal/digest"
 	"github.com/simplesurance/baur/v2/internal/digest/sha384"
 )
@@ -15,10 +13,13 @@ type InputFile struct {
 	digest *digest.Digest
 }
 
-// NewInputFile returns a new input file
-func NewInputFile(repoRootPath, relPath string) *InputFile {
+// NewInputFile creates an InputFile.
+// absPath is the absolute path to the file. It is used to create the digest.
+// relPath is a relative path to the file. It is used as part of the digest. To
+// which base path relPath is relative is arbitrary.
+func NewInputFile(absPath, relPath string) *InputFile {
 	return &InputFile{
-		absPath:     filepath.Join(repoRootPath, relPath),
+		absPath:     absPath,
 		repoRelPath: relPath,
 	}
 }
@@ -33,6 +34,7 @@ func (f *InputFile) RelPath() string {
 	return f.repoRelPath
 }
 
+// AbsPath returns the absolute path of the file.
 func (f *InputFile) AbsPath() string {
 	return f.absPath
 }

--- a/pkg/baur/inputfile_singletoncache.go
+++ b/pkg/baur/inputfile_singletoncache.go
@@ -1,0 +1,34 @@
+package baur
+
+import "path/filepath"
+
+const inputFileSingletonCacheInitialSize = 250
+
+// InputFileSingletonCache stores previously created InputFiles and returns
+// them for the same path instead of creating another instance.
+type InputFileSingletonCache struct {
+	cache map[string]*InputFile
+}
+
+// newInputFile SingletonCache creates a inputFileSingletonCache.
+func NewInputFileSingletonCache() *InputFileSingletonCache {
+	return &InputFileSingletonCache{
+		cache: make(map[string]*InputFile, inputFileSingletonCacheInitialSize),
+	}
+}
+
+// CreateOrGetInputFile returns a new InputFile if none with the same
+// repoRootPath and relPath has been created before with this method.
+// Otherwise it returns a reference to the previously created InputFile.
+func (c *InputFileSingletonCache) CreateOrGetInputFile(repoRootPath, relPath string) *InputFile {
+	absPath := filepath.Join(repoRootPath, relPath)
+
+	if f, exists := c.cache[absPath]; exists {
+		return f
+	}
+
+	f := NewInputFile(repoRootPath, relPath)
+	c.cache[absPath] = f
+
+	return f
+}

--- a/pkg/baur/inputfile_singletoncache.go
+++ b/pkg/baur/inputfile_singletoncache.go
@@ -1,7 +1,5 @@
 package baur
 
-import "path/filepath"
-
 const inputFileSingletonCacheInitialSize = 250
 
 // InputFileSingletonCache stores previously created InputFiles and returns
@@ -20,14 +18,12 @@ func NewInputFileSingletonCache() *InputFileSingletonCache {
 // CreateOrGetInputFile returns a new InputFile if none with the same
 // repoRootPath and relPath has been created before with this method.
 // Otherwise it returns a reference to the previously created InputFile.
-func (c *InputFileSingletonCache) CreateOrGetInputFile(repoRootPath, relPath string) *InputFile {
-	absPath := filepath.Join(repoRootPath, relPath)
-
+func (c *InputFileSingletonCache) CreateOrGetInputFile(absPath, relPath string) *InputFile {
 	if f, exists := c.cache[absPath]; exists {
 		return f
 	}
 
-	f := NewInputFile(repoRootPath, relPath)
+	f := NewInputFile(absPath, relPath)
 	c.cache[absPath] = f
 
 	return f

--- a/pkg/baur/inputfile_singletoncache_test.go
+++ b/pkg/baur/inputfile_singletoncache_test.go
@@ -1,6 +1,7 @@
 package baur
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,9 +9,11 @@ import (
 
 func TestInputFileSingletonCache(t *testing.T) {
 	c := NewInputFileSingletonCache()
-	f1 := c.CreateOrGetInputFile("/etc/", "issue")
-	f2 := c.CreateOrGetInputFile("/etc/", "issue")
-	f3 := c.CreateOrGetInputFile("/etc/", "motd")
+	f1Path := filepath.Join("etc", "issue")
+	f2Path := filepath.Join("etc", "motd")
+	f1 := c.CreateOrGetInputFile(f1Path, "issue")
+	f2 := c.CreateOrGetInputFile(f1Path, "issue")
+	f3 := c.CreateOrGetInputFile(f2Path, "motd")
 
 	require.Same(t, f1, f2)
 	require.NotSame(t, f1, f3)

--- a/pkg/baur/inputfile_singletoncache_test.go
+++ b/pkg/baur/inputfile_singletoncache_test.go
@@ -1,0 +1,17 @@
+package baur
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInputFileSingletonCache(t *testing.T) {
+	c := NewInputFileSingletonCache()
+	f1 := c.CreateOrGetInputFile("/etc/", "issue")
+	f2 := c.CreateOrGetInputFile("/etc/", "issue")
+	f3 := c.CreateOrGetInputFile("/etc/", "motd")
+
+	require.Same(t, f1, f2)
+	require.NotSame(t, f1, f3)
+}

--- a/pkg/baur/inputfile_test.go
+++ b/pkg/baur/inputfile_test.go
@@ -13,17 +13,20 @@ import (
 func TestDigestDoesNotDependOnRepoPath(t *testing.T) {
 	tempdir := t.TempDir()
 
-	repoPath1 := filepath.Join(tempdir, "repo1")
-	repoPath2 := filepath.Join(tempdir, "repo2")
+	repoAbsPath1 := filepath.Join(tempdir, "repo1")
+	repoAbsPath2 := filepath.Join(tempdir, "repo2")
 
 	relFilepath1 := filepath.Join("appdir", "file1")
 	relFilepath2 := filepath.Join("appdir", "file1")
 
-	fstest.WriteToFile(t, []byte("hello"), filepath.Join(repoPath1, relFilepath1))
-	fstest.WriteToFile(t, []byte("hello"), filepath.Join(repoPath2, relFilepath2))
+	absFilepath1 := filepath.Join(repoAbsPath1, relFilepath1)
+	absFilepath2 := filepath.Join(repoAbsPath2, relFilepath2)
 
-	f1 := NewInputFile(repoPath1, relFilepath1)
-	f2 := NewInputFile(repoPath2, relFilepath2)
+	fstest.WriteToFile(t, []byte("hello"), absFilepath1)
+	fstest.WriteToFile(t, []byte("hello"), absFilepath2)
+
+	f1 := NewInputFile(absFilepath1, relFilepath1)
+	f2 := NewInputFile(absFilepath2, relFilepath2)
 
 	d1, err := f1.Digest()
 	require.NoError(t, err)

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -19,18 +19,20 @@ type InputResolver struct {
 	globPathResolver *glob.Resolver
 	goSourceResolver *gosource.Resolver
 
-	vcsState vcs.StateFetcher
-	cache    *inputResolverCache
+	vcsState                vcs.StateFetcher
+	cache                   *inputResolverCache
+	inputFileSingletonCache *InputFileSingletonCache
 }
 
 // NewInputResolver returns an InputResolver that caches resolver
 // results.
 func NewInputResolver(vcsState vcs.StateFetcher) *InputResolver {
 	return &InputResolver{
-		globPathResolver: &glob.Resolver{},
-		goSourceResolver: gosource.NewResolver(log.Debugf),
-		cache:            newInputResolverCache(),
-		vcsState:         vcsState,
+		globPathResolver:        &glob.Resolver{},
+		goSourceResolver:        gosource.NewResolver(log.Debugf),
+		vcsState:                vcsState,
+		cache:                   newInputResolverCache(),
+		inputFileSingletonCache: NewInputFileSingletonCache(),
 	}
 }
 
@@ -160,7 +162,7 @@ func (i *InputResolver) pathsToUniqInputs(repositoryRoot string, pathSlice ...[]
 				return nil, err
 			}
 
-			res = append(res, NewInputFile(repositoryRoot, relPath))
+			res = append(res, i.inputFileSingletonCache.CreateOrGetInputFile(repositoryRoot, relPath))
 		}
 	}
 

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -162,7 +162,7 @@ func (i *InputResolver) pathsToUniqInputs(repositoryRoot string, pathSlice ...[]
 				return nil, err
 			}
 
-			res = append(res, i.inputFileSingletonCache.CreateOrGetInputFile(repositoryRoot, relPath))
+			res = append(res, i.inputFileSingletonCache.CreateOrGetInputFile(path, relPath))
 		}
 	}
 


### PR DESCRIPTION
```
inputfile: accept absolute path instead of repoRelPath in constructor

Change NewInputFile() InputFileSingletonCache.CreateOrGetInputFile() to accept
the absolute path to the file instead of the absolute repository path and relative file path.
The methods created the absolute path from both of these arguments and only used
the absolute and relative path.

The caller (InputResolver) already has the absolute path and can pass it
directly. This prevents redundant filepath.AbsPath() calls.

This is a breaking change. It changes the baur package API.

-------------------------------------------------------------------------------
inputfile: use singleton pattern for input file

Instantiate an InputFile struct only once per file.
Previously if multiple apps had the same file defined as InputFile, for each
app an InputFile was created that calculated the digest.

To prevent calculating the digest multiple times for the same InputFile,
instantiate InputFiles only once per path.

This is achieved by introducing an InputFileSingletonCache struct, that has a
map of absolutePath->*Inputfile. InputFileSingletonCache. CreateOrGetInputFile
returns an *InputFile from the cache if one was created for the same path
before, otherwise it creates one and adds it to the cache.

-------------------------------------------------------------------------------
```


baur status runtime on internal test repo:
- with version 9f415bb:  2m53s
- with this change: 2m25s