### PR TITLE
show: fix: output of input slice types is broken

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -102,7 +102,7 @@ func mustWriteStringSliceRows(fmt format.Formatter, header string, indentlvl int
 		}
 
 		if i+1 < len(sl) {
-			val += ", "
+			val += ","
 		}
 		rowArgs = append(rowArgs, term.Highlight(val))
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -79,19 +79,26 @@ func (c *showCmd) run(cmd *cobra.Command, args []string) {
 	c.showApp(arg)
 }
 
+func copyAppendSlice(slice []any, elems ...any) []any {
+	res := make([]any, len(slice))
+	copy(res, slice)
+	return append(res, elems...)
+}
+
 func mustWriteStringSliceRows(fmt format.Formatter, header string, indentlvl int, sl []string) {
-	rowArgs := make([]interface{}, 0, indentlvl+1+1)
+	defRowArgs := make([]interface{}, 0, indentlvl+1+1)
 
 	for i := 0; i < indentlvl; i++ {
-		rowArgs = append(rowArgs, "")
+		defRowArgs = append(defRowArgs, "")
 	}
 
 	for i, val := range sl {
+		var rowArgs []any
 
 		if i == 0 {
-			rowArgs = append(rowArgs, header)
+			rowArgs = copyAppendSlice(defRowArgs, header)
 		} else {
-			rowArgs = append(rowArgs, "")
+			rowArgs = copyAppendSlice(defRowArgs, "")
 		}
 
 		if i+1 < len(sl) {

--- a/internal/command/show_internal_test.go
+++ b/internal/command/show_internal_test.go
@@ -22,8 +22,8 @@ func TestMustWriteStringSliceRows(t *testing.T) {
 	formatter.Flush()
 
 	expectedOut := ("" +
-		indentStr + indentStr + hdr + indentStr + elems[0] + ", " + "\n" +
-		hdrIndent + indentStr + indentStr + indentStr + elems[1] + ", " + "\n" +
+		indentStr + indentStr + hdr + indentStr + elems[0] + "," + "\n" +
+		hdrIndent + indentStr + indentStr + indentStr + elems[1] + "," + "\n" +
 		hdrIndent + indentStr + indentStr + indentStr + elems[2] + "\n" +
 		"")
 	assert.Equal(t, expectedOut, buf.String())

--- a/internal/command/show_internal_test.go
+++ b/internal/command/show_internal_test.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/simplesurance/baur/v2/internal/format/table"
+)
+
+func TestMustWriteStringSliceRows(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := table.New(nil, &buf)
+
+	const hdr = "thehdr"
+	const hdrIndent = "      " // " " * len(hdr)
+	const indentlvl = 2
+	const indentStr = "        "
+	elems := []string{"one", "2", "three"}
+	mustWriteStringSliceRows(formatter, hdr, indentlvl, elems)
+	formatter.Flush()
+
+	expectedOut := ("" +
+		indentStr + indentStr + hdr + indentStr + elems[0] + ", " + "\n" +
+		hdrIndent + indentStr + indentStr + indentStr + elems[1] + ", " + "\n" +
+		hdrIndent + indentStr + indentStr + indentStr + elems[2] + "\n" +
+		"")
+	assert.Equal(t, expectedOut, buf.String())
+}


### PR DESCRIPTION
```
show: remove trailing whitespace for slice types

When "baur show" printed a slice type that had  >=2 values, each element was
separated with ", \n".
Change the separator to ",\n"

-------------------------------------------------------------------------------
show: fix: output of input slice types is broken

ec95560 broke the "baur show" output, if an input slice had >1 elements, the
field was printed multiple times, each line repeating the previous input + one
additional one.
Use again a separate slice containing the indentation elements, instead of
appending the output for each row to it.

This commit also adds a testcase for mustWriteStringSliceRows().

-------------------------------------------------------------------------------
```