### PR TITLE
inputs: support to exclude files by glob patterns

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -215,7 +215,7 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 			}
 		}
 
-		if len(task.UnresolvedInputs.EnvironmentVariables) > 0 && len(task.UnresolvedInputs.GolangSources) > 0 {
+		if (len(task.UnresolvedInputs.EnvironmentVariables) > 0 || len(task.UnresolvedInputs.Files) > 0) && len(task.UnresolvedInputs.GolangSources) > 0 {
 			mustWriteRow(formatter, "", "", "", "")
 		}
 
@@ -231,6 +231,18 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 				mustWriteRow(formatter, "", "", "", "")
 			}
 		}
+
+		if len(task.UnresolvedInputs.ExcludedFiles.Paths) > 0 &&
+			(len(task.UnresolvedInputs.GolangSources) > 0 ||
+				len(task.UnresolvedInputs.EnvironmentVariables) > 0 ||
+				len(task.UnresolvedInputs.Files) > 0) {
+			mustWriteRow(formatter, "", "", "", "")
+		}
+
+		mustWriteRow(formatter, "", "", "", "")
+		mustWriteRow(formatter, "", "", "Type:", term.Highlight("Excluded Files"))
+		mustWriteStringSliceRows(formatter, "Paths:", 2, task.UnresolvedInputs.ExcludedFiles.Paths)
+
 	}
 
 	if task.HasOutputs() {

--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -36,3 +36,7 @@ func FileGlob(pattern string) ([]string, error) {
 
 	return res, err
 }
+
+func MatchGlob(pattern, path string) (bool, error) {
+	return doublestar.PathMatch(pattern, path)
+}

--- a/internal/fs/fileglob_test.go
+++ b/internal/fs/fileglob_test.go
@@ -1,9 +1,12 @@
 package fs
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/simplesurance/baur/v3/internal/testutils/fstest"
 	"github.com/simplesurance/baur/v3/internal/testutils/strtest"
@@ -163,4 +166,26 @@ func Test_Resolve(t *testing.T) {
 		checkFilesInResolvedFiles(t, tempdir, resolvedFiles, tc)
 	}
 
+}
+
+func TestGlobMatch(t *testing.T) {
+	tcs := []struct {
+		pattern     string
+		path        string
+		expectMatch bool
+	}{
+		{
+			pattern:     "?",
+			path:        "a",
+			expectMatch: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("pattern:%s,path:%s", tc.pattern, tc.path), func(t *testing.T) {
+			match, err := MatchGlob(tc.pattern, tc.path)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectMatch, match)
+		})
+	}
 }

--- a/internal/resolve/glob/glob.go
+++ b/internal/resolve/glob/glob.go
@@ -11,7 +11,7 @@ import (
 // directories recursively.
 type Resolver struct{}
 
-// Resolve resolves the globPath to absolute file paths.
+// Resolve resolves globPath to file paths.
 // Files are resolved in the same way then filepath.Glob() does, with 2 Exceptions:
 // - it also supports '**' to match files and directories recursively,
 // - it only returns paths to files, no directory paths,
@@ -24,4 +24,22 @@ func (r *Resolver) Resolve(globPath string) ([]string, error) {
 	}
 
 	return paths, nil
+}
+
+// Matches returns true and the matching pattern, if a pattern in patters
+// matches path. If none matches, false and an empty string is returned
+// If the pattern is malformed an error is returned.
+func (r *Resolver) Matches(path string, patterns []string) (bool, string, error) {
+	for _, pattern := range patterns {
+		match, err := fs.MatchGlob(pattern, path)
+		if err != nil {
+			return false, "", fmt.Errorf("matching pattern %q with path %q failed: %w", pattern, path, err)
+		}
+
+		if match {
+			return true, pattern, nil
+		}
+	}
+
+	return false, "", nil
 }

--- a/internal/testutils/strtest/strtest.go
+++ b/internal/testutils/strtest/strtest.go
@@ -2,6 +2,7 @@
 package strtest
 
 // InSlice returns true if the slice contains the passed string
+// Deprecated: use assert.Contains() instead
 func InSlice(slice []string, wanted string) bool {
 	for _, elem := range slice {
 		if elem == wanted {

--- a/pkg/cfg/app.go
+++ b/pkg/cfg/app.go
@@ -32,6 +32,9 @@ func ExampleApp(name string) *App {
 							Paths: []string{"dbmigrations/*.sql"},
 						},
 					},
+					ExcludedFiles: FileExcludeList{
+						Paths: []string{"dbmigrations/1.sql"},
+					},
 					EnvironmentVariables: []EnvVarsInputs{
 						{
 							Names:    []string{"APP_VERSION", name + "_*"},

--- a/pkg/cfg/fileignorelist.go
+++ b/pkg/cfg/fileignorelist.go
@@ -1,0 +1,29 @@
+package cfg
+
+// FileExcludeList specifies paths to files that are excluded as inputs.
+type FileExcludeList struct {
+	Paths []string `toml:"paths" comment:"Specifies files that are excluded from the Inputs.\n ExcludedFiles are processed after all other Input types.\n All Paths are relative to the application directory.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively."`
+}
+
+func (f *FileExcludeList) Validate() error {
+	for _, path := range f.Paths {
+		if len(path) == 0 {
+			return newFieldError("can not be empty", "path")
+
+		}
+	}
+
+	return nil
+}
+
+func (f *FileExcludeList) resolve(resolver Resolver) error {
+	for i, p := range f.Paths {
+		var err error
+
+		if f.Paths[i], err = resolver.Resolve(p); err != nil {
+			return fieldErrorWrap(err, "Paths", p)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cfg/include.go
+++ b/pkg/cfg/include.go
@@ -119,6 +119,7 @@ func ExampleInclude(id string) *Include {
 				Files: []FileInputs{
 					{},
 				},
+				ExcludedFiles: FileExcludeList{},
 				GolangSources: []GolangSources{
 					{},
 				},

--- a/pkg/cfg/inputdef.go
+++ b/pkg/cfg/inputdef.go
@@ -4,4 +4,5 @@ type inputDef interface {
 	envVariables() []EnvVarsInputs
 	fileInputs() []FileInputs
 	golangSourcesInputs() []GolangSources
+	excludedFiles() *FileExcludeList
 }

--- a/pkg/cfg/inputinclude.go
+++ b/pkg/cfg/inputinclude.go
@@ -11,6 +11,7 @@ type InputInclude struct {
 	EnvironmentVariables []EnvVarsInputs
 	Files                []FileInputs
 	GolangSources        []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
+	ExcludedFiles        FileExcludeList
 
 	filepath string
 }
@@ -25,6 +26,10 @@ func (in *InputInclude) golangSourcesInputs() []GolangSources {
 
 func (in *InputInclude) envVariables() []EnvVarsInputs {
 	return in.EnvironmentVariables
+}
+
+func (in *InputInclude) excludedFiles() *FileExcludeList {
+	return &in.ExcludedFiles
 }
 
 func (in *InputInclude) IsEmpty() bool {


### PR DESCRIPTION
inputs: support to exclude files by glob patterns

Support to exclude files from the inputs by specifying them in an ignore list.
The list of files to exclude can be specified as glob patterns in an
"Input.ExcludedFiles" section. Patterns in the ExcludedFiles section that
reference non-existing paths are silently ignored.
The ExcludedFiles are processed after all other input sections.
Input files that were discovered and match one of the ExcludeFiles patterns are
removed.
ExcludedFiles sections can be defined in include files and imported on task
level.

In the .toml config file the Files, GolangSources and EnvironmentVariables
members of the input sections are lists.
E.g. '[[Task.Input.Files]]' sections for a task can exit with different options.
The ExcludedFiles is a single element, because it does not have additional
options.
Because it is not a list, the representation in the toml config differs:
'[Task.Input.ExcludeFiles]' vs '[[Task.Input.Files]]'

Example .app.toml section:

```toml
  [Task.Input.ExcludedFiles]
    paths = ["dbmigrations/1.sql"]

```
