### PR TITLE
 shell completions: support arg completion 

### DIFF
--- a/internal/command/completion.go
+++ b/internal/command/completion.go
@@ -99,3 +99,7 @@ func completeTarget(
 
 	return result, cobra.ShellCompDirectiveDefault
 }
+
+func completeOnlyDirectories(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveFilterDirs
+}

--- a/internal/command/completion.go
+++ b/internal/command/completion.go
@@ -52,6 +52,8 @@ func completeAppNameAndAppDir(
 
 type completeTargetFuncOpts struct {
 	withoutWildcards bool
+	withoutPaths     bool
+	withoutAppNames  bool
 }
 
 func newCompleteTargetFunc(
@@ -73,7 +75,10 @@ func newCompleteTargetFunc(
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		wd, _ := os.Getwd()
+		wd := ""
+		if !opts.withoutPaths {
+			wd, _ = os.Getwd()
+		}
 
 		resultSet := make(map[string]struct{}, len(tasks)*3)
 		for _, t := range tasks {
@@ -82,8 +87,10 @@ func newCompleteTargetFunc(
 				resultSet["*."+t.ID()] = struct{}{}
 			}
 
-			if _, exist := resultSet[t.AppName]; exist {
-				continue
+			if !opts.withoutAppNames {
+				if _, exist := resultSet[t.AppName]; exist {
+					continue
+				}
 			}
 
 			resultSet[t.AppName] = struct{}{}

--- a/internal/command/completion.go
+++ b/internal/command/completion.go
@@ -1,0 +1,51 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simplesurance/baur/v3/internal/log"
+	"github.com/simplesurance/baur/v3/pkg/baur"
+)
+
+func mockGitCommitID() (string, error) {
+	return "123", nil
+}
+
+func completeAppNameAndAppDir(
+	_ *cobra.Command,
+	_ []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	repo, err := findRepository()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	loader, err := baur.NewLoader(repo.Cfg, mockGitCommitID, log.StdLogger)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	apps, err := loader.LoadApps()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	wd, _ := os.Getwd()
+
+	result := make([]string, 0, len(apps)*2)
+	for _, app := range apps {
+		result = append(result, app.Name)
+		if wd != "" {
+			relPath, err := filepath.Rel(wd, app.Path)
+			if err == nil {
+				result = append(result, relPath)
+			}
+		}
+	}
+
+	return result, cobra.ShellCompDirectiveDefault
+}

--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -82,6 +82,11 @@ func newDiffInputsCmd() *diffInputsCmd {
 			Long:    strings.TrimSpace(diffInputslongHelp),
 			Example: strings.TrimSpace(diffInputsExample),
 			Args:    diffArgs(),
+			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{
+				withoutWildcards: true,
+				withoutAppNames:  true,
+				withoutPaths:     true,
+			}),
 		},
 	}
 

--- a/internal/command/init_app.go
+++ b/internal/command/init_app.go
@@ -24,12 +24,13 @@ const initAppExample = `
 baur init app shop-ui	create an application config with the app name set to shop-ui`
 
 var initAppCmd = &cobra.Command{
-	Use:     "app [APP_NAME]",
-	Short:   "create an application config file in the current directory",
-	Long:    strings.TrimSpace(initAppLongHelp),
-	Example: strings.TrimSpace(initAppExample),
-	Run:     initApp,
-	Args:    cobra.MaximumNArgs(1),
+	Use:               "app [APP_NAME]",
+	Short:             "create an application config file in the current directory",
+	Long:              strings.TrimSpace(initAppLongHelp),
+	Example:           strings.TrimSpace(initAppExample),
+	Run:               initApp,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: cobra.NoFileCompletions,
 }
 
 func initApp(cmd *cobra.Command, args []string) {

--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -44,10 +44,11 @@ type initBashCompCmd struct {
 func newInitBashCompCmd() *initBashCompCmd {
 	cmd := initBashCompCmd{
 		Command: cobra.Command{
-			Use:     "bashcomp",
-			Short:   "generate and install a bash completion script",
-			Long:    strings.TrimSpace(initBashCompLongHelp),
-			GroupID: initShellCompletionGroupID,
+			Use:               "bashcomp",
+			Short:             "generate and install a bash completion script",
+			Long:              strings.TrimSpace(initBashCompLongHelp),
+			GroupID:           initShellCompletionGroupID,
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -139,5 +139,11 @@ func (c *initBashCompCmd) run(_ *cobra.Command, _ []string) {
 	err = rootCmd.GenBashCompletionFileV2(complFile, false)
 	exitOnErr(err, "generating completion script failed")
 
-	stdout.Printf("bash completion script written to %s\n", term.Highlight(complFile))
+	stdout.Printf(
+		"bash completion script was written to %s.\n"+
+			"To load completions in your current shell session run:\n"+
+			"\t%s\n",
+		term.Highlight(complFile),
+		term.Highlight(fmt.Sprintf("source %s", complFile)),
+	)
 }

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -26,12 +26,13 @@ by setting the '%s' environment variable.`,
 	term.Highlight(envVarPSQLURL))
 
 var initDbCmd = &cobra.Command{
-	Use:     "db [POSTGRES_URL]",
-	Short:   "create baur tables in a PostgreSQL database",
-	Example: strings.TrimSpace(initDbExample),
-	Long:    strings.TrimSpace(initDbLongHelp),
-	Run:     initDb,
-	Args:    cobra.MaximumNArgs(1),
+	Use:               "db [POSTGRES_URL]",
+	Short:             "create baur tables in a PostgreSQL database",
+	Example:           strings.TrimSpace(initDbExample),
+	Long:              strings.TrimSpace(initDbLongHelp),
+	Run:               initDb,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: cobra.NoFileCompletions,
 }
 
 func init() {

--- a/internal/command/init_fishcomp.go
+++ b/internal/command/init_fishcomp.go
@@ -36,10 +36,11 @@ Environment Variables:
 func newInitFishCompCmd() *initFishCompCmd {
 	cmd := initFishCompCmd{
 		Command: cobra.Command{
-			Use:     "fishcomp",
-			Short:   "generate and install a fish completion script",
-			Long:    initFishCompLongHelp,
-			GroupID: initShellCompletionGroupID,
+			Use:               "fishcomp",
+			Short:             "generate and install a fish completion script",
+			Long:              initFishCompLongHelp,
+			GroupID:           initShellCompletionGroupID,
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/init_powershellcomp.go
+++ b/internal/command/init_powershellcomp.go
@@ -21,10 +21,11 @@ The generated script is printed to stdout.
 func newInitPowerShellCompCmd() *initPowerShellCompCmd {
 	cmd := initPowerShellCompCmd{
 		Command: cobra.Command{
-			Use:     "powershellcomp",
-			Short:   "generate a powershell completion script",
-			Long:    initPowerShellCompLongHelp,
-			GroupID: initShellCompletionGroupID,
+			Use:               "powershellcomp",
+			Short:             "generate a powershell completion script",
+			Long:              initPowerShellCompLongHelp,
+			GroupID:           initShellCompletionGroupID,
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/init_repo.go
+++ b/internal/command/init_repo.go
@@ -23,11 +23,12 @@ If no argument is passed, the file is created in the current directory.
 `
 
 var initRepoCmd = &cobra.Command{
-	Use:   "repo [DIR]",
-	Short: "create a repository config file",
-	Long:  strings.TrimSpace(initRepoLongHelp),
-	Run:   initRepo,
-	Args:  cobra.MaximumNArgs(1),
+	Use:               "repo [DIR]",
+	Short:             "create a repository config file",
+	Long:              strings.TrimSpace(initRepoLongHelp),
+	Run:               initRepo,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeOnlyDirectories,
 }
 
 func initRepo(cmd *cobra.Command, args []string) {

--- a/internal/command/init_zshcomp.go
+++ b/internal/command/init_zshcomp.go
@@ -21,10 +21,11 @@ The generated script is printed to stdout.
 func newInitZshCompCmd() *initZshCompCmd {
 	cmd := initZshCompCmd{
 		Command: cobra.Command{
-			Use:     "zshcomp",
-			Short:   "generate a zsh completion script",
-			Long:    initZshCompLongHelp,
-			GroupID: initShellCompletionGroupID,
+			Use:               "zshcomp",
+			Short:             "generate a zsh completion script",
+			Long:              initZshCompLongHelp,
+			GroupID:           initShellCompletionGroupID,
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -36,9 +36,10 @@ type lsAppsCmd struct {
 func newLsAppsCmd() *lsAppsCmd {
 	cmd := lsAppsCmd{
 		Command: cobra.Command{
-			Use:   "apps [APP_NAME|APP_DIR]...",
-			Short: "list applications",
-			Args:  cobra.ArbitraryArgs,
+			Use:               "apps [APP_NAME|APP_DIR]...",
+			Short:             "list applications",
+			Args:              cobra.ArbitraryArgs,
+			ValidArgsFunction: completeAppNameAndAppDir,
 		},
 
 		fields: flag.MustNewFields(

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -30,7 +30,7 @@ type lsInputsCmd struct {
 func newLsInputsCmd() *lsInputsCmd {
 	cmd := lsInputsCmd{
 		Command: cobra.Command{
-			Use:   "inputs APP_NAME.TASK_NAME|RUN_ID APP_NAME.TASK_NAME|RUN_ID",
+			Use:   "inputs APP_NAME.TASK_NAME|RUN_ID|APP_DIR",
 			Short: "list inputs of a task or task run",
 			Args:  cobra.ExactArgs(1),
 		},

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -33,6 +33,9 @@ func newLsInputsCmd() *lsInputsCmd {
 			Use:   "inputs APP_NAME.TASK_NAME|RUN_ID|APP_DIR",
 			Short: "list inputs of a task or task run",
 			Args:  cobra.ExactArgs(1),
+			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{
+				withoutWildcards: true,
+			}),
 		},
 	}
 

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -46,15 +46,15 @@ func newLsOutputsCmd() *lsOutputsCmd {
 }
 
 func (c *lsOutputsCmd) run(cmd *cobra.Command, args []string) {
-	repo := mustFindRepository()
-	pgClient := mustNewCompatibleStorage(repo)
-	defer pgClient.Close()
-
 	taskRunID, err := strconv.Atoi(args[0])
 	if err != nil {
 		stderr.Printf("'%s' is not a numeric task run ID\n", args[0])
 		exitFunc(1)
 	}
+
+	repo := mustFindRepository()
+	pgClient := mustNewCompatibleStorage(repo)
+	defer pgClient.Close()
 
 	_, err = pgClient.TaskRun(ctx, taskRunID)
 	if err != nil {

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -28,9 +28,10 @@ func init() {
 func newLsOutputsCmd() *lsOutputsCmd {
 	cmd := lsOutputsCmd{
 		Command: cobra.Command{
-			Use:   "outputs <RUN_ID>",
-			Short: "list outputs of a task run",
-			Args:  cobra.ExactArgs(1),
+			Use:               "outputs <RUN_ID>",
+			Short:             "list outputs of a task run",
+			Args:              cobra.ExactArgs(1),
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -62,6 +62,11 @@ func newLsRunsCmd() *lsRunsCmd {
 			Long:    strings.TrimSpace(lsRunsLongHelp),
 			Example: strings.TrimSpace(lsRunsExample),
 			Args:    cobra.ExactArgs(1),
+			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{
+				withoutAppNames:  true,
+				withoutPaths:     true,
+				withoutWildcards: true,
+			}),
 		},
 
 		sort: flag.NewSort(map[string]storage.Field{

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -105,10 +105,11 @@ type runCmd struct {
 func newRunCmd() *runCmd {
 	cmd := runCmd{
 		Command: cobra.Command{
-			Use:     "run [TARGET|APP_DIR]...",
-			Short:   "run tasks",
-			Long:    runLongHelp,
-			Example: strings.TrimSpace(runExample),
+			Use:               "run [TARGET|APP_DIR]...",
+			Short:             "run tasks",
+			Long:              runLongHelp,
+			Example:           strings.TrimSpace(runExample),
+			ValidArgsFunction: completeTarget,
 		},
 	}
 

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -109,7 +109,7 @@ func newRunCmd() *runCmd {
 			Short:             "run tasks",
 			Long:              runLongHelp,
 			Example:           strings.TrimSpace(runExample),
-			ValidArgsFunction: completeTarget,
+			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{}),
 		},
 	}
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -44,11 +44,12 @@ type showCmd struct {
 func newShowCmd() *showCmd {
 	cmd := showCmd{
 		Command: cobra.Command{
-			Use:     "show <APP_DIR|APP_NAME[.TASK_NAME]|RUN_ID>",
-			Short:   "show information about apps or recorded task runs",
-			Args:    cobra.ExactArgs(1),
-			Long:    strings.TrimSpace(showLongHelp),
-			Example: strings.TrimSpace(showExamples),
+			Use:               "show <APP_DIR|APP_NAME[.TASK_NAME]|RUN_ID>",
+			Short:             "show information about apps or recorded task runs",
+			Args:              cobra.ExactArgs(1),
+			Long:              strings.TrimSpace(showLongHelp),
+			Example:           strings.TrimSpace(showExamples),
+			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{withoutWildcards: true}),
 		},
 	}
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -60,7 +60,7 @@ func newStatusCmd() *statusCmd {
 			Short:             "list status of tasks",
 			Long:              statusLongHelp,
 			Args:              cobra.ArbitraryArgs,
-			ValidArgsFunction: completeTarget,
+			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{}),
 		},
 
 		fields: flag.MustNewFields(

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -56,10 +56,11 @@ type statusCmd struct {
 func newStatusCmd() *statusCmd {
 	cmd := statusCmd{
 		Command: cobra.Command{
-			Use:   "status [TARGET|APP_DIR]...",
-			Short: "list status of tasks",
-			Long:  statusLongHelp,
-			Args:  cobra.ArbitraryArgs,
+			Use:               "status [TARGET|APP_DIR]...",
+			Short:             "list status of tasks",
+			Long:              statusLongHelp,
+			Args:              cobra.ArbitraryArgs,
+			ValidArgsFunction: completeTarget,
 		},
 
 		fields: flag.MustNewFields(

--- a/internal/command/upgrade_configs.go
+++ b/internal/command/upgrade_configs.go
@@ -19,8 +19,9 @@ type upgradeConfigsCmd struct {
 func newUpgradeConfigsCmd() *upgradeConfigsCmd {
 	cmd := upgradeConfigsCmd{
 		Command: cobra.Command{
-			Use:   "configs",
-			Short: "upgrade baur configs from config version 4 to 5",
+			Use:               "configs",
+			Short:             "upgrade baur configs from config version 4 to 5",
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/upgrade_db.go
+++ b/internal/command/upgrade_db.go
@@ -30,9 +30,10 @@ type upgradeDbCmd struct {
 func newUpgradeDatabaseCmd() *upgradeDbCmd {
 	cmd := upgradeDbCmd{
 		Command: cobra.Command{
-			Use:   "db",
-			Short: "upgrade the database schema",
-			Long:  upgradeDbLongHelp,
+			Use:               "db",
+			Short:             "upgrade the database schema",
+			Long:              upgradeDbLongHelp,
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for completing arguments for all baur commands.

If the baur command is run in a baur repository, the configuration files are passed and the available apps, tasks and directories containing apps are used for completion.
Completing to arguments that must be fetched from the database, e.g. run-ids or task-id for `ls runs` is not implemented in this PR.

```
completions: complete "ls runs" args to app and task-ids

Support to complete argument pass to "ls runs" to task-ids.

-------------------------------------------------------------------------------
completions: disable file completions for "ls outputs"

"ls outputs" only supports database IDs as argument, do not offer completions to
filenames and directories.

-------------------------------------------------------------------------------
completions: support argument completion for "ls inputs"

Support to complete "ls inputs" arguments to task-ids and app-directories,
completing to run-ids is not supported.

-------------------------------------------------------------------------------
completions: support completing "diff inputs" arguments

Support to complete "diff inputs" arguments to task ids found in the repository.
Arguments are not completed to task ids found in the repository, to run-ids and
the '^' syntax.

-------------------------------------------------------------------------------
completions: support completing "baur show" arguments

Add support for completing the argument of "baur show".

Run-IDs are currently not completed.
It would be possible, by querying the existing IDs from the database that start
with the same numbers then the ones on the commandline. If a lot of records
exist, doing e.g. "baur show 1<TAB>" results in thousands of options.
That does not seem very helpful nor necessary.

-------------------------------------------------------------------------------
ls outputs: fail earlier when passed argument is not a number

If an argument is passed that is not a number fail immediately.
Previously the check was done after the baur repository was located and the
database connection was established. Both steps are unnecessary in this case.

-------------------------------------------------------------------------------
ls inputs: correct usage string

The usage output of ls inputs was wrong:
- APP_DIR was missing as supported arguments,
- it showed 2x the same argument but it is only supported to pass it 1x

-------------------------------------------------------------------------------
init bashcomp: print how to load completions in current sessions

After writing the completion script to a file, print which command can be run to
use the completion script in the current shell session.

-------------------------------------------------------------------------------
completion: limit "init repo" completion to directory names

"init repo" only supports directory names as arguments.
Limit the generated shell completion options to directory names.

-------------------------------------------------------------------------------
completion: disable file completion for commands not supporting path arguments

Disabling shell completion for argument to filenames and directory for commands
that do not support paths as arguments.

-------------------------------------------------------------------------------
completion: complete "baur status" arguments

Add shell completion support for the arguments of "baur status".
The supported arguments are the same then for "baur run". Therefore the same
completion function is used.

-------------------------------------------------------------------------------
completion: complete "baur run" arguments

Add a shell completion function that completes argument to TARGET or relative
directory names.

Completions are generated for all possible completion which can become a lot.

The following completion options are generated for the baur-example repository,
when in the root directory 'baur run<TAB>' is entered in bash.

    a-team/go/src/github.com/simplesurance/hello-server  rng
    a-team/myredis                                       rng.*
    hello-server                                         *.rng.build
    hello-server.*                                       rng.build
    *.hello-server.build                                 *.rng.check
    hello-server.build                                   rng.check
    myredis                                              *.rng.test
    myredis.*                                            rng.test
    *.myredis.build                                      unixtime
    myredis.build                                        unixtime.*
    project-pink-einstein/rng                            *.unixtime.build
    project-pink-einstein/unixtime                       unixtime.build

-------------------------------------------------------------------------------
completion: complete "ls apps" arguments

Add a custom shell completion function for "ls apps" arguments.
When the current directory is part of a baur repository, the argument is
completed to app-names and relative app directories.
The completed app directories are relative to the current working directory.

The following arguments are suggested by bash when "baur ls apps <tab>" is
entered in the root of the baur-examples git:
    a-team/go/src/github.com/simplesurance/hello-server  project-pink-einstein/rng
    a-team/myredis                                       project-pink-einstein/unixtime
    hello-server                                         rng
    myredis                                              unixtime

-------------------------------------------------------------------------------
```