### PR TITLE
implement "baur upgrade db" command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.9
 	github.com/aws/smithy-go v1.13.2
 	github.com/bmatcuk/doublestar/v4 v4.2.0
+	github.com/simplesurance/baur/v2 v2.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -726,6 +726,8 @@ github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simplesurance/baur v0.20.0 h1:XFDXOTU08Lvbg4b8YlhWjDZuZgbgkfQRVI3HTJajq44=
 github.com/simplesurance/baur v0.20.0/go.mod h1:l0g3jW4yM4cxzWCeRCIVamxZAcN3MCO4bAeocdabZRI=
+github.com/simplesurance/baur/v2 v2.2.0 h1:uB5/0l9UoonhCAO8fkfc9fMEykrw2NTa5QThEHfzk34=
+github.com/simplesurance/baur/v2 v2.2.0/go.mod h1:tlaRs/Fvz+EWLbmbLXCqXX8EiixaRxB3a4h6L0+6eNk=
 github.com/simplesurance/doublestar/v4 v4.0.0-20220919144030-63e293d7dccf h1:/icT/XO9uA2jnWxK+HslKdbi1/KzsxxfBE3luh9hYjE=
 github.com/simplesurance/doublestar/v4 v4.0.0-20220919144030-63e293d7dccf/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -106,11 +106,7 @@ func newStorageClient(psqlURI string) (storage.Storer, error) {
 		logger = log.StdLogger
 	}
 
-	client, err := postgres.New(ctx, uri, logger)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
+	return postgres.New(ctx, uri, logger)
 }
 
 // mustGetPSQLURI returns if it's set the URI from the environment variable

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/simplesurance/baur/v3/internal/command/term"
 	"github.com/simplesurance/baur/v3/pkg/baur"
+	"github.com/simplesurance/baur/v3/pkg/storage"
 )
 
 const initDbExample = `
@@ -64,6 +66,10 @@ func initDb(cmd *cobra.Command, args []string) {
 	defer storageClt.Close()
 
 	err = storageClt.Init(ctx)
+	if errors.Is(err, storage.ErrExists) {
+		stderr.ErrPrintln(errors.New("database already exists"))
+		exitFunc(1)
+	}
 	exitOnErr(err)
 
 	stdout.Println("database tables created successfully")

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -44,7 +44,6 @@ func initDb(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		dbURL = args[0]
 	} else {
-
 		repo, err := findRepository()
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/internal/command/upgrade_db.go
+++ b/internal/command/upgrade_db.go
@@ -1,0 +1,75 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simplesurance/baur/v3/internal/command/term"
+	"github.com/simplesurance/baur/v3/pkg/storage"
+)
+
+var upgradeDbLongHelp = `
+Upgrade the database schema.
+
+If the database schema is from an older baur version, the schema is updated.
+This changes the database structure and makes the database incompatible with
+older baur version.
+This is not reversible.
+`
+
+func init() {
+	upgradeCmd.AddCommand(&newUpgradeDatabaseCmd().Command)
+}
+
+type upgradeDbCmd struct {
+	cobra.Command
+}
+
+func newUpgradeDatabaseCmd() *upgradeDbCmd {
+	cmd := upgradeDbCmd{
+		Command: cobra.Command{
+			Use:   "db",
+			Short: "upgrade the database schema",
+			Long:  upgradeDbLongHelp,
+		},
+	}
+
+	cmd.Run = cmd.run
+
+	return &cmd
+}
+
+func (*upgradeDbCmd) run(cmd *cobra.Command, _ []string) {
+	repo := mustFindRepository()
+
+	clt, err := newStorageClient(mustGetPSQLURI(repo.Cfg))
+	exitOnErr(err, "establishing database connection failed")
+	defer clt.Close()
+
+	curVer, err := clt.SchemaVersion(ctx)
+	if errors.Is(err, storage.ErrNotExist) {
+		stderr.ErrPrintln(fmt.Errorf(
+			"database not found, run '%s' to create the database",
+			term.Highlight("baur init db"),
+		))
+		exitFunc(1)
+	}
+	exitOnErr(err, "querying database schema version failed")
+
+	if curVer == clt.RequiredSchemaVersion() {
+		stdout.Println("database schema is already up to date, nothing to do")
+		return
+	}
+
+	if curVer > clt.RequiredSchemaVersion() {
+		stderr.Println("database schema is from a newer baur version, please update baur")
+		exitFunc(1)
+	}
+
+	err = clt.Upgrade(ctx)
+	exitOnErr(err, "upgrading database schema failed")
+
+	stdout.Printf("database schema successfully upgraded from version %d to %d\n", curVer, clt.RequiredSchemaVersion())
+}

--- a/internal/command/upgrade_db_test.go
+++ b/internal/command/upgrade_db_test.go
@@ -1,0 +1,68 @@
+//go:build dbtest
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	oldpostgres "github.com/simplesurance/baur/v2/pkg/storage/postgres"
+
+	"github.com/simplesurance/baur/v3/internal/testutils/repotest"
+)
+
+func TestUpgradeDb_DatabaseNotExist(t *testing.T) {
+	var exitCode int
+
+	initTest(t)
+	_ = repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	_, stderrBuf := interceptCmdOutput(t)
+
+	oldExitFunc := exitFunc
+	exitFunc = func(code int) {
+		exitCode = code
+	}
+	t.Cleanup(func() {
+		exitFunc = oldExitFunc
+	})
+
+	upgradeDbCmd := newUpgradeDatabaseCmd()
+	upgradeDbCmd.Command.Run(&upgradeDbCmd.Command, nil)
+
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderrBuf.String(), "database not found")
+}
+
+func TestUpgradeDb_AlreadyUptodate(t *testing.T) {
+	initTest(t)
+	_ = repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	stdoutBuf, _ := interceptCmdOutput(t)
+
+	initDbCmd.Run(initDbCmd, nil)
+
+	upgradeDbCmd := newUpgradeDatabaseCmd()
+	upgradeDbCmd.Command.Run(&upgradeDbCmd.Command, nil)
+
+	assert.Contains(t, stdoutBuf.String(), "already up to date")
+}
+
+func TestUpgradeDb(t *testing.T) {
+	initTest(t)
+	_ = repotest.CreateBaurRepository(t, repotest.WithNewDB())
+
+	repo := mustFindRepository()
+	uri := mustGetPSQLURI(repo.Cfg)
+
+	oldDbClt, err := oldpostgres.New(ctx, uri, nil)
+	require.NoError(t, err)
+	err = oldDbClt.Init(ctx)
+	require.NoError(t, err)
+
+	stdoutBuf, _ := interceptCmdOutput(t)
+	upgradeDbCmd := newUpgradeDatabaseCmd()
+	upgradeDbCmd.Command.Run(&upgradeDbCmd.Command, nil)
+
+	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 2")
+}

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -251,7 +251,10 @@ func (c *Client) v0SchemaNotExits(ctx context.Context) error {
 	}
 
 	if exists {
-		return errors.New("incompatible database schema from old baur version exists")
+		return errors.New("incompatible database schema from baur version <2 found.\n" +
+			"Upgrading is unsupported.\n" +
+			"Please create a new database.",
+		)
 	}
 
 	return nil

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -103,11 +103,11 @@ func (c *Client) Init(ctx context.Context) error {
 }
 
 // migrationsFromVer returns a slice from migrations that only contains
-// migrations with a version >= minVer.
-// if no migration has a version >=minver, nil is returned.
+// migrations with a version > minVer.
+// if no migration has a version > minver, nil is returned.
 func migrationsFromVer(minVer int32, migrations []*migration) []*migration {
 	for i, m := range migrations {
-		if m.version >= minVer {
+		if m.version > minVer {
 			return migrations[i:]
 		}
 	}

--- a/pkg/storage/postgres/schema_test.go
+++ b/pkg/storage/postgres/schema_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v3/pkg/storage"
 )
 
 func TestIsCompatible_AfterInit(t *testing.T) {
@@ -23,7 +25,7 @@ func TestIsCompatible_SchemaNotExist(t *testing.T) {
 	defer cleanupFn()
 
 	err := client.IsCompatible(ctx)
-	require.EqualError(t, err, "database schema does not exist")
+	require.ErrorIs(t, err, storage.ErrNotExist)
 }
 
 func TestIsCompatible_OldBaurSchemaExist(t *testing.T) {
@@ -57,7 +59,7 @@ func TestApplyMigrations(t *testing.T) {
 
 	require.NoError(t, client.Init(ctx))
 
-	err := client.ApplyMigrations(ctx, []*migration{
+	err := client.applyMigrations(ctx, []*migration{
 		{
 			version: 1,
 			sql:     "CREATE table t1()",

--- a/pkg/storage/postgres/schema_unit_test.go
+++ b/pkg/storage/postgres/schema_unit_test.go
@@ -39,23 +39,20 @@ func TestMigrationsFromVer(t *testing.T) {
 
 	t.Run("0", func(t *testing.T) {
 		assert.ElementsMatch(t,
-			migrations,
+			migrations[1:],
 			migrationsFromVer(0, migrations),
 		)
 	})
 
 	t.Run("5", func(t *testing.T) {
 		assert.ElementsMatch(t,
-			[]*migration{{version: 5}, {version: 7}},
+			[]*migration{{version: 7}},
 			migrationsFromVer(5, migrations),
 		)
 	})
 
 	t.Run("7", func(t *testing.T) {
-		assert.ElementsMatch(t,
-			[]*migration{{version: 7}},
-			migrationsFromVer(7, migrations),
-		)
+		assert.Empty(t, migrationsFromVer(7, migrations))
 	})
 
 	t.Run("8", func(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -99,6 +99,13 @@ const (
 type Storer interface {
 	Close() error
 
+	// SchemaVersion returns the version of the schema that the storage is
+	// using.
+	SchemaVersion(ctx context.Context) (int32, error)
+	// RequiredSchemaVersion returns the schema version that the Storer
+	// implementation requires.
+	RequiredSchemaVersion() int32
+
 	// Init initializes a storage, e.g. creating the database scheme
 	Init(context.Context) error
 	// IsCompatible verifies that the storage is compatible with the baur version

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -10,6 +10,9 @@ import (
 // ErrNotExist indicates that a record does not exist
 var ErrNotExist = errors.New("does not exist")
 
+// ErrExists indicates that the database or a record already exist.
+var ErrExists = errors.New("already exists")
+
 type InputFile struct {
 	Path   string
 	Digest string
@@ -105,11 +108,14 @@ type Storer interface {
 	// RequiredSchemaVersion returns the schema version that the Storer
 	// implementation requires.
 	RequiredSchemaVersion() int32
-
-	// Init initializes a storage, e.g. creating the database scheme
-	Init(context.Context) error
 	// IsCompatible verifies that the storage is compatible with the baur version
 	IsCompatible(context.Context) error
+	// Upgrade upgrades the schema to RequiredSchemaVersion().
+	// If the database does not exist ErrNotExist is returned.
+	Upgrade(ctx context.Context) error
+	// Init initializes a storage, e.g. creating the database scheme.
+	// If it already exist, ErrExist is returned.
+	Init(context.Context) error
 
 	SaveTaskRun(context.Context, *TaskRunFull) (id int, err error)
 	LatestTaskRunByDigest(ctx context.Context, appName, taskName, totalInputDigest string) (*TaskRunWithID, error)

--- a/vendor/github.com/simplesurance/baur/v2/LICENSE
+++ b/vendor/github.com/simplesurance/baur/v2/LICENSE
@@ -1,0 +1,339 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {description}
+    Copyright (C) {year}  {fullname}
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/filter.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/filter.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Field represents data fields that can be used in sort and filter operations
+type Field int
+
+// Defines the available data fields
+const (
+	FieldUndefined Field = iota
+	FieldApplicationName
+	FieldTaskName
+	FieldDuration
+	FieldStartTime
+	FieldID
+	FieldInputString
+	FieldInputFilePath
+)
+
+func (f Field) String() string {
+	switch f {
+	case FieldApplicationName:
+		return "FieldApplicationName"
+	case FieldTaskName:
+		return "FieldTaskName"
+	case FieldDuration:
+		return "FieldDuration"
+	case FieldStartTime:
+		return "FieldStartTime"
+	case FieldID:
+		return "FieldID"
+	case FieldInputString:
+		return "FieldInputString"
+	default:
+		return "FieldUndefined"
+	}
+}
+
+// Filter specifies filter operatons for queries
+type Filter struct {
+	Field    Field
+	Operator Op
+	Value    interface{}
+}
+
+// Op describes the filter operator
+type Op int
+
+const (
+	// OpEQ represents an equal (=) operator
+	OpEQ Op = iota
+	// OpGT represents a greater than (>) operator
+	OpGT
+	// OpLT represents a smaller than (<) operator
+	OpLT
+	// OpIN represents a In operator, works like the SQL IN operator, the
+	// corresponding Value field in The filter struct must be a slice
+	OpIN
+)
+
+func (o Op) String() string {
+	switch o {
+	case OpEQ:
+		return "OpEQ"
+	case OpGT:
+		return "OpGT"
+	default:
+		return "OpUndefined"
+	}
+}
+
+// Order specifies the sort order
+type Order int
+
+const (
+	// SortInvalid represents an invalid sort value
+	SortInvalid Order = iota
+	// OrderAsc sorts ascending
+	OrderAsc
+	// OrderDesc sorts descending
+	OrderDesc
+)
+
+func (s Order) String() string {
+	switch s {
+	case OrderAsc:
+		return "asc"
+	case OrderDesc:
+		return "desc"
+	default:
+		return "invalid"
+	}
+}
+
+//OrderFromStr converts a string to an Order
+func OrderFromStr(s string) (Order, error) {
+	switch strings.ToLower(s) {
+	case "asc":
+		return OrderAsc, nil
+	case "desc":
+		return OrderDesc, nil
+	default:
+		return SortInvalid, errors.New("undefined order")
+	}
+}
+
+// Sorter specifies how the result of queries should be sorted
+type Sorter struct {
+	Field Field
+	Order Order
+}
+
+// String return the string representation
+func (s *Sorter) String() string {
+	return fmt.Sprintf("%s-%s", s.Field, s.Order)
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/client.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/client.go
@@ -1,0 +1,60 @@
+// Package postgres is a baur-storage implementation storing data in postgresql.
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// Client is a postgres storage client
+type Client struct {
+	db   dbConn
+	pool *pgxpool.Pool
+}
+
+// Logger is an interface for logging debug informations
+type Logger interface {
+	Debugln(v ...interface{})
+}
+
+// New returns a new postgres client.
+// If logger is nil, logging is disabled.
+func New(ctx context.Context, url string, logger Logger) (*Client, error) {
+	cfg, err := pgxpool.ParseConfig(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if logger != nil {
+		cfg.ConnConfig.Logger = &pgxLogger{logger: logger}
+		cfg.ConnConfig.LogLevel = pgx.LogLevelInfo
+	}
+
+	con, err := pgxpool.ConnectConfig(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		pool: con,
+		db:   con,
+	}, nil
+}
+
+// Close closes the connections of the client.
+// It always returns a nil error.
+func (c *Client) Close() error {
+	c.pool.Close()
+
+	return nil
+}
+
+type dbConn interface {
+	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
+	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
+	Begin(context.Context) (pgx.Tx, error)
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/errors.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/errors.go
@@ -1,0 +1,32 @@
+package postgres
+
+import (
+	"fmt"
+	"strings"
+)
+
+type queryError struct {
+	Query     string
+	Arguments []interface{}
+	Err       error
+}
+
+func (e *queryError) Unwrap() error {
+	return e.Err
+}
+
+func (e *queryError) Error() string {
+	return fmt.Sprintf("%s\nquery:\n---\n%s\n---\narguments: %s",
+		e.Err,
+		strings.TrimSpace(e.Query),
+		strArgList(e.Arguments...),
+	)
+}
+
+func newQueryError(query string, err error, args ...interface{}) *queryError {
+	return &queryError{
+		Query:     query,
+		Arguments: args,
+		Err:       err,
+	}
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/filters_sorters.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/filters_sorters.go
@@ -1,0 +1,148 @@
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/simplesurance/baur/v2/pkg/storage"
+)
+
+// query assembles an SQL-Query described by storage Filters and Sorters
+type query struct {
+	BaseQuery string
+	Filters   []*storage.Filter
+	Sorters   []*storage.Sorter
+	Limit     uint
+}
+
+func columnName(f storage.Field) (string, error) {
+	switch f {
+	case storage.FieldApplicationName:
+		return "application_name", nil
+	case storage.FieldTaskName:
+		return "task_name", nil
+	case storage.FieldDuration:
+		return "duration", nil
+	case storage.FieldStartTime:
+		return "start_timestamp", nil
+	case storage.FieldID:
+		return "task_run_id", nil
+	case storage.FieldInputString:
+		return "input_string_val", nil
+	case storage.FieldInputFilePath:
+		return "input_file_path", nil
+
+	default:
+		return "", fmt.Errorf("no postgresql mapping for storage field %s exists", f)
+	}
+}
+
+func compileOp(a string, op storage.Op, b string) (string, error) {
+	switch op {
+	case storage.OpEQ:
+		return a + " = " + b, nil
+	case storage.OpGT:
+		return a + " > " + b, nil
+	case storage.OpLT:
+		return a + " < " + b, nil
+	case storage.OpIN:
+		return fmt.Sprintf("%s = ANY (%s)", a, b), nil
+
+	default:
+		return "", fmt.Errorf("no postgresql mapping for storage operator %s exists", op)
+	}
+}
+
+func compileSortOrder(o storage.Order, column string) (string, error) {
+	switch o {
+	case storage.OrderAsc:
+		return column + " ASC", nil
+	case storage.OrderDesc:
+		return column + " DESC ", nil
+
+	default:
+		return "", fmt.Errorf("no postgresql mapping for storage order direction %s exists", o)
+	}
+}
+
+func (q *query) compileFilterStr() (filterStr string, args []interface{}, err error) {
+	if len(q.Filters) == 0 {
+		return
+	}
+
+	for i, f := range q.Filters {
+		column, err := columnName(f.Field)
+		if err != nil {
+			return "", nil, err
+		}
+
+		opStr, err := compileOp(column, f.Operator, fmt.Sprintf("$%d", i+1))
+		if err != nil {
+			return "", nil, err
+		}
+
+		filterStr += opStr
+		args = append(args, f.Value)
+
+		if i+1 < len(q.Filters) {
+			filterStr += " AND "
+		}
+	}
+
+	return "WHERE " + filterStr, args, err
+}
+
+func (q *query) compileSorterStr() (string, error) {
+	if len(q.Sorters) == 0 {
+		return "", nil
+	}
+
+	var sorterStr string
+	for i, f := range q.Sorters {
+		column, err := columnName(f.Field)
+		if err != nil {
+			return "", err
+		}
+
+		orderStr, err := compileSortOrder(f.Order, column)
+		if err != nil {
+			return "", err
+		}
+
+		sorterStr += orderStr
+
+		if i+1 < len(q.Sorters) {
+			sorterStr += ",  "
+		}
+	}
+
+	return "ORDER BY " + sorterStr, nil
+}
+
+func (q *query) compileLimitStr() string {
+	if q.Limit == storage.NoLimit {
+		return ""
+	}
+
+	return fmt.Sprintf("LIMIT %d", q.Limit)
+}
+
+// Compile creates the SQL query string and returns it with the arguments for the query
+func (q *query) Compile() (query string, args []interface{}, err error) {
+	if len(q.Filters) == 0 && len(q.Sorters) == 0 {
+		return q.BaseQuery, nil, nil
+	}
+
+	filterStr, args, err := q.compileFilterStr()
+	if err != nil {
+		return "", nil, err
+	}
+
+	orderStr, err := q.compileSorterStr()
+	if err != nil {
+		return "", nil, err
+	}
+
+	limitStr := q.compileLimitStr()
+
+	return fmt.Sprintf("%s %s %s %s", q.BaseQuery, filterStr, orderStr, limitStr), args, nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/insert.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/insert.go
@@ -1,0 +1,527 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v4"
+
+	"github.com/simplesurance/baur/v2/pkg/storage"
+)
+
+func strArgList(args ...interface{}) string {
+	var result strings.Builder
+
+	result.WriteRune('[')
+
+	for i, arg := range args {
+		fmt.Fprintf(&result, "'%v'", arg)
+
+		if i < len(args)-1 {
+			result.WriteString(", ")
+		}
+	}
+
+	result.WriteRune(']')
+
+	return result.String()
+}
+
+// queryValueStr returns the argument for an SQL VALUES statement with
+// enumerated parameters.
+// It creates pairsCount "($n, $n+1, $n+...)" string pairs, with argsPerPair
+// values per pair.
+func queryValueStr(pairsCount, argsPerPair int) string {
+	var res strings.Builder
+
+	// allocation size is not exact but better then no preallocation:
+	// 4 Bytes per parameter '$nn,' +
+	// 4 bytes for the opening bracket, closing bracket, commata and space
+	res.Grow((argsPerPair * 4) + (pairsCount * 3))
+
+	argNr := 1
+	for i := 0; i < pairsCount; i++ {
+		if i > 0 {
+			res.WriteRune(' ')
+		}
+
+		res.WriteRune('(')
+
+		for j := 0; j < argsPerPair; j++ {
+			fmt.Fprintf(&res, "$%d", argNr)
+			argNr++
+
+			if j < argsPerPair-1 {
+				res.WriteString(", ")
+			}
+		}
+
+		res.WriteRune(')')
+
+		if i < pairsCount-1 {
+			res.WriteString(", ")
+		}
+	}
+
+	return res.String()
+}
+
+func scanIDs(rows pgx.Rows, res *[]int) error {
+	for rows.Next() {
+		var id int
+
+		err := rows.Scan(&id)
+		if err != nil {
+			rows.Close()
+			return err
+		}
+
+		*res = append(*res, id)
+	}
+
+	return rows.Err()
+}
+
+func insertAppIfNotExist(ctx context.Context, db dbConn, appName string) (int, error) {
+	const query = `
+	   INSERT INTO application (name)
+	   VALUES ($1)
+	       ON CONFLICT ON CONSTRAINT application_name_uniq
+	       DO UPDATE SET id=application.id
+	RETURNING id
+	`
+
+	var id int
+
+	if err := db.QueryRow(ctx, query, appName).Scan(&id); err != nil {
+		return -1, newQueryError(query, err, appName)
+	}
+
+	return id, nil
+}
+
+func insertTaskIfNotExist(ctx context.Context, db dbConn, appName, taskName string) (int, error) {
+	var id int
+
+	appID, err := insertAppIfNotExist(ctx, db, appName)
+	if err != nil {
+		return -1, err
+	}
+
+	const query = `
+	   INSERT INTO task (name, application_id)
+	   VALUES ($1, $2)
+	       ON CONFLICT ON CONSTRAINT task_name_application_id_uniq
+	       DO UPDATE SET id=task.id
+	RETURNING id
+	`
+
+	if err := db.QueryRow(ctx, query, taskName, appID).Scan(&id); err != nil {
+		return -1, newQueryError(query, err, appName, taskName)
+	}
+
+	return id, nil
+}
+
+func insertVCSIfNotExist(ctx context.Context, db dbConn, revision string, isDirty bool) (int, error) {
+	const query = `
+	   INSERT INTO vcs (revision, dirty)
+	   VALUES ($1, $2)
+	       ON CONFLICT ON CONSTRAINT vcs_revision_dirty_uniq
+	       DO UPDATE SET id=vcs.id
+	RETURNING id
+	`
+
+	var id int
+
+	if err := db.QueryRow(ctx, query, revision, isDirty).Scan(&id); err != nil {
+		return -1, newQueryError(query, err, revision, isDirty)
+	}
+
+	return id, nil
+}
+
+// clonedSortedInputfiles returns a shallow-copied sorted variant of inputs.
+func clonedSortedInputfiles(inputs []*storage.InputFile) []*storage.InputFile {
+	inputs = append([]*storage.InputFile{}, inputs...)
+
+	sort.Slice(inputs, func(i, j int) bool {
+		switch strings.Compare(inputs[i].Path, inputs[j].Path) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+
+		return strings.Compare(inputs[i].Digest, inputs[j].Digest) == -1
+	})
+
+	return inputs
+}
+
+// clonedSortedInputStrings returns a shallow-copied sorted variant of inputs.
+func clonedSortedInputStrings(inputs []*storage.InputString) []*storage.InputString {
+	inputs = append([]*storage.InputString{}, inputs...)
+
+	sort.Slice(inputs, func(i, j int) bool {
+		switch strings.Compare(inputs[i].String, inputs[j].String) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+
+		return strings.Compare(inputs[i].Digest, inputs[j].Digest) == -1
+	})
+
+	return inputs
+}
+
+func insertInputFilesIfNotExist(ctx context.Context, db dbConn, inputs []*storage.InputFile) ([]int, error) {
+	const stmt1 = `
+           INSERT INTO input_file (path, digest)
+	   VALUES
+`
+	const stmt2 = `
+	       ON CONFLICT ON CONSTRAINT input_file_path_digest_uniq
+	       DO UPDATE SET id=input_file.id
+	RETURNING id
+	`
+
+	// inputs are sorted to prevent an deadlock when running multiple
+	// transaction in parallel doing inserts, see
+	// https://github.com/simplesurance/baur/issues/343
+	inputs = clonedSortedInputfiles(inputs)
+
+	stmtVals := queryValueStr(len(inputs), 2)
+
+	queryArgs := make([]interface{}, 0, len(inputs)*2)
+	for _, in := range inputs {
+		queryArgs = append(queryArgs, in.Path, in.Digest)
+	}
+
+	query := stmt1 + stmtVals + " " + stmt2
+
+	rows, err := db.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, newQueryError(query, err, queryArgs...)
+	}
+
+	ids := make([]int, 0, len(inputs))
+	if err := scanIDs(rows, &ids); err != nil {
+		return nil, newQueryError(query, err, queryArgs...)
+	}
+
+	return ids, nil
+}
+
+func insertInputStringFilesIfNotExist(ctx context.Context, db dbConn, inputs []*storage.InputString) ([]int, error) {
+	const stmt1 = `
+           INSERT INTO input_string (string, digest)
+	   VALUES
+`
+	const stmt2 = `
+	       ON CONFLICT ON CONSTRAINT input_string_digest_uniq
+	       DO UPDATE SET id=input_string.id
+	RETURNING id
+	`
+
+	// inputs are sorted to prevent an deadlock when running multiple
+	// transaction in parallel doing inserts, see
+	// https://github.com/simplesurance/baur/issues/343
+	inputs = clonedSortedInputStrings(inputs)
+
+	stmtVals := queryValueStr(len(inputs), 2)
+
+	queryArgs := make([]interface{}, 0, len(inputs)*2)
+	for _, in := range inputs {
+		queryArgs = append(queryArgs, in.String, in.Digest)
+	}
+
+	query := stmt1 + stmtVals + " " + stmt2
+
+	rows, err := db.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, newQueryError(query, err, queryArgs...)
+	}
+
+	ids := make([]int, 0, len(inputs))
+	if err := scanIDs(rows, &ids); err != nil {
+		return nil, newQueryError(query, err, queryArgs...)
+	}
+
+	return ids, nil
+}
+
+func insertTaskRunInputStringsIfNotExist(ctx context.Context, db dbConn, taskRunID int, inputStrings []*storage.InputString) error {
+	const stmt1 = `
+	INSERT INTO task_run_string_input (task_run_id, input_string_id)
+	VALUES
+	`
+
+	if len(inputStrings) == 0 {
+		return nil
+	}
+
+	inputStringIDs, err := insertInputStringFilesIfNotExist(ctx, db, inputStrings)
+	if err != nil {
+		return err
+	}
+
+	var stmtVals strings.Builder
+	argNr := 2
+	for i := 0; i < len(inputStringIDs); i++ {
+		fmt.Fprintf(&stmtVals, "($1, $%d)", argNr)
+		argNr++
+
+		if i < len(inputStringIDs)-1 {
+			stmtVals.WriteString(", ")
+		}
+	}
+
+	queryArgs := make([]interface{}, 1, (len(inputStringIDs)*2)+2)
+	queryArgs[0] = taskRunID
+
+	for _, inputID := range inputStringIDs {
+		queryArgs = append(queryArgs, inputID)
+	}
+
+	query := stmt1 + stmtVals.String()
+
+	_, err = db.Exec(ctx, query, queryArgs...)
+	if err != nil {
+		return newQueryError(query, err, queryArgs...)
+	}
+
+	return nil
+}
+
+func insertTaskRunInputFilesIfNotExist(ctx context.Context, db dbConn, taskRunID int, inputFiles []*storage.InputFile) error {
+	const stmt1 = `
+	INSERT INTO task_run_file_input (task_run_id, input_file_id)
+	VALUES
+	`
+
+	if len(inputFiles) == 0 {
+		return nil
+	}
+
+	inputIDs, err := insertInputFilesIfNotExist(ctx, db, inputFiles)
+	if err != nil {
+		return err
+	}
+
+	var stmtVals strings.Builder
+	argNr := 2
+	for i := 0; i < len(inputIDs); i++ {
+		fmt.Fprintf(&stmtVals, "($1, $%d)", argNr)
+		argNr++
+
+		if i < len(inputIDs)-1 {
+			stmtVals.WriteString(", ")
+		}
+	}
+
+	queryArgs := make([]interface{}, 1, (len(inputIDs)*2)+2)
+	queryArgs[0] = taskRunID
+
+	for _, inputID := range inputIDs {
+		queryArgs = append(queryArgs, inputID)
+	}
+
+	query := stmt1 + stmtVals.String()
+
+	_, err = db.Exec(ctx, query, queryArgs...)
+	if err != nil {
+		return newQueryError(query, err, queryArgs...)
+	}
+
+	return nil
+}
+
+func insertUploads(ctx context.Context, db dbConn, uploads []*storage.Upload) ([]int, error) {
+	const stmt1 = `
+	INSERT into upload (uri, method, start_timestamp, stop_timestamp)
+	VALUES`
+	const stmt2 = "RETURNING id"
+
+	stmtVals := queryValueStr(len(uploads), 4)
+
+	queryArgs := make([]interface{}, 0, len(uploads)*4)
+	for _, upload := range uploads {
+		queryArgs = append(
+			queryArgs,
+			upload.URI, upload.Method, upload.UploadStartTimestamp, upload.UploadStopTimestamp,
+		)
+	}
+
+	query := stmt1 + stmtVals + " " + stmt2
+
+	rows, err := db.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, newQueryError(query, err, queryArgs...)
+	}
+
+	ids := make([]int, 0, len(uploads))
+	if err := scanIDs(rows, &ids); err != nil {
+		return nil, newQueryError(query, err, queryArgs...)
+	}
+
+	return ids, err
+}
+
+func insertOutputIfNotExist(ctx context.Context, db dbConn, output *storage.Output) (int, error) {
+	const query = `
+	   INSERT INTO output (name, type, digest, size_bytes)
+	   VALUES($1, $2, $3, $4)
+	       ON CONFLICT ON CONSTRAINT output_name_type_digest_size_bytes_uniq
+	       DO UPDATE SET id=output.id
+	RETURNING id
+	`
+
+	var id int
+
+	queryArgs := []interface{}{
+		output.Name,
+		output.Type,
+		output.Digest,
+		output.SizeBytes,
+	}
+
+	err := db.QueryRow(
+		ctx,
+		query,
+		queryArgs...,
+	).Scan(&id)
+	if err != nil {
+		return -1, newQueryError(query, err, queryArgs...)
+	}
+
+	return id, nil
+}
+
+func insertTaskOutputsIfNotExist(ctx context.Context, db dbConn, taskRunID int, outputs []*storage.Output) error {
+	if len(outputs) == 0 {
+		return nil
+	}
+
+	type taskOutput struct {
+		outputID int
+		uploadID int
+	}
+
+	var records []*taskOutput
+
+	for _, output := range outputs {
+		outputID, err := insertOutputIfNotExist(ctx, db, output)
+		if err != nil {
+			return err
+		}
+
+		uploadIDs, err := insertUploads(ctx, db, output.Uploads)
+		if err != nil {
+			return err
+		}
+
+		for _, uploadID := range uploadIDs {
+			records = append(records, &taskOutput{
+				outputID: outputID,
+				uploadID: uploadID,
+			})
+		}
+	}
+
+	const stmt1 = "INSERT INTO task_run_output (task_run_id, output_id, upload_id) VALUES"
+
+	stmtVals := queryValueStr(len(records), 3)
+
+	queryArgs := make([]interface{}, 0, len(records)*3)
+	for _, record := range records {
+		queryArgs = append(queryArgs, taskRunID, record.outputID, record.uploadID)
+	}
+
+	query := stmt1 + stmtVals
+
+	_, err := db.Exec(ctx, query, queryArgs...)
+	if err != nil {
+		return newQueryError(query, err, queryArgs...)
+	}
+
+	return nil
+}
+
+func (c *Client) saveTaskRun(ctx context.Context, tx pgx.Tx, taskRun *storage.TaskRunFull) (int, error) {
+	const query = `
+		   INSERT INTO task_run (vcs_id, task_id, total_input_digest, start_timestamp, stop_timestamp, result)
+		   VALUES($1, $2, $3, $4, $5, $6)
+		RETURNING ID
+		`
+
+	var taskRunID int
+
+	vcsID, err := insertVCSIfNotExist(ctx, tx, taskRun.VCSRevision, taskRun.VCSIsDirty)
+	if err != nil {
+		return -1, fmt.Errorf("storing vcs record failed: %w", err)
+	}
+
+	taskID, err := insertTaskIfNotExist(ctx, tx, taskRun.ApplicationName, taskRun.TaskName)
+	if err != nil {
+		return -1, fmt.Errorf("storing task record failed: %w", err)
+	}
+
+	queryArgs := []interface{}{
+		vcsID,
+		taskID,
+		taskRun.TotalInputDigest,
+		taskRun.StartTimestamp,
+		taskRun.StopTimestamp,
+		taskRun.Result,
+	}
+
+	err = tx.QueryRow(
+		ctx,
+		query,
+		queryArgs...,
+	).Scan(&taskRunID)
+	if err != nil {
+		return -1, newQueryError(query, err, queryArgs...)
+	}
+
+	err = insertTaskRunInputStringsIfNotExist(ctx, tx, taskRunID, taskRun.Inputs.Strings)
+	if err != nil {
+		return -1, err
+	}
+
+	err = insertTaskRunInputFilesIfNotExist(ctx, tx, taskRunID, taskRun.Inputs.Files)
+	if err != nil {
+		return -1, err
+	}
+
+	err = insertTaskOutputsIfNotExist(ctx, tx, taskRunID, taskRun.Outputs)
+	if err != nil {
+		return -1, err
+	}
+
+	return taskRunID, nil
+}
+
+func (c *Client) SaveTaskRun(ctx context.Context, taskRun *storage.TaskRunFull) (int, error) {
+	tx, err := c.db.Begin(ctx)
+	if err != nil {
+		return -1, err
+	}
+
+	id, err := c.saveTaskRun(ctx, tx, taskRun)
+	if err != nil {
+		_ = tx.Rollback(ctx)
+		return -1, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return -1, err
+	}
+
+	return id, nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/logadapter.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/logadapter.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v4"
+)
+
+type pgxLogger struct {
+	logger Logger
+}
+
+func (l *pgxLogger) Log(_ context.Context, level pgx.LogLevel, msg string, data map[string]interface{}) {
+	logArgs := make([]interface{}, 2, 2+len(data))
+	logArgs[0] = level
+	logArgs[1] = msg
+
+	for k, v := range data {
+		logArgs = append(logArgs, fmt.Sprintf("%s=%v", k, v))
+	}
+
+	l.logger.Debugln(logArgs...)
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/query.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/query.go
@@ -1,0 +1,382 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v4"
+
+	"github.com/simplesurance/baur/v2/pkg/storage"
+)
+
+func (c *Client) TaskRun(ctx context.Context, id int) (*storage.TaskRunWithID, error) {
+	var taskRun *storage.TaskRunWithID
+
+	idFilter := []*storage.Filter{
+		{
+			Field:    storage.FieldID,
+			Operator: storage.OpEQ,
+			Value:    id,
+		},
+	}
+
+	err := c.TaskRuns(ctx, idFilter, nil, storage.NoLimit, func(tr *storage.TaskRunWithID) error {
+		taskRun = tr
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if taskRun == nil {
+		panic("TaskRuns returned a nil TaskRunWithID and nil error")
+	}
+
+	return taskRun, nil
+}
+
+func (c *Client) LatestTaskRunByDigest(ctx context.Context, appName, taskName, totalInputDigest string) (*storage.TaskRunWithID, error) {
+	// TODO: improve the query, retrieving the newest record via LIMIT should be slow
+	const query = `
+	SELECT task_run.id,
+	       application.name,
+	       task.name,
+	       vcs.revision,
+	       vcs.dirty,
+	       task_run.total_input_digest,
+	       task_run.start_timestamp,
+	       task_run.stop_timestamp,
+	       task_run.result
+	  FROM application
+	  JOIN task ON application.id = task.application_id
+	  JOIN task_run ON task.id = task_run.task_id
+	  LEFT OUTER JOIN vcs ON vcs.id = task_run.vcs_id
+	 WHERE application.name = $1
+	   AND task.name = $2
+	   AND task_run.total_input_digest = $3
+	 ORDER BY task_run.stop_timestamp DESC
+	 LIMIT 1
+	 `
+
+	var result storage.TaskRunWithID
+
+	row := c.db.QueryRow(ctx, query, appName, taskName, totalInputDigest)
+
+	err := row.Scan(
+		&result.ID,
+		&result.ApplicationName,
+		&result.TaskName,
+		&result.VCSRevision,
+		&result.VCSIsDirty,
+		&result.TotalInputDigest,
+		&result.StartTimestamp,
+		&result.StopTimestamp,
+		&result.Result,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, storage.ErrNotExist
+		}
+
+		return nil, fmt.Errorf("query %s with args: %s failed: %w", query, strArgList(appName, taskName, totalInputDigest), err)
+	}
+
+	return &result, nil
+}
+
+func (c *Client) inputStrings(ctx context.Context, taskRunID int) ([]*storage.InputString, error) {
+	const query = `
+	SELECT input_string.string,
+	       input_string.digest
+	  FROM input_string
+	  JOIN task_run_string_input ON input_string.id = task_run_string_input.input_string_id
+	 WHERE task_run_string_input.task_run_id = $1
+	 `
+
+	var result []*storage.InputString
+
+	rows, err := c.db.Query(ctx, query, taskRunID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, storage.ErrNotExist
+		}
+
+		return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+	}
+
+	for rows.Next() {
+		var input storage.InputString
+
+		if err := rows.Scan(&input.String, &input.Digest); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+		}
+
+		result = append(result, &input)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+	}
+
+	return result, nil
+
+}
+
+func (c *Client) inputFiles(ctx context.Context, taskRunID int) ([]*storage.InputFile, error) {
+	const query = `
+	SELECT input_file.path,
+	       input_file.digest
+	  FROM input_file
+	  JOIN task_run_file_input ON input_file.id = task_run_file_input.input_file_id
+	  WHERE task_run_file_input.task_run_id = $1
+	  `
+
+	var result []*storage.InputFile
+
+	rows, err := c.db.Query(ctx, query, taskRunID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, storage.ErrNotExist
+		}
+
+		return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+	}
+
+	for rows.Next() {
+		var input storage.InputFile
+
+		if err := rows.Scan(&input.Path, &input.Digest); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+		}
+
+		result = append(result, &input)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+	}
+
+	return result, nil
+}
+
+func (c *Client) Inputs(ctx context.Context, taskRunID int) (*storage.Inputs, error) {
+	var result storage.Inputs
+	var err error
+
+	result.Files, err = c.inputFiles(ctx, taskRunID)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Strings, err = c.inputStrings(ctx, taskRunID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Files) == 0 && len(result.Strings) == 0 {
+		return nil, storage.ErrNotExist
+	}
+
+	return &result, nil
+}
+
+func (c *Client) Outputs(ctx context.Context, taskRunID int) ([]*storage.Output, error) {
+	const query = `
+	SELECT output.id,
+	       output.name,
+	       output.type,
+	       output.digest,
+	       output.size_bytes,
+	       upload.uri,
+	       upload.method,
+	       upload.start_timestamp,
+	       upload.stop_timestamp
+	  FROM output
+	  JOIN task_run_output ON task_run_output.output_id = output.id
+	  JOIN upload ON upload.id = task_run_output.upload_id
+	 WHERE task_run_output.task_run_id = $1
+	 `
+
+	resMap := map[int]*storage.Output{}
+
+	rows, err := c.db.Query(ctx, query, taskRunID)
+	if err != nil {
+		return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+	}
+
+	for rows.Next() {
+		var upload storage.Upload
+		var outputID int
+		output := &storage.Output{}
+
+		err := rows.Scan(
+			&outputID,
+			&output.Name,
+			&output.Type,
+			&output.Digest,
+			&output.SizeBytes,
+			&upload.URI,
+			&upload.Method,
+			&upload.UploadStartTimestamp,
+			&upload.UploadStopTimestamp,
+		)
+		if err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+		}
+
+		if rec := resMap[outputID]; rec == nil {
+			resMap[outputID] = output
+		} else {
+			output = rec
+		}
+
+		output.Uploads = append(output.Uploads, &upload)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query %s with arg: %d failed: %w", query, taskRunID, err)
+	}
+
+	if len(resMap) == 0 {
+		return nil, storage.ErrNotExist
+	}
+
+	result := make([]*storage.Output, 0, len(resMap))
+	for _, output := range resMap {
+		result = append(result, output)
+	}
+
+	return result, nil
+}
+
+func (c *Client) TaskRuns(
+	ctx context.Context,
+	filters []*storage.Filter,
+	sorters []*storage.Sorter,
+	limit uint,
+	cb func(*storage.TaskRunWithID) error,
+) error {
+	const queryTemplate = `
+	SELECT task_run_id, application_name, task_name, revision, dirty, total_input_digest, start_timestamp, stop_timestamp, result
+	  FROM (
+	       SELECT DISTINCT ON ({distinct_on})
+		      task_run.id AS task_run_id,
+	              application.name AS application_name,
+	              task.name AS task_name,
+	              vcs.revision,
+	              vcs.dirty,
+	              task_run.total_input_digest,
+	              task_run.start_timestamp AS start_timestamp,
+	              task_run.stop_timestamp,
+	              task_run.result,
+	              {fields}
+	              (EXTRACT(EPOCH FROM (task_run.stop_timestamp - task_run.start_timestamp))::bigint * 1000000000) AS duration
+	         FROM application
+	         JOIN task ON application.id = task.application_id
+	         JOIN task_run ON task.id = task_run.task_id
+		 {joins}
+	         LEFT OUTER JOIN vcs ON vcs.id = task_run.vcs_id
+	       ) tr
+	  `
+
+	containsInputStringFilter := false
+	containsInputFileFilter := false
+	for _, filter := range filters {
+		if filter.Field == storage.FieldInputString {
+			containsInputStringFilter = true
+		} else if filter.Field == storage.FieldInputFilePath {
+			containsInputFileFilter = true
+		}
+	}
+
+	if containsInputFileFilter && containsInputStringFilter {
+		return errors.New("either a FieldInputString or FieldInputFilePath filter can be specified, not both")
+	}
+
+	var replacer *strings.Replacer
+	if containsInputStringFilter {
+		replacer = strings.NewReplacer(
+			"{distinct_on}", "task_run.id, input_string.string",
+			"{fields}", "input_string.string AS input_string_val,",
+			"{joins}", "JOIN task_run_string_input ON task_run_string_input.task_run_id = task_run.id\n"+
+				"JOIN input_string ON input_string.id = task_run_string_input.input_string_id",
+		)
+	} else if containsInputFileFilter {
+		replacer = strings.NewReplacer(
+			"{distinct_on}", "task_run.id, input_file.path",
+			"{fields}", "input_file.path AS input_file_path,",
+			"{joins}", "JOIN task_run_file_input ON task_run_file_input.task_run_id = task_run.id\n"+
+				"JOIN input_file ON input_file.id = task_run_file_input.input_file_id",
+		)
+	} else {
+		replacer = strings.NewReplacer(
+			"{distinct_on}", "task_run.id",
+			"{fields}", "",
+			"{joins}", "")
+	}
+	queryStr := replacer.Replace(queryTemplate)
+
+	var queryReturnedRows bool
+
+	q := query{
+		BaseQuery: queryStr,
+		Filters:   filters,
+		Sorters:   sorters,
+		Limit:     limit,
+	}
+
+	query, args, err := q.Compile()
+	if err != nil {
+		return fmt.Errorf("compiling query string failed: %w", err)
+	}
+
+	rows, err := c.db.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("query %s with args: %s failed: %w", query, strArgList(args), err)
+	}
+
+	for rows.Next() {
+		var taskRun storage.TaskRunWithID
+
+		queryReturnedRows = true
+
+		err := rows.Scan(
+			&taskRun.ID,
+			&taskRun.ApplicationName,
+			&taskRun.TaskName,
+			&taskRun.VCSRevision,
+			&taskRun.VCSIsDirty,
+			&taskRun.TotalInputDigest,
+			&taskRun.StartTimestamp,
+			&taskRun.StopTimestamp,
+			&taskRun.Result,
+		)
+
+		if err != nil {
+			rows.Close()
+			return fmt.Errorf("query %s with args: %s failed: %w", query, strArgList(args), err)
+		}
+
+		if err := cb(&taskRun); err != nil {
+			rows.Close()
+			return fmt.Errorf("callback failed: %w", err)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("query %s with args: %s failed: %w", query, strArgList(args), err)
+	}
+
+	if !queryReturnedRows {
+		return storage.ErrNotExist
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/schema.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/postgres/schema.go
@@ -1,0 +1,212 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+const schemaVer = 1
+
+const initQuery = `
+CREATE TABLE migrations (
+	schema_version integer NOT NULL
+);
+
+INSERT INTO migrations (schema_version) VALUES(1);
+
+CREATE TABLE application (
+	id serial PRIMARY KEY,
+	name text NOT NULL UNIQUE,
+	CONSTRAINT application_name_uniq UNIQUE (name)
+);
+
+CREATE TABLE vcs (
+	id serial PRIMARY KEY,
+	revision text NOT NULL,
+	dirty boolean NOT NULL,
+	CONSTRAINT vcs_revision_dirty_uniq UNIQUE (revision, dirty)
+);
+
+CREATE TABLE output (
+	id serial PRIMARY KEY,
+	name text NOT NULL,
+	type text NOT NULL,
+	digest text NOT NULL,
+	size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+	CONSTRAINT output_name_type_digest_size_bytes_uniq UNIQUE (name, type, digest, size_bytes)
+);
+
+CREATE TABLE upload (
+	id serial PRIMARY KEY,
+	uri text NOT NULL,
+	method text NOT NULL,
+	start_timestamp timestamp with time zone NOT NULL,
+	stop_timestamp timestamp with time zone NOT NULL
+);
+
+CREATE TABLE task (
+	id serial PRIMARY KEY,
+	name text NOT NULL,
+	application_id integer NOT NULL REFERENCES application(id) ON DELETE CASCADE,
+	CONSTRAINT task_name_application_id_uniq UNIQUE (name, application_id)
+);
+
+CREATE TABLE task_run (
+	id serial PRIMARY KEY,
+	vcs_id integer REFERENCES vcs(id),
+	task_id integer NOT NULL REFERENCES task (id) ON DELETE CASCADE,
+	total_input_digest text NOT NULL,
+	start_timestamp timestamp with time zone NOT NULL,
+	stop_timestamp timestamp with time zone NOT NULL,
+	result text NOT NULL,
+	CONSTRAINT result_check CHECK (result in ('success', 'failure'))
+);
+CREATE INDEX idx_task_run_total_input_digest ON task_run(total_input_digest);
+
+CREATE TABLE input_file (
+	id serial PRIMARY KEY,
+	path text NOT NULL,
+	digest text NOT NULL,
+	CONSTRAINT input_file_path_digest_uniq UNIQUE (path, digest)
+);
+CREATE INDEX idx_input_file_path ON input_file(path);
+
+CREATE TABLE input_string (
+	id serial PRIMARY KEY,
+	string text NOT NULL,
+	digest text NOT NULL,
+	CONSTRAINT input_string_digest_uniq UNIQUE (digest)
+);
+/* An index on the input_string.string column would limit the size of the
+  values to the max. size of columns in indexes (8191B).
+*/
+
+CREATE TABLE task_run_file_input (
+	task_run_id integer NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,
+	input_file_id integer NOT NULL REFERENCES input_file(id) ON DELETE CASCADE,
+	CONSTRAINT task_run_file_input_task_run_id_input_id_uniq UNIQUE (task_run_id, input_file_id)
+);
+CREATE INDEX task_run_file_input_task_run_id_idx ON task_run_file_input(task_run_id);
+
+CREATE TABLE task_run_string_input (
+	task_run_id integer NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,
+	input_string_id integer NOT NULL REFERENCES input_string(id) ON DELETE CASCADE,
+	CONSTRAINT task_run_string_input_task_run_id_input_string_id_uniq UNIQUE (task_run_id, input_string_id)
+);
+
+CREATE INDEX idx_task_run_string_input ON task_run_string_input(task_run_id);
+
+CREATE TABLE task_run_output (
+	task_run_id integer NOT NULL REFERENCES task_run (id) ON DELETE CASCADE,
+	output_id integer NOT NULL REFERENCES output (id) ON DELETE CASCADE,
+	upload_id integer NOT NULL REFERENCES upload(id) ON DELETE CASCADE,
+	CONSTRAINT task_output_task_run_id_output_id_upload_id_uniq UNIQUE (task_run_id, output_id, upload_id)
+);
+
+CREATE INDEX idx_task_run_output_task_run_id ON task_run_output(task_run_id);
+`
+
+// Init creates the baur tables in the postgresql database
+func (c *Client) Init(ctx context.Context) error {
+	_, err := c.db.Exec(ctx, initQuery)
+
+	return err
+}
+
+// IsCompatible checks if the database schema exist and has the required
+// migration version.
+func (c *Client) IsCompatible(ctx context.Context) error {
+	if err := c.v0SchemaNotExits(ctx); err != nil {
+		return err
+	}
+
+	if err := c.schemaExist(ctx); err != nil {
+		return err
+	}
+
+	return c.ensureSchemaIsCompatible(ctx)
+}
+
+func (c *Client) ensureSchemaIsCompatible(ctx context.Context) error {
+	var rowsCount int
+
+	rows, err := c.db.Query(ctx, "SELECT schema_version from migrations")
+	if err != nil {
+		return fmt.Errorf("querying schema_version failed: %w", err)
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var ver int
+
+		if rowsCount != 0 {
+			return errors.New("migrations table contains >1 rows")
+		}
+
+		err = rows.Scan(&ver)
+		if err != nil {
+			return err
+		}
+
+		if ver != schemaVer {
+			return fmt.Errorf("database schema version is not compatible with baur version, schema version: %d, expected version: %d", ver, schemaVer)
+		}
+
+		rowsCount++
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if rowsCount != 1 {
+		return fmt.Errorf("read %d rows from migrations table, expected 1", rowsCount)
+	}
+
+	return nil
+}
+
+func (c *Client) tableExists(ctx context.Context, tableName string) (bool, error) {
+	const query = `
+	SELECT EXISTS
+	       (
+		SELECT FROM pg_tables
+		 WHERE schemaname = 'public'
+		   AND tablename = $1
+	       )
+`
+
+	var exists bool
+
+	err := c.db.QueryRow(ctx, query, tableName).Scan(&exists)
+
+	return exists, err
+}
+
+func (c *Client) v0SchemaNotExits(ctx context.Context) error {
+	exists, err := c.tableExists(ctx, "input_build")
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		return errors.New("incompatible database schema from old baur version exists")
+	}
+
+	return nil
+}
+
+func (c *Client) schemaExist(ctx context.Context) error {
+	exists, err := c.tableExists(ctx, "migrations")
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return errors.New("database schema does not exist")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/storage/storage.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/storage/storage.go
@@ -1,0 +1,122 @@
+// Package storage provides an interface for baur data storage implementations.
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNotExist indicates that a record does not exist
+var ErrNotExist = errors.New("does not exist")
+
+type InputFile struct {
+	Path   string
+	Digest string
+}
+
+type InputString struct {
+	String string
+	Digest string
+}
+
+type Inputs struct {
+	Files   []*InputFile
+	Strings []*InputString
+}
+
+// UploadMethod is the method that was used to upload the object
+type UploadMethod string
+
+const (
+	UploadMethodS3             UploadMethod = "s3"
+	UploadMethodDockerRegistry UploadMethod = "docker"
+	UploadMethodFileCopy       UploadMethod = "filecopy"
+)
+
+type Upload struct {
+	URI                  string
+	UploadStartTimestamp time.Time
+	UploadStopTimestamp  time.Time
+	Method               UploadMethod
+}
+
+type ArtifactType string
+
+const (
+	ArtifactTypeDocker ArtifactType = "docker"
+	ArtifactTypeFile   ArtifactType = "file"
+)
+
+type Output struct {
+	Name      string
+	Type      ArtifactType
+	Digest    string
+	SizeBytes uint64
+	Uploads   []*Upload
+}
+
+type Result string
+
+const (
+	ResultSuccess Result = "success"
+	ResultFailure Result = "failure"
+)
+
+type TaskRun struct {
+	ApplicationName  string
+	TaskName         string
+	VCSRevision      string
+	VCSIsDirty       bool
+	StartTimestamp   time.Time
+	StopTimestamp    time.Time
+	TotalInputDigest string
+	Result           Result
+}
+
+type TaskRunFull struct {
+	TaskRun
+	Inputs  Inputs
+	Outputs []*Output
+}
+
+type TaskRunWithID struct {
+	ID int
+	TaskRun
+}
+
+const (
+	NoLimit uint = 0
+)
+
+// Storer is an interface for storing and retrieving baur task runs
+type Storer interface {
+	Close() error
+
+	// Init initializes a storage, e.g. creating the database scheme
+	Init(context.Context) error
+	// IsCompatible verifies that the storage is compatible with the baur version
+	IsCompatible(context.Context) error
+
+	SaveTaskRun(context.Context, *TaskRunFull) (id int, err error)
+	LatestTaskRunByDigest(ctx context.Context, appName, taskName, totalInputDigest string) (*TaskRunWithID, error)
+
+	TaskRun(ctx context.Context, id int) (*TaskRunWithID, error)
+	// TaskRuns queries the storage for runs that match the filters.
+	// A limit value of 0 will return all results.
+	// The found results are passed in iterative manner to the callback
+	// function. When the callback function returns an error, the iteration
+	// stops.
+	// When no matching records exist, the method returns ErrNotExist.
+	TaskRuns(ctx context.Context,
+		filters []*Filter,
+		sorters []*Sorter,
+		limit uint,
+		callback func(*TaskRunWithID) error,
+	) error
+
+	// Inputs returns the inputs of a task run. If no records were found,
+	// the method returns ErrNotExist.
+	Inputs(ctx context.Context, taskRunID int) (*Inputs, error)
+	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -300,6 +300,10 @@ github.com/simplesurance/baur/resolve/gosource
 github.com/simplesurance/baur/storage
 github.com/simplesurance/baur/upload/docker
 github.com/simplesurance/baur/upload/scheduler
+# github.com/simplesurance/baur/v2 v2.2.0
+## explicit; go 1.17
+github.com/simplesurance/baur/v2/pkg/storage
+github.com/simplesurance/baur/v2/pkg/storage/postgres
 # github.com/sirupsen/logrus v1.9.0
 ## explicit; go 1.13
 github.com/sirupsen/logrus


### PR DESCRIPTION
Implement a new baur subcommand (`baur upgrade db`) to upgrade the database schema to a newer version.
The public storage API is extended for methods to upgrade db and get the current and required schema version.
Testcases for the `upgrade db` command are added, which are creating a database schema via the baur 2.x packages and then upgrading the db.

See commit messages for more details