### PR TITLE
fs/FindFileInparentDirs: ensure search ends on root path os independent

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -91,7 +91,10 @@ func SameFile(a, b string) (bool, error) {
 // If it reaches the root directory without finding the file it returns
 // os.ErrNotExist.
 func FindFileInParentDirs(startPath, filename string) (string, error) {
-	searchDir := startPath
+	// filepath.Clean() is called to remove excessive PathSeperators from the end.
+	// If this does not happen, the search might be aborted too early because a path
+	// ending in a Separator is interpreted as the root directory.
+	searchDir := filepath.Clean(startPath)
 
 	for {
 		p := filepath.Join(searchDir, filename)
@@ -110,12 +113,11 @@ func FindFileInParentDirs(startPath, filename string) (string, error) {
 			return "", err
 		}
 
-		// TODO: how to detect OS independent if reached the root dir
-		if searchDir == "/" {
+		if searchDir[len(searchDir)-1] == os.PathSeparator {
 			return "", os.ErrNotExist
 		}
 
-		searchDir = filepath.Join(searchDir, "..")
+		searchDir = filepath.Dir(searchDir)
 	}
 }
 

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -1,0 +1,32 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/simplesurance/baur/v2/internal/testutils/fstest"
+)
+
+func TestFindFileInParentDirsOnRoot(t *testing.T) {
+	_, err := FindFileInParentDirs(filepath.FromSlash("/"), "mytestfile-which-must-not-exist-1234")
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestFindFileInParentDirWithExcessivePathSeperator(t *testing.T) {
+	var err error
+	tempdir := fstest.TempDir(t)
+
+	const wantedFilename = ".baur.cfg"
+	const subdir1 = "subdir1"
+	subdir2AbsPath := filepath.Join(tempdir, subdir1, "subdir2")
+	wantedFileAbsPath := filepath.Join(tempdir, subdir1, wantedFilename)
+
+	fstest.WriteToFile(t, []byte("hello"), filepath.Join(tempdir, subdir1, wantedFilename))
+
+	foundPath, err := FindFileInParentDirs(subdir2AbsPath+string(os.PathSeparator), wantedFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, wantedFileAbsPath, foundPath)
+}


### PR DESCRIPTION
address the Todo note that FindFileInparentDirs() might not have been able to detect the root path on all OSes.
This is achieved by:
- using filepath.Dir() to get the path to the parent directory instead of using "..", which might also not have been worked on all OSes. filepath.Dir() returns a path ending in os.PathSeparator only when it is the root path, this is used to detect the root path.
- To prevent that the search aborts too early if an unclean path ending in a PathSeperator is passed as startPath, filepath.Clean() is called on the startPath now