### PR TITLE
support shell completion for zsh, fish and powershell

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -16,6 +16,8 @@ const (
 	cmdInitRepo     = "baur init repo"
 )
 
+const initShellCompletionGroupID = "shellcompletion"
+
 var initLongHelp = fmt.Sprintf(`
 The init commands initialize baur configuration files,
 create baur tables in the database or install bash completion files.
@@ -39,5 +41,6 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.AddGroup(&cobra.Group{ID: initShellCompletionGroupID, Title: "Generating shell completions"})
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -44,9 +44,10 @@ type initBashCompCmd struct {
 func newInitBashCompCmd() *initBashCompCmd {
 	cmd := initBashCompCmd{
 		Command: cobra.Command{
-			Use:   "bashcomp",
-			Short: "generate and install a bash completion script",
-			Long:  strings.TrimSpace(initBashCompLongHelp),
+			Use:     "bashcomp",
+			Short:   "generate and install a bash completion script",
+			Long:    strings.TrimSpace(initBashCompLongHelp),
+			GroupID: initShellCompletionGroupID,
 		},
 	}
 

--- a/internal/command/init_fishcomp.go
+++ b/internal/command/init_fishcomp.go
@@ -36,9 +36,10 @@ Environment Variables:
 func newInitFishCompCmd() *initFishCompCmd {
 	cmd := initFishCompCmd{
 		Command: cobra.Command{
-			Use:   "fishcomp",
-			Short: "generate and install a fish completion script",
-			Long:  initFishCompLongHelp,
+			Use:     "fishcomp",
+			Short:   "generate and install a fish completion script",
+			Long:    initFishCompLongHelp,
+			GroupID: initShellCompletionGroupID,
 		},
 	}
 

--- a/internal/command/init_fishcomp.go
+++ b/internal/command/init_fishcomp.go
@@ -1,0 +1,115 @@
+package command
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simplesurance/baur/v3/internal/command/term"
+	"github.com/simplesurance/baur/v3/internal/fs"
+)
+
+type initFishCompCmd struct {
+	cobra.Command
+	stdout bool
+}
+
+func init() {
+	initCmd.AddCommand(&newInitFishCompCmd().Command)
+}
+
+var initFishCompLongHelp = fmt.Sprintf(`
+Generate and install a baur completion script for the fish shell.
+
+If --stdout is passed, the completion script is written to STDOUT.
+Otherwise it is written to the completion directory determined by the following
+environment variables.
+
+Environment Variables:
+ %s			Script is written to %s
+`,
+	envVarXDGDataHome,
+	filepath.Join("$"+envVarXDGDataHome, fishCompRelDataHomeDirFilepath()),
+)
+
+func newInitFishCompCmd() *initFishCompCmd {
+	cmd := initFishCompCmd{
+		Command: cobra.Command{
+			Use:   "fishcomp",
+			Short: "generate and install a fish completion script",
+			Long:  initFishCompLongHelp,
+		},
+	}
+
+	cmd.Flags().BoolVar(&cmd.stdout, "stdout", false, "write completion script to stdout")
+
+	cmd.Run = cmd.run
+
+	return &cmd
+}
+
+func fishCompletionFile() (string, error) {
+	/*
+		https://fishshell.com/docs/current/completions.html#where-to-put-completions
+
+		By default, Fish searches the following for completions, using
+		the first available file that it finds:
+
+		A directory for end-users to keep their own completions,
+		usually ~/.config/fish/completions (controlled by the
+		XDG_CONFIG_HOME environment variable);
+
+		A directory for systems administrators to install completions
+		for all users on the system, usually /etc/fish/completions;
+
+		A user-specified directory for third-party vendor completions,
+		usually ~/.local/share/fish/vendor_completions.d (controlled by
+		the XDG_DATA_HOME environment variable);
+
+		A directory for third-party software vendors to ship their own
+		completions for their software, usually
+		/usr/share/fish/vendor_completions.d;
+
+		The completions shipped with fish, usually installed in
+		/usr/share/fish/completions; and
+
+		Completions automatically generated from the operating system’s
+		manual, usually stored in
+		~/.local/share/fish/generated_completions. os.UserConfigDir
+	*/
+
+	dataHome, err := xdgDataHome()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dataHome, fishCompRelDataHomeDirFilepath()), nil
+}
+
+func fishCompRelDataHomeDirFilepath() string {
+	return filepath.Join("fish", "vendor_completions.d", "baur.fish")
+}
+
+func (c *initFishCompCmd) run(_ *cobra.Command, _ []string) {
+	if c.stdout {
+		err := rootCmd.GenFishCompletion(stdout, false)
+		exitOnErr(err)
+		return
+	}
+
+	complFile, err := fishCompletionFile()
+	exitOnErr(err,
+		"could not find fish completion directory,",
+		"try rerunning the command with '--stdout'",
+	)
+
+	complDir := filepath.Dir(complFile)
+	err = fs.Mkdir(complDir)
+	exitOnErrf(err, "could not create directory %q", complDir)
+
+	err = rootCmd.GenFishCompletionFile(complFile, false)
+	exitOnErr(err, "generating completion script failed")
+
+	stdout.Printf("fish completion script written to %s\n", term.Highlight(complFile))
+}

--- a/internal/command/init_powershellcomp.go
+++ b/internal/command/init_powershellcomp.go
@@ -21,9 +21,10 @@ The generated script is printed to stdout.
 func newInitPowerShellCompCmd() *initPowerShellCompCmd {
 	cmd := initPowerShellCompCmd{
 		Command: cobra.Command{
-			Use:   "powershellcomp",
-			Short: "generate a powershell completion script",
-			Long:  initPowerShellCompLongHelp,
+			Use:     "powershellcomp",
+			Short:   "generate a powershell completion script",
+			Long:    initPowerShellCompLongHelp,
+			GroupID: initShellCompletionGroupID,
 		},
 	}
 

--- a/internal/command/init_powershellcomp.go
+++ b/internal/command/init_powershellcomp.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type initPowerShellCompCmd struct {
+	cobra.Command
+}
+
+func init() {
+	initCmd.AddCommand(&newInitPowerShellCompCmd().Command)
+}
+
+const initPowerShellCompLongHelp = `
+Generate a completion script for PowerShell.
+
+The generated script is printed to stdout.
+`
+
+func newInitPowerShellCompCmd() *initPowerShellCompCmd {
+	cmd := initPowerShellCompCmd{
+		Command: cobra.Command{
+			Use:   "powershellcomp",
+			Short: "generate a powershell completion script",
+			Long:  initPowerShellCompLongHelp,
+		},
+	}
+
+	cmd.Run = cmd.run
+
+	return &cmd
+}
+
+func (c *initPowerShellCompCmd) run(_ *cobra.Command, _ []string) {
+	err := rootCmd.GenPowerShellCompletion(stdout)
+	exitOnErr(err)
+}

--- a/internal/command/init_zshcomp.go
+++ b/internal/command/init_zshcomp.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type initZshCompCmd struct {
+	cobra.Command
+}
+
+func init() {
+	initCmd.AddCommand(&newInitZshCompCmd().Command)
+}
+
+const initZshCompLongHelp = `
+Generate a completion script for the zsh shell.
+
+The generated script is printed to stdout.
+`
+
+func newInitZshCompCmd() *initZshCompCmd {
+	cmd := initZshCompCmd{
+		Command: cobra.Command{
+			Use:   "zshcomp",
+			Short: "generate a zsh completion script",
+			Long:  initZshCompLongHelp,
+		},
+	}
+
+	cmd.Run = cmd.run
+
+	return &cmd
+}
+
+func (c *initZshCompCmd) run(_ *cobra.Command, _ []string) {
+	err := rootCmd.GenZshCompletionNoDesc(stdout)
+	exitOnErr(err)
+}

--- a/internal/command/init_zshcomp.go
+++ b/internal/command/init_zshcomp.go
@@ -21,9 +21,10 @@ The generated script is printed to stdout.
 func newInitZshCompCmd() *initZshCompCmd {
 	cmd := initZshCompCmd{
 		Command: cobra.Command{
-			Use:   "zshcomp",
-			Short: "generate a zsh completion script",
-			Long:  initZshCompLongHelp,
+			Use:     "zshcomp",
+			Short:   "generate a zsh completion script",
+			Long:    initZshCompLongHelp,
+			GroupID: initShellCompletionGroupID,
 		},
 	}
 


### PR DESCRIPTION
Add support to generate shell completion scripts for zsh, fish and powershell.

See the commit messages for details.