### PR TITLE
inputresolver: improve caching + minor improvements

### DIFF
--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -1,16 +1,17 @@
 package fs
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-// FileGlob resolves the pattern to absolute file paths.
-// Files are resolved in the same way then filepath.Glob() does, with  Exceptions:
+// FileGlob resolves the pattern to file paths.
+// If the pattern is an absolute path, absolute paths are returned, otherwise
+// relative paths.
+// Files are resolved in the same way then filepath.Glob() does, with the
+// following exceptions:
 // - it also supports '**' to match files and directories recursively,
 // - it only returns paths to files, no directory paths,
+// - if a part of the pattern is a filepath and it does not exist, an errur is returned,
 // If a globPath doesn't match any files an empty []string is returned and
 // error is nil
 func FileGlob(pattern string) ([]string, error) {
@@ -20,13 +21,8 @@ func FileGlob(pattern string) ([]string, error) {
 	}
 
 	res := make([]string, 0, len(globRes))
-	for _, r := range globRes {
-		absPath, err := filepath.Abs(r)
-		if err != nil {
-			return nil, fmt.Errorf("evaluating absolute path of %q failed: %w", absPath, err)
-		}
-
-		isFile, err := IsFile(absPath)
+	for _, path := range globRes {
+		isFile, err := IsFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +30,8 @@ func FileGlob(pattern string) ([]string, error) {
 		if !isFile {
 			continue
 		}
-		res = append(res, absPath)
+
+		res = append(res, path)
 	}
 
 	return res, err

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -199,16 +199,15 @@ func Mkdir(path string) error {
 // AbsPaths ensures that all elements in paths are absolute paths.
 // If an element is not an absolute path, it is joined with rootPath.
 func AbsPaths(rootPath string, paths []string) []string {
-	result := make([]string, 0, len(rootPath))
+	result := make([]string, len(paths))
 
-	for _, p := range paths {
+	for i, p := range paths {
 		if filepath.IsAbs(p) {
-			result = append(result, p)
+			result[i] = p
 			continue
 		}
 
-		absPath := filepath.Join(rootPath, p)
-		result = append(result, absPath)
+		result[i] = filepath.Join(rootPath, p)
 	}
 
 	return result

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -196,12 +196,18 @@ func Mkdir(path string) error {
 	return os.MkdirAll(path, os.FileMode(0755))
 }
 
-// AbsPaths prepends to all paths in relPaths the passed rootPath.
-func AbsPaths(rootPath string, relPaths []string) []string {
+// AbsPaths ensures that all elements in paths are absolute paths.
+// If an element is not an absolute path, it is joined with rootPath.
+func AbsPaths(rootPath string, paths []string) []string {
 	result := make([]string, 0, len(rootPath))
 
-	for _, relPath := range relPaths {
-		absPath := filepath.Join(rootPath, relPath)
+	for _, p := range paths {
+		if filepath.IsAbs(p) {
+			result = append(result, p)
+			continue
+		}
+
+		absPath := filepath.Join(rootPath, p)
 		result = append(result, absPath)
 	}
 

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -56,7 +56,6 @@ func (i *InputResolver) Resolve(ctx context.Context, repositoryDir string, task 
 	allInputsPaths := make([]string, 0, len(goSourcePaths)+len(globPaths)+len(task.CfgFilepaths))
 	allInputsPaths = append(allInputsPaths, globPaths...)
 	allInputsPaths = append(allInputsPaths, goSourcePaths...)
-
 	allInputsPaths = append(allInputsPaths, task.CfgFilepaths...)
 
 	uniqInputs, err := i.pathsToUniqInputs(repositoryDir, allInputsPaths)
@@ -82,7 +81,7 @@ func (i *InputResolver) resolveCacheFileGlob(path string, optional bool) ([]stri
 	// If !optional and parts of the path does not exist an error must be returned.
 	// We can not use cached results of lookups with optional
 	// flag enabled, if an lookup with !optional is requested, it would
-	// supress non-existing path errors.
+	// suppress non-existing path errors.
 	// Also only successful !optional must be cached.
 	cacheKey := inputResolverFileCacheKey{
 		Path:     path,
@@ -189,32 +188,26 @@ func (i *InputResolver) resolveGoSrcInputs(ctx context.Context, appDir string, i
 	return result, nil
 }
 
-func (i *InputResolver) pathsToUniqInputs(repositoryRoot string, pathSlice ...[]string) ([]Input, error) {
-	var pathsCount int
-
-	for _, paths := range pathSlice {
-		pathsCount += len(paths)
-	}
+func (i *InputResolver) pathsToUniqInputs(repositoryRoot string, paths []string) ([]Input, error) {
+	pathsCount := len(paths)
 
 	res := make([]Input, 0, pathsCount)
 	dedupMap := make(map[string]struct{}, pathsCount)
 
-	for _, paths := range pathSlice {
-		for _, path := range paths {
-			if _, exist := dedupMap[path]; exist {
-				log.Debugf("removed duplicate input %q", path)
-				continue
-			}
-
-			dedupMap[path] = struct{}{}
-
-			relPath, err := filepath.Rel(repositoryRoot, path)
-			if err != nil {
-				return nil, err
-			}
-
-			res = append(res, i.inputFileSingletonCache.CreateOrGetInputFile(path, relPath))
+	for _, path := range paths {
+		if _, exist := dedupMap[path]; exist {
+			log.Debugf("removed duplicate input %q", path)
+			continue
 		}
+
+		dedupMap[path] = struct{}{}
+
+		relPath, err := filepath.Rel(repositoryRoot, path)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, i.inputFileSingletonCache.CreateOrGetInputFile(path, relPath))
 	}
 
 	return res, nil

--- a/pkg/cfg/fileinputs.go
+++ b/pkg/cfg/fileinputs.go
@@ -1,9 +1,5 @@
 package cfg
 
-import (
-	"strings"
-)
-
 // FileInputs stores glob paths to inputs of a task.
 type FileInputs struct {
 	// if attributes are added/removed or modified, the input resolver
@@ -32,10 +28,6 @@ func (f *FileInputs) validate() error {
 		if len(path) == 0 {
 			return newFieldError("can not be empty", "path")
 
-		}
-
-		if strings.Count(path, "**") > 1 {
-			return newFieldError("'**' can only appear one time in a path", "path")
 		}
 	}
 


### PR DESCRIPTION
```
fs/AbsPaths: use array indexing instead of append in AbsPaths()

it is faster

-------------------------------------------------------------------------------
fs/AbsPaths: only join relative paths

AbsPaths() is changed to only join paths elements that are not absolute paths.
This will allow to call the functions with a paths slice that contain absolute
and relative paths.

-------------------------------------------------------------------------------
fs/fileglob: do not call filepath.Abs()

Removing calling filepath.Abs() in FileGlob().
It is unnecessary for our usecase.
The paths returned by doublestar are absolute if an pattern is passed with an
absolute path, which baur is always doing.

-------------------------------------------------------------------------------
inputresolver: simplify pathsToUniqInputs

Pass a []string, instead of a [][]string with 1 element

-------------------------------------------------------------------------------
inputresolver: improve caching

- File resolver results with the optional flag disabled are now reused when
  the same lookup is done but with the optional flag enabled.
  Results with optional disabled can not reuse results from lookups with
  Optional enabled because the error handling differs.
  When optional is enabled non-existing paths in the pattern do not result in an
  error, when optional is disabled it should cause an error.
- File input resolver results with GitTrackedOnly enabled are now using cached
  results for the same pattern with GitTrackedOnly disabled instead of doing the
  glob match again, afterwards the non git tracked files are excluded

-------------------------------------------------------------------------------
cfg: support multiple '**' patterns in input file paths

Having multiple '**' patterns is supported since switching to doublestar for
globbing.
Remove the validation check that caused baur to fail if '**' occurred multiple
times in a path.

-------------------------------------------------------------------------------
```