### PR TITLE
inputfiles: improve globbing

### DIFF
--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -69,11 +69,6 @@ func findAllDirsNoDups(result map[string]struct{}, path string) error {
 		return nil
 	}
 
-	path, err = filepath.EvalSymlinks(path)
-	if err != nil {
-		return fmt.Errorf("resolving symlinks in %q failed: %w", path, err)
-	}
-
 	if _, exist := result[path]; exist {
 		return nil
 	}

--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -69,6 +69,11 @@ func findAllDirsNoDups(result map[string]struct{}, path string) error {
 		return nil
 	}
 
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("calculating absolute path of %q failed: %w", path, err)
+	}
+
 	if _, exist := result[path]; exist {
 		return nil
 	}

--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -65,8 +65,24 @@ func TestResolveSymlink(t *testing.T) {
 			},
 		},
 		{
+			testdir:   "directory_broken",
+			inputPath: "**",
+			validateFn: func(t *testing.T, err error, result []Input) {
+				require.ErrorContains(t, err, "no such file or directory")
+				require.Len(t, result, 0)
+			},
+		},
+		{
 			testdir:   "file_broken",
 			inputPath: "symlink",
+			validateFn: func(t *testing.T, err error, result []Input) {
+				require.ErrorContains(t, err, "no such file or directory")
+				require.Len(t, result, 0)
+			},
+		},
+		{
+			testdir:   "file_broken",
+			inputPath: "**",
 			validateFn: func(t *testing.T, err error, result []Input) {
 				require.ErrorContains(t, err, "no such file or directory")
 				require.Len(t, result, 0)


### PR DESCRIPTION
```
tests/inputresolver: add tests for glob patterns matching broken symlinks

Add 2 testcases were "**" glob patterns are used in directories that only
contain broken symlinks.

-------------------------------------------------------------------------------
fs/glob: use AbsPath when keeping track of the already visited directories

Use the AbsolutePath of a directory to keep track of the visited ones.
This should prevent that directories are visited twice because different
representations of the same path are used.

-------------------------------------------------------------------------------
inputfiles: do not resolve directory symlinks

When an InputFile Glob matched a directory that was a symlink, the symlink was
resolved and the resolved directory path was returned.

Do not resolve directory symlinks. This can hide changes in the InputFiles of an
Application and prevent that a task is rerun.

If a task has as Inputfile the real file path defined and a path which contains
a glob + a directory symlink, only the real file path was returned in the
result.
If the input file with the directory symlink was removed or added, the inputs
did not change and would not have triggered a task rerun.

This fixes the TestResolveSymlink testcase failure since d2f8b31.

-------------------------------------------------------------------------------
fs/fileglob: replace Glob() with ReadDirnames

Replace a filepath.Glob() call in findAllDirsNoDups() with os.open +
File.ReadDirnames().

This is more efficient. It is the same was Glob() does internally after it
validated and resolved the Glob path.

Because always Directory/* was passed as glob path, it has the same result.

-------------------------------------------------------------------------------
```