### PR TITLE
storage: support applying schema migrations

### DIFF
--- a/pkg/storage/postgres/client.go
+++ b/pkg/storage/postgres/client.go
@@ -53,6 +53,7 @@ func (c *Client) Close() error {
 }
 
 type dbConn interface {
+	BeginFunc(context.Context, func(pgx.Tx) error) error
 	QueryRow(context.Context, string, ...interface{}) pgx.Row
 	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
 	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)

--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -508,20 +508,10 @@ func (c *Client) saveTaskRun(ctx context.Context, tx pgx.Tx, taskRun *storage.Ta
 }
 
 func (c *Client) SaveTaskRun(ctx context.Context, taskRun *storage.TaskRunFull) (int, error) {
-	tx, err := c.db.Begin(ctx)
-	if err != nil {
-		return -1, err
-	}
+	var id int
 
-	id, err := c.saveTaskRun(ctx, tx, taskRun)
-	if err != nil {
-		_ = tx.Rollback(ctx)
-		return -1, err
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return -1, err
-	}
-
-	return id, nil
+	return id, c.db.BeginFunc(ctx, func(tx pgx.Tx) (err error) {
+		id, err = c.saveTaskRun(ctx, tx, taskRun)
+		return err
+	})
 }

--- a/pkg/storage/postgres/migrations/1.sql
+++ b/pkg/storage/postgres/migrations/1.sql
@@ -1,0 +1,95 @@
+CREATE TABLE migrations (
+	schema_version integer NOT NULL
+);
+
+INSERT INTO migrations (schema_version) VALUES(1);
+
+CREATE TABLE application (
+	id serial PRIMARY KEY,
+	name text NOT NULL UNIQUE,
+	CONSTRAINT application_name_uniq UNIQUE (name)
+);
+
+CREATE TABLE vcs (
+	id serial PRIMARY KEY,
+	revision text NOT NULL,
+	dirty boolean NOT NULL,
+	CONSTRAINT vcs_revision_dirty_uniq UNIQUE (revision, dirty)
+);
+
+CREATE TABLE output (
+	id serial PRIMARY KEY,
+	name text NOT NULL,
+	type text NOT NULL,
+	digest text NOT NULL,
+	size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+	CONSTRAINT output_name_type_digest_size_bytes_uniq UNIQUE (name, type, digest, size_bytes)
+);
+
+CREATE TABLE upload (
+	id serial PRIMARY KEY,
+	uri text NOT NULL,
+	method text NOT NULL,
+	start_timestamp timestamp with time zone NOT NULL,
+	stop_timestamp timestamp with time zone NOT NULL
+);
+
+CREATE TABLE task (
+	id serial PRIMARY KEY,
+	name text NOT NULL,
+	application_id integer NOT NULL REFERENCES application(id) ON DELETE CASCADE,
+	CONSTRAINT task_name_application_id_uniq UNIQUE (name, application_id)
+);
+
+CREATE TABLE task_run (
+	id serial PRIMARY KEY,
+	vcs_id integer REFERENCES vcs(id),
+	task_id integer NOT NULL REFERENCES task (id) ON DELETE CASCADE,
+	total_input_digest text NOT NULL,
+	start_timestamp timestamp with time zone NOT NULL,
+	stop_timestamp timestamp with time zone NOT NULL,
+	result text NOT NULL,
+	CONSTRAINT result_check CHECK (result in ('success', 'failure'))
+);
+CREATE INDEX idx_task_run_total_input_digest ON task_run(total_input_digest);
+
+CREATE TABLE input_file (
+	id serial PRIMARY KEY,
+	path text NOT NULL,
+	digest text NOT NULL,
+	CONSTRAINT input_file_path_digest_uniq UNIQUE (path, digest)
+);
+CREATE INDEX idx_input_file_path ON input_file(path);
+
+CREATE TABLE input_string (
+	id serial PRIMARY KEY,
+	string text NOT NULL,
+	digest text NOT NULL,
+	CONSTRAINT input_string_digest_uniq UNIQUE (digest)
+);
+/* An index on the input_string.string column would limit the size of the
+  values to the max. size of columns in indexes (8191B).
+*/
+
+CREATE TABLE task_run_file_input (
+	task_run_id integer NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,
+	input_file_id integer NOT NULL REFERENCES input_file(id) ON DELETE CASCADE,
+	CONSTRAINT task_run_file_input_task_run_id_input_id_uniq UNIQUE (task_run_id, input_file_id)
+);
+CREATE INDEX task_run_file_input_task_run_id_idx ON task_run_file_input(task_run_id);
+
+CREATE TABLE task_run_string_input (
+	task_run_id integer NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,
+	input_string_id integer NOT NULL REFERENCES input_string(id) ON DELETE CASCADE,
+	CONSTRAINT task_run_string_input_task_run_id_input_string_id_uniq UNIQUE (task_run_id, input_string_id)
+);
+CREATE INDEX idx_task_run_string_input ON task_run_string_input(task_run_id);
+
+CREATE TABLE task_run_output (
+	task_run_id integer NOT NULL REFERENCES task_run (id) ON DELETE CASCADE,
+	output_id integer NOT NULL REFERENCES output (id) ON DELETE CASCADE,
+	upload_id integer NOT NULL REFERENCES upload(id) ON DELETE CASCADE,
+	CONSTRAINT task_output_task_run_id_output_id_upload_id_uniq UNIQUE (task_run_id, output_id, upload_id)
+);
+
+CREATE INDEX idx_task_run_output_task_run_id ON task_run_output(task_run_id);

--- a/pkg/storage/postgres/schema_test.go
+++ b/pkg/storage/postgres/schema_test.go
@@ -50,3 +50,30 @@ func TestIsCompatible_SchemaVersionDoesNotMatch(t *testing.T) {
 	err = client.IsCompatible(ctx)
 	assert.Error(t, err, "database schema version is not compatible")
 }
+
+func TestApplyMigrations(t *testing.T) {
+	client, cleanupFn := newTestClient(t)
+	defer cleanupFn()
+
+	require.NoError(t, client.Init(ctx))
+
+	err := client.ApplyMigrations(ctx, []*migration{
+		{
+			version: 1,
+			sql:     "CREATE table t1()",
+		},
+		{
+			version: 2,
+			sql:     "CREATE table t2()",
+		},
+	})
+	require.NoError(t, err)
+
+	exist, err := client.tableExists(ctx, "t1")
+	require.NoError(t, err)
+	require.True(t, exist, "t1 table does not exist")
+
+	exist, err = client.tableExists(ctx, "t2")
+	require.NoError(t, err)
+	require.True(t, exist, "t2 table does not exist")
+}

--- a/pkg/storage/postgres/schema_unit_test.go
+++ b/pkg/storage/postgres/schema_unit_test.go
@@ -1,0 +1,64 @@
+package postgres
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustParseMigrations(t *testing.T) {
+	var migrations []*migration
+	assert.NotPanics(t, func() { migrations = mustParseMigrations() })
+
+	assert.NotEmpty(t, migrations)
+
+	assert.Truef(t,
+		sort.SliceIsSorted(migrations, func(i, j int) bool {
+			return migrations[i].version < migrations[j].version
+		}),
+		"returned migrations are not sorted ascending by version: %+v", migrations,
+	)
+}
+
+func TestMigrationsFromVer(t *testing.T) {
+	migrations := []*migration{
+		{
+			version: 0,
+		},
+		{
+			version: 1,
+		},
+		{
+			version: 5,
+		},
+		{
+			version: 7,
+		},
+	}
+
+	t.Run("0", func(t *testing.T) {
+		assert.ElementsMatch(t,
+			migrations,
+			migrationsFromVer(0, migrations),
+		)
+	})
+
+	t.Run("5", func(t *testing.T) {
+		assert.ElementsMatch(t,
+			[]*migration{{version: 5}, {version: 7}},
+			migrationsFromVer(5, migrations),
+		)
+	})
+
+	t.Run("7", func(t *testing.T) {
+		assert.ElementsMatch(t,
+			[]*migration{{version: 7}},
+			migrationsFromVer(7, migrations),
+		)
+	})
+
+	t.Run("8", func(t *testing.T) {
+		assert.Empty(t, migrationsFromVer(8, migrations))
+	})
+}


### PR DESCRIPTION
```
storage: support applying schema migrations

This commit adds support to change the database schema via migrations.

Schema migrations are stored in the embedded FS pkg/storage/postgres/migrations.
They are named as <VERSION>.sql. <VERSION> must be an int32 >=1.
The initial db schema that was stored as a constant in schema.go is moved to
pkg/storage/postgres/migrations/1.sql.

The migrations files are read and the filename is parsed when Init() or
ApplyMigrations() is called.
Init() applies all found migrations files.
ApplyMigrations() only applies the migrations that have a version that is
smaller then schema version stored in the database.

ApplyMigrations() will be used in a following commit.
-------------------------------------------------------------------------------

storage/insert: use BeginFunc from pgx

Use the handy BeginFunc from pgx to use a transaction in SaveTaskRun, instead of
implementing the Begin/Commit/Rollback logic on our own.

-------------------------------------------------------------------------------
```