### PR TITLE
inputs: support tracking environment variables

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -201,7 +201,21 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 			}
 		}
 
-		if len(task.UnresolvedInputs.Files) > 0 && len(task.UnresolvedInputs.GolangSources) > 0 {
+		if len(task.UnresolvedInputs.Files) > 0 && len(task.UnresolvedInputs.EnvironmentVariables) > 0 {
+			mustWriteRow(formatter, "", "", "", "")
+		}
+
+		for i, f := range task.UnresolvedInputs.EnvironmentVariables {
+			mustWriteRow(formatter, "", "", "Type:", term.Highlight("Environment Variable"))
+			mustWriteRow(formatter, "", "", "Optional:", term.Highlight(f.Optional))
+			mustWriteStringSliceRows(formatter, "Names:", 2, f.Names)
+
+			if i+1 < len(task.UnresolvedInputs.EnvironmentVariables) {
+				mustWriteRow(formatter, "", "", "", "")
+			}
+		}
+
+		if len(task.UnresolvedInputs.EnvironmentVariables) > 0 && len(task.UnresolvedInputs.GolangSources) > 0 {
 			mustWriteRow(formatter, "", "", "", "")
 		}
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -177,11 +177,12 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 		var row []interface{}
 		var taskRun *storage.TaskRunWithID
 		var taskStatus baur.TaskStatus
+		var inputs *baur.Inputs
 
 		if storageQueryNeeded {
 			var err error
 
-			taskStatus, _, taskRun, err = statusMgr.Status(ctx, task)
+			taskStatus, inputs, taskRun, err = statusMgr.Status(ctx, task)
 			exitOnErrf(err, "%s: evaluating task status failed", task)
 
 			// querying the build status for all applications can
@@ -200,7 +201,7 @@ func (c *statusCmd) run(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		row = c.statusAssembleRow(repo.Path, task, taskRun, taskStatus)
+		row = c.statusAssembleRow(repo.Path, task, taskRun, taskStatus, inputs)
 
 		mustWriteRow(formatter, row...)
 	}
@@ -228,7 +229,7 @@ func (c *statusCmd) storageQueryIsNeeded() bool {
 	return false
 }
 
-func (c *statusCmd) statusAssembleRow(repositoryDir string, task *baur.Task, taskRun *storage.TaskRunWithID, buildStatus baur.TaskStatus) []interface{} {
+func (c *statusCmd) statusAssembleRow(repositoryDir string, task *baur.Task, taskRun *storage.TaskRunWithID, buildStatus baur.TaskStatus, inputs *baur.Inputs) []interface{} {
 	var row []interface{}
 
 	for _, f := range c.fields.Fields {

--- a/internal/command/storageinputwrapper.go
+++ b/internal/command/storageinputwrapper.go
@@ -32,6 +32,18 @@ func (i *storageInputString) String() string {
 	return fmt.Sprintf("string:%s", i.InputString.String)
 }
 
+type storageInputEnvVar struct {
+	*storage.InputEnvVar
+}
+
+func (i *storageInputEnvVar) String() string {
+	return "$" + i.InputEnvVar.Name
+}
+
+func (i *storageInputEnvVar) Digest() (*digest.Digest, error) {
+	return digest.FromString(i.InputEnvVar.Digest)
+}
+
 func toBaurInputs(inputs *storage.Inputs) []baur.Input {
 	result := make([]baur.Input, 0, len(inputs.Files)+len(inputs.Strings))
 
@@ -41,6 +53,10 @@ func toBaurInputs(inputs *storage.Inputs) []baur.Input {
 
 	for _, in := range inputs.Strings {
 		result = append(result, &storageInputString{InputString: in})
+	}
+
+	for _, in := range inputs.EnvironmentVariables {
+		result = append(result, &storageInputEnvVar{InputEnvVar: in})
 	}
 
 	return result

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -74,3 +74,18 @@ func redirectOutputToLogger(t *testing.T) {
 		stderr = oldStderr
 	})
 }
+
+// interceptExitCode changes the exitFunc to store the exit Code in
+// resultExitCode.
+// If the executed command does not exit with code 0, it will not panic.
+// The previous exitFunc will be restored when the test finished.
+func interceptExitCode(t *testing.T, resultExitCode *int) {
+	oldExitFunc := exitFunc
+	exitFunc = func(code int) {
+		*resultExitCode = code
+	}
+
+	t.Cleanup(func() {
+		exitFunc = oldExitFunc
+	})
+}

--- a/pkg/baur/inputenvar.go
+++ b/pkg/baur/inputenvar.go
@@ -1,0 +1,54 @@
+package baur
+
+import (
+	"fmt"
+
+	"github.com/simplesurance/baur/v2/internal/digest"
+	"github.com/simplesurance/baur/v2/internal/digest/sha384"
+)
+
+// InputEnvVar represents an environment variable that is tracked as baur
+// input.
+type InputEnvVar struct {
+	name   string
+	value  string
+	digest *digest.Digest
+}
+
+// NewInputEnvVar creates an InputEnvVar.
+// InputEnvVar can not distinguish between empty and unset environment variables.
+func NewInputEnvVar(name, value string) *InputEnvVar {
+	return &InputEnvVar{name: name, value: value}
+}
+
+func (v *InputEnvVar) Digest() (*digest.Digest, error) {
+	if v.digest != nil {
+		return v.digest, nil
+	}
+
+	return v.calcDigest()
+}
+
+func (v *InputEnvVar) calcDigest() (*digest.Digest, error) {
+	sha := sha384.New()
+
+	hashStr := fmt.Sprintf("ENV: %s=%s", v.name, v.value)
+	err := sha.AddBytes([]byte(hashStr))
+	if err != nil {
+		return nil, err
+	}
+
+	v.digest = sha.Digest()
+
+	return v.digest, nil
+}
+
+// String returns the name of the environment variable prefixed with a "$".
+func (v *InputEnvVar) String() string {
+	return "$" + v.name
+}
+
+// Name returns the name of the environment variable.
+func (v *InputEnvVar) Name() string {
+	return v.name
+}

--- a/pkg/baur/storage.go
+++ b/pkg/baur/storage.go
@@ -93,6 +93,12 @@ func inputsToStorageInputs(inputs *Inputs) (*storage.Inputs, error) {
 				String: v.Value(),
 				Digest: digest.String(),
 			})
+
+		case *InputEnvVar:
+			result.EnvironmentVariables = append(result.EnvironmentVariables, &storage.InputEnvVar{
+				Name:   v.Name(),
+				Digest: digest.String(),
+			})
 		}
 	}
 

--- a/pkg/cfg/app.go
+++ b/pkg/cfg/app.go
@@ -32,6 +32,12 @@ func ExampleApp(name string) *App {
 							Paths: []string{"dbmigrations/*.sql"},
 						},
 					},
+					EnvironmentVariables: []EnvVarsInputs{
+						{
+							Names:    []string{"APP_VERSION", name + "_*"},
+							Optional: false,
+						},
+					},
 					GolangSources: []GolangSources{
 						{
 							Queries:     []string{"./..."},

--- a/pkg/cfg/envinputs.go
+++ b/pkg/cfg/envinputs.go
@@ -1,0 +1,34 @@
+package cfg
+
+import (
+	"fmt"
+	"strings"
+)
+
+type EnvVarsInputs struct {
+	Names    []string `toml:"names" comment:"Names of environment variables that are tracked.\n Glob patterns are supported, all names are case-sensitive.\n Declared but undefined environment variable are treated as not existing."`
+	Optional bool     `toml:"optional" comment:"When optional is true, a variable pattern matching 0 defined variables will not cause an error."`
+}
+
+// Validate always returns nil.
+func (ei *EnvVarsInputs) Validate() error {
+	// unix and windows OSes agree on `=` being an invalid env name
+	// characters, apart from that Windows allows almost any character,
+	// Linux only a small set.
+	// The validation is kept to a minimum, invalid names will later not
+	// match any defined vars.
+	for _, e := range ei.Names {
+		if len(e) == 0 {
+			return newFieldError("element can not be empty", "variables")
+		}
+
+		if strings.ContainsRune(e, '=') {
+			return newFieldError(
+				fmt.Sprintf("environment variable name %q contains invalid character '='", e),
+				"variables",
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cfg/include.go
+++ b/pkg/cfg/include.go
@@ -122,6 +122,9 @@ func ExampleInclude(id string) *Include {
 				GolangSources: []GolangSources{
 					{},
 				},
+				EnvironmentVariables: []EnvVarsInputs{
+					{},
+				},
 			},
 		},
 		Output: []*OutputInclude{

--- a/pkg/cfg/input.go
+++ b/pkg/cfg/input.go
@@ -2,12 +2,15 @@ package cfg
 
 // Input contains information about task inputs
 type Input struct {
-	Files         []FileInputs
-	GolangSources []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
+	EnvironmentVariables []EnvVarsInputs
+	Files                []FileInputs
+	GolangSources        []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
 }
 
 func (in *Input) IsEmpty() bool {
-	return len(in.Files) == 0 && len(in.GolangSources) == 0
+	return len(in.Files) == 0 &&
+		len(in.GolangSources) == 0 &&
+		len(in.EnvironmentVariables) == 0
 }
 
 func (in *Input) fileInputs() []FileInputs {
@@ -18,10 +21,15 @@ func (in *Input) golangSourcesInputs() []GolangSources {
 	return in.GolangSources
 }
 
+func (in *Input) envVariables() []EnvVarsInputs {
+	return in.EnvironmentVariables
+}
+
 // merge appends the information in other to in.
 func (in *Input) merge(other inputDef) {
 	in.Files = append(in.Files, other.fileInputs()...)
 	in.GolangSources = append(in.GolangSources, other.golangSourcesInputs()...)
+	in.EnvironmentVariables = append(in.EnvironmentVariables, other.envVariables()...)
 }
 
 func (in *Input) resolve(resolver Resolver) error {
@@ -53,6 +61,12 @@ func inputValidate(i inputDef) error {
 	for _, gs := range i.golangSourcesInputs() {
 		if err := gs.validate(); err != nil {
 			return fieldErrorWrap(err, "GolangSources")
+		}
+	}
+
+	for _, env := range i.envVariables() {
+		if err := env.Validate(); err != nil {
+			return fieldErrorWrap(err, "EnvVariables")
 		}
 	}
 

--- a/pkg/cfg/inputdef.go
+++ b/pkg/cfg/inputdef.go
@@ -1,6 +1,7 @@
 package cfg
 
 type inputDef interface {
+	envVariables() []EnvVarsInputs
 	fileInputs() []FileInputs
 	golangSourcesInputs() []GolangSources
 }

--- a/pkg/cfg/inputinclude.go
+++ b/pkg/cfg/inputinclude.go
@@ -8,8 +8,9 @@ import (
 type InputInclude struct {
 	IncludeID string `toml:"include_id" comment:"identifier of the include"`
 
-	Files         []FileInputs
-	GolangSources []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
+	EnvironmentVariables []EnvVarsInputs
+	Files                []FileInputs
+	GolangSources        []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
 
 	filepath string
 }
@@ -22,8 +23,14 @@ func (in *InputInclude) golangSourcesInputs() []GolangSources {
 	return in.GolangSources
 }
 
+func (in *InputInclude) envVariables() []EnvVarsInputs {
+	return in.EnvironmentVariables
+}
+
 func (in *InputInclude) IsEmpty() bool {
-	return len(in.Files) == 0 && len(in.GolangSources) == 0
+	return len(in.Files) == 0 &&
+		len(in.GolangSources) == 0 &&
+		len(in.EnvironmentVariables) == 0
 }
 
 // validate checks if the stored information is valid.

--- a/pkg/storage/postgres/migrations/2.sql
+++ b/pkg/storage/postgres/migrations/2.sql
@@ -1,0 +1,14 @@
+CREATE TABLE input_env_var (
+	id serial PRIMARY KEY,
+	name text NOT NULL,
+	digest text NOT NULL,
+	CONSTRAINT input_env_var_name_digest_uniq UNIQUE (digest)
+);
+CREATE INDEX idx_input_env_var_name ON input_env_var(name);
+
+CREATE TABLE task_run_env_var_input (
+	task_run_id integer NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,
+	input_env_var_id integer NOT NULL REFERENCES input_env_var(id) ON DELETE CASCADE,
+	CONSTRAINT task_run_env_var_input_task_run_id_input_env_var_id_uniq UNIQUE (task_run_id, input_env_var_id)
+);
+CREATE INDEX idx_task_run_env_var_input ON task_run_env_var_input(task_run_id);

--- a/pkg/storage/postgres/query_test.go
+++ b/pkg/storage/postgres/query_test.go
@@ -253,6 +253,17 @@ func TestInputs(t *testing.T) {
 					Digest: "46",
 				},
 			},
+			EnvironmentVariables: []*storage.InputEnvVar{
+				{
+					Name:   "VER",
+					Digest: "45",
+				},
+
+				{
+					Name:   "MYNUMBER",
+					Digest: "9",
+				},
+			},
 		},
 	}
 
@@ -265,6 +276,7 @@ func TestInputs(t *testing.T) {
 
 	assert.ElementsMatch(t, run.Inputs.Files, inputs.Files)
 	assert.ElementsMatch(t, run.Inputs.Strings, inputs.Strings)
+	assert.ElementsMatch(t, run.Inputs.EnvironmentVariables, inputs.EnvironmentVariables)
 }
 
 func TestTaskRun(t *testing.T) {

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -15,7 +15,7 @@ import (
 )
 
 // schemaVer is the database schema version required by this package.
-const schemaVer int32 = 1
+const schemaVer int32 = 2
 
 // migration represents a database schema migration.
 type migration struct {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,9 +20,15 @@ type InputString struct {
 	Digest string
 }
 
+type InputEnvVar struct {
+	Name   string
+	Digest string
+}
+
 type Inputs struct {
-	Files   []*InputFile
-	Strings []*InputString
+	Files                []*InputFile
+	Strings              []*InputString
+	EnvironmentVariables []*InputEnvVar
 }
 
 // UploadMethod is the method that was used to upload the object


### PR DESCRIPTION
This commits adds support to track the value of environment variables as Input. As all other inputs, they can be defined in an include or app configuration file.
The .app.toml configuration sections looks like:
```toml
  [[Task.Input.EnvironmentVariables]]
    names = [
      "APP_VERSION",
      "PAYMENT_APP_*",
    ]
    optional = false
```

Environment variables names can contain go glob patterns. This allows to track all variables that a certain patterns without having to list each of them. If the optional flag is true, baur command that calculate app inputs (baur status, baur run, etc) will fail if no environment variable is defined matching the defined pattern.
Declared but undefined environment variables are treated as non-existing.

The values of environment variables is not stored in the database or shown by "ls inputs", to prevent that secrets are accidentally shown or stored. A new database migration is added that adds table to store the digests of environment variables of runs.


Demonstration: https://github.com/simplesurance/baur-example/commit/2800bb04437aa666a7c76b2beffa41a91b874911