### PR TITLE
cfg: increase config version & support upgrading to new version

### DIFF
--- a/internal/command/testdata/multitasks/.baur.toml
+++ b/internal/command/testdata/multitasks/.baur.toml
@@ -1,6 +1,6 @@
 
 # Internal field, version of baur configuration format
-config_version = 5
+config_version = 6
 
 [Database]
 

--- a/internal/command/testdata/var_in_include/.baur.toml
+++ b/internal/command/testdata/var_in_include/.baur.toml
@@ -1,6 +1,6 @@
 
 # Version of baur configuration format
-config_version = 5
+config_version = 6
 
 [Database]
 

--- a/pkg/baur/cfgupgrade.go
+++ b/pkg/baur/cfgupgrade.go
@@ -6,11 +6,14 @@ import (
 	"strings"
 
 	baur_old "github.com/simplesurance/baur"
-	cfg_old "github.com/simplesurance/baur/cfg"
+	cfg_v4 "github.com/simplesurance/baur/cfg"
+	cfg_v5 "github.com/simplesurance/baur/v2/pkg/cfg"
 
 	"github.com/simplesurance/baur/v3/internal/fs"
 	"github.com/simplesurance/baur/v3/internal/log"
+	"github.com/simplesurance/baur/v3/pkg/cfg"
 	v4 "github.com/simplesurance/baur/v3/pkg/cfg/upgrade/v4"
+	v5 "github.com/simplesurance/baur/v3/pkg/cfg/upgrade/v5"
 )
 
 // CfgUpgrader converts baur configurations files from a previous format to the
@@ -36,7 +39,7 @@ func (u *CfgUpgrader) upgradeAppConfigs(
 ) error {
 	for _, app := range apps {
 		cfgPath := filepath.Join(app.Path, baur_old.AppCfgFile)
-		appCfg, err := cfg_old.AppFromFile(cfgPath)
+		appCfg, err := cfg_v4.AppFromFile(cfgPath)
 		if err != nil {
 			return fmt.Errorf("reading application config %q failed: %w", cfgPath, err)
 		}
@@ -80,19 +83,40 @@ func (u *CfgUpgrader) upgradeAppConfigs(
 // Each upgraded configuration file is validated by running the responsible
 // validate() method from the cfg package.
 func (u *CfgUpgrader) Upgrade() error {
-	const oldUpgradeVer = 4
-
-	includesToUpgrade := map[string]struct{}{}
-	repoCfgPath := filepath.Join(u.repoRootDir, baur_old.RepositoryCfgFile)
-
-	oldRepoCfg, err := cfg_old.RepositoryFromFile(repoCfgPath)
+	repoCfgPath := filepath.Join(u.repoRootDir, RepositoryCfgFile)
+	repoCfg, err := cfg.RepositoryFromFile(repoCfgPath)
 	if err != nil {
 		return fmt.Errorf("loading repository config %q failed: %w", repoCfgPath, err)
 	}
 
-	if oldRepoCfg.ConfigVersion != oldUpgradeVer {
-		return fmt.Errorf("repository config (%q) has version %d, only version %d can be upgraded",
-			repoCfgPath, oldRepoCfg.ConfigVersion, oldUpgradeVer)
+	if repoCfg.ConfigVersion == 0 {
+		return fmt.Errorf("loading repository config %q succeeded but 'config_version' parameter is missing or 0", repoCfgPath)
+	}
+
+	if repoCfg.ConfigVersion != 4 && repoCfg.ConfigVersion != 5 {
+		return fmt.Errorf("%q specifies 'config_version=%d', upgrading is only supported from version 4 and 5", repoCfgPath, repoCfg.ConfigVersion)
+	}
+
+	if repoCfg.ConfigVersion == 4 {
+		if err := u.upgradeV4(); err != nil {
+			return fmt.Errorf("upgrading configuration files from version %d to %d failed: %w", repoCfg.ConfigVersion, 5, err)
+		}
+	}
+
+	if err := u.upgradeV5(repoCfgPath); err != nil {
+		return fmt.Errorf("upgrading configuration files from version %d to %d failed: %w", 5, 6, err)
+	}
+
+	return nil
+}
+
+func (u *CfgUpgrader) upgradeV4() error {
+	includesToUpgrade := map[string]struct{}{}
+	repoCfgPath := filepath.Join(u.repoRootDir, baur_old.RepositoryCfgFile)
+
+	oldRepoCfg, err := cfg_v4.RepositoryFromFile(repoCfgPath)
+	if err != nil {
+		return fmt.Errorf("loading repository config %q failed: %w", repoCfgPath, err)
 	}
 
 	oldRepo, err := baur_old.NewRepository(repoCfgPath)
@@ -112,7 +136,7 @@ func (u *CfgUpgrader) Upgrade() error {
 	}
 
 	for includePath := range includesToUpgrade {
-		oldInclude, err := cfg_old.IncludeFromFile(includePath)
+		oldInclude, err := cfg_v4.IncludeFromFile(includePath)
 		if err != nil {
 			return err
 		}
@@ -131,7 +155,7 @@ func (u *CfgUpgrader) Upgrade() error {
 			return err
 		}
 
-		log.Debugf("%s: updated", includePath)
+		log.Debugf("%s: was updated from v4 to v5", includePath)
 	}
 
 	newRepoCfg := v4.UpgradeRepositoryConfig(oldRepoCfg)
@@ -143,6 +167,28 @@ func (u *CfgUpgrader) Upgrade() error {
 	if err := newRepoCfg.ToFile(repoCfgPath); err != nil {
 		return fmt.Errorf("writing new repository config file to disk failed: %w", err)
 	}
+
+	log.Debugf("%s: was updated from v4 to v5", repoCfgPath)
+
+	return nil
+}
+
+func (u *CfgUpgrader) upgradeV5(repoCfgPath string) error {
+	oldRepoCfg, err := cfg_v5.RepositoryFromFile(repoCfgPath)
+	if err != nil {
+		return fmt.Errorf("loading repository config %q failed: %w", repoCfgPath, err)
+	}
+
+	if err := fs.BackupFile(repoCfgPath); err != nil {
+		return err
+	}
+
+	newRepoCfg := v5.UpgradeRepositoryConfig(oldRepoCfg)
+	if err := newRepoCfg.ToFile(repoCfgPath, cfg.ToFileOptOverwrite()); err != nil {
+		return fmt.Errorf("writing new repository config file to disk failed: %w", err)
+	}
+
+	log.Debugf("%s: was updated from v5 to v6", repoCfgPath)
 
 	return nil
 }

--- a/pkg/cfg/repository.go
+++ b/pkg/cfg/repository.go
@@ -11,9 +11,9 @@ const (
 	minSearchDepth = 0
 	maxSearchDepth = 10
 	// Version identifies the format of the configuration files that the
-	// package is able to parse. Whenever an incompatible change is made,
-	// the Version number is increased.
-	Version int = 5
+	// package can parse. Whenever an incompatible change is made, the
+	// Version number is increased.
+	Version int = 6
 )
 
 // Repository contains the repository configuration.

--- a/pkg/cfg/upgrade/v5/v5.go
+++ b/pkg/cfg/upgrade/v5/v5.go
@@ -1,0 +1,21 @@
+// Package v5 provides helpers to convert baur configs in v5 format (baur 2.x) to v6 (baur 3.0)
+package v5
+
+import (
+	cfg_v5 "github.com/simplesurance/baur/v2/pkg/cfg"
+
+	"github.com/simplesurance/baur/v3/pkg/cfg"
+)
+
+func UpgradeRepositoryConfig(old *cfg_v5.Repository) *cfg.Repository {
+	return &cfg.Repository{
+		ConfigVersion: cfg.Version,
+		Database: cfg.Database{
+			PGSQLURL: old.Database.PGSQLURL,
+		},
+		Discover: cfg.Discover{
+			Dirs:        old.Discover.Dirs,
+			SearchDepth: old.Discover.SearchDepth,
+		},
+	}
+}

--- a/vendor/github.com/simplesurance/baur/v2/internal/deepcopy/deepcopy.go
+++ b/vendor/github.com/simplesurance/baur/v2/internal/deepcopy/deepcopy.go
@@ -1,0 +1,29 @@
+package deepcopy
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+func Copy(from, to interface{}) error {
+	var buf bytes.Buffer
+
+	err := gob.NewEncoder(&buf).Encode(from)
+	if err != nil {
+		return err
+	}
+
+	err = gob.NewDecoder(&buf).Decode(to)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MustCopy(from, to interface{}) {
+	err := Copy(from, to)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/app.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/app.go
@@ -1,0 +1,167 @@
+package cfg
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml"
+)
+
+// App stores an application configuration.
+type App struct {
+	Name     string   `toml:"name" comment:"Application name"`
+	Includes []string `toml:"includes" comment:"Task-includes that the task inherits.\n Includes are specified in the format FILEPATH#INCLUDE_ID.\n Paths are relative to the application directory."`
+	Tasks    Tasks    `toml:"Task"`
+
+	filepath string
+}
+
+// ExampleApp returns an exemplary app cfg struct with the name set to the given value.
+func ExampleApp(name string) *App {
+	return &App{
+		Name: name,
+		Tasks: []*Task{
+			{
+				Name:    "build",
+				Command: []string{"make", "dist"},
+				Input: Input{
+					Files: []FileInputs{
+						{
+							Paths: []string{"dbmigrations/*.sql"},
+						},
+					},
+					GolangSources: []GolangSources{
+						{
+							Queries:     []string{"./..."},
+							Environment: []string{"GOFLAGS=-mod=vendor", "GO111MODULE=on"},
+							BuildFlags:  []string{"-tags=linux"},
+						},
+					},
+				},
+				Output: Output{
+					File: []FileOutput{
+						{
+							Path: "dist/{{ .appname }}.tar.xz",
+							S3Upload: []S3Upload{
+								{
+									Bucket: "go-artifacts/",
+									Key:    "{{ .AppName }}-{{ gitCommit }}.tar.xz",
+								},
+							},
+							FileCopy: []FileCopy{
+								{
+									Path: "/mnt/fileserver/build_artifacts/{{ .AppName }}-{{ gitCommit }}.tar.xz",
+								},
+							},
+						},
+					},
+					DockerImage: []DockerImageOutput{
+						{
+							IDFile: "{{ .appname }}-container.id",
+							RegistryUpload: []DockerImageRegistryUpload{
+								{
+									Repository: "my-company/{{ .AppName }}",
+									Tag:        "{{ ENV BRANCH_NAME }}-{{ gitCommit }}",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// AppFromFile unmarshals an application configuration from a file and returns
+// it.
+func AppFromFile(path string) (*App, error) {
+	config := App{}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	config.filepath = path
+
+	for _, task := range config.Tasks {
+		task.cfgFiles = map[string]struct{}{config.filepath: {}}
+	}
+
+	return &config, err
+}
+
+// ToFile marshals the App into toml format and writes it to the given filepath.
+func (a *App) ToFile(filepath string, opts ...toFileOpt) error {
+	a.filepath = filepath
+	return toFile(a, filepath, opts...)
+}
+
+// FilePath returns the path of the app configuration file
+func (a *App) FilePath() string {
+	return a.filepath
+}
+
+// Resolve runs the resolvers on string fields that can contain special strings.
+// These special strings are replaced with concrete values by the resolvers.
+func (a *App) Resolve(resolver Resolver) error {
+	if err := a.Tasks.resolve(resolver); err != nil {
+		return fieldErrorWrap(err, "Tasks")
+	}
+
+	return nil
+}
+
+// Merge merges the configuration with it's includes.
+// The task includes listed in App.Includes are loaded via the includedb and
+// then appeneded to the task list.
+func (a *App) Merge(includedb *IncludeDB, includeSpecResolver Resolver) error {
+	for _, includeID := range a.Includes {
+		taskInclude, err := includedb.loadTaskInclude(includeSpecResolver, filepath.Dir(a.filepath), includeID)
+		if err != nil {
+			return fmt.Errorf("%s: %w", includeID, err)
+		}
+
+		task := taskInclude.toTask()
+		task.addCfgFilepath(a.filepath)
+		a.Tasks = append(a.Tasks, task)
+	}
+
+	for _, task := range a.Tasks {
+		err := taskMerge(task, filepath.Dir(a.filepath), includeSpecResolver, includedb)
+		if err != nil {
+			return fieldErrorWrap(err, "Tasks", task.Name)
+		}
+	}
+
+	return nil
+}
+
+// Validate validates the configuration.
+// It should be called after Merge().
+func (a *App) Validate() error {
+	if err := validateTaskOrAppName(a.Name); err != nil {
+		return fieldErrorWrap(err, "name")
+	}
+
+	if strings.Contains(a.Name, ".") {
+		return newFieldError("dots are not allowed in application names", "name")
+	}
+
+	if err := validateIncludes(a.Includes); err != nil {
+		return fieldErrorWrap(err, "includes")
+	}
+
+	if err := a.Tasks.validate(); err != nil {
+		return fieldErrorWrap(err, "Tasks")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/cfg.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/cfg.go
@@ -1,0 +1,99 @@
+// Package cfg implements the baur configuration file parser.
+package cfg
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/pelletier/go-toml"
+)
+
+type toFileOpts struct {
+	overwrite bool
+	commented bool
+}
+
+// toFileOpt is an option that can be passed to the ToFile functions
+type toFileOpt func(*toFileOpts)
+
+// ToFileOptOverwrite overwrite an existing file instead of returning an error
+func ToFileOptOverwrite() toFileOpt { // nolint: revive // returns unexported type
+	return func(o *toFileOpts) {
+		o.overwrite = true
+	}
+}
+
+// ToFileOptCommented comment every line in the config
+func ToFileOptCommented() toFileOpt { // nolint: revive // returns unexported type
+	return func(o *toFileOpts) {
+		o.commented = true
+	}
+}
+
+// toFile marshals a struct to TOML format and writes it to a file.
+func toFile(data interface{}, filepath string, opts ...toFileOpt) error {
+	var buf bytes.Buffer
+	var settings toFileOpts
+
+	for _, opt := range opts {
+		opt(&settings)
+	}
+
+	encoder := toml.NewEncoder(&buf)
+	encoder.ArraysWithOneElementPerLine(true)
+	encoder.Order(toml.OrderPreserve)
+
+	err := encoder.Encode(data)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(filepath, fileOpenFlags(settings.overwrite), 0640)
+	if err != nil {
+		return err
+	}
+
+	if settings.commented {
+		if err := writeCommented(f, &buf); err != nil {
+			f.Close()
+			return err
+		}
+	} else {
+		if _, err := io.Copy(f, &buf); err != nil {
+			f.Close()
+			return err
+		}
+	}
+
+	err = f.Close()
+	if err != nil {
+		return fmt.Errorf("closing file failed: %w", err)
+	}
+
+	return err
+}
+
+func fileOpenFlags(overwrite bool) int {
+	if overwrite {
+		return os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	}
+
+	return os.O_WRONLY | os.O_CREATE | os.O_EXCL
+}
+
+func writeCommented(out io.Writer, in io.Reader) error {
+	s := bufio.NewScanner(in)
+
+	for s.Scan() {
+		line := s.Text()
+
+		if _, err := fmt.Fprintf(out, "# %s\n", line); err != nil {
+			return err
+		}
+	}
+
+	return s.Err()
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/dockerimageoutput.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/dockerimageoutput.go
@@ -1,0 +1,40 @@
+package cfg
+
+// DockerImageOutput describes where a docker container is uploaded to.
+type DockerImageOutput struct {
+	IDFile         string `toml:"idfile" comment:"File containing the image ID of the produced image (docker build --iidfile)."`
+	RegistryUpload []DockerImageRegistryUpload
+}
+
+func (d *DockerImageOutput) resolve(resolver Resolver) error {
+	var err error
+
+	if d.IDFile, err = resolver.Resolve(d.IDFile); err != nil {
+		return fieldErrorWrap(err, "idfile")
+	}
+
+	for i, upload := range d.RegistryUpload {
+		if err = upload.Resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "RegistryUpload")
+		}
+
+		d.RegistryUpload[i] = upload
+	}
+
+	return nil
+}
+
+// validate validates its content
+func (d *DockerImageOutput) validate() error {
+	if len(d.IDFile) == 0 {
+		return newFieldError("can not be empty", "idfile")
+	}
+
+	for _, upload := range d.RegistryUpload {
+		if err := upload.validate(); err != nil {
+			return fieldErrorWrap(err, "RegistryUpload")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/dockerimageregistryupload.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/dockerimageregistryupload.go
@@ -1,0 +1,38 @@
+package cfg
+
+// DockerImageRegistryUpload stores information about a Docker image upload.
+type DockerImageRegistryUpload struct {
+	Registry   string `toml:"registry" comment:"Registry address in the format <HOST>:[<PORT>]. If it's empty the docker agent's default is used."`
+	Repository string `toml:"repository"`
+	Tag        string `toml:"tag"`
+}
+
+func (d *DockerImageRegistryUpload) Resolve(resolver Resolver) error {
+	var err error
+
+	if d.Registry, err = resolver.Resolve(d.Registry); err != nil {
+		return fieldErrorWrap(err, "registry")
+	}
+
+	if d.Repository, err = resolver.Resolve(d.Repository); err != nil {
+		return fieldErrorWrap(err, "repository")
+	}
+
+	if d.Tag, err = resolver.Resolve(d.Tag); err != nil {
+		return fieldErrorWrap(err, "tag")
+	}
+
+	return nil
+}
+
+func (d *DockerImageRegistryUpload) validate() error {
+	if len(d.Repository) == 0 {
+		return newFieldError("can not be empty", "repository")
+	}
+
+	if len(d.Tag) == 0 {
+		return newFieldError("can not be empty", "tag")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/fielderror.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/fielderror.go
@@ -1,0 +1,50 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// fieldError describes an error related to an element in a configuration struct.
+type fieldError struct {
+	elementPath []string
+	err         error
+}
+
+// newFieldError creates a new FieldError with the given error message and ElementPath.
+func newFieldError(msg string, path ...string) *fieldError {
+	return &fieldError{
+		err:         errors.New(msg),
+		elementPath: path,
+	}
+}
+
+// fieldErrorWrap returns a new FieldError thats wraps the passed err, if err
+// is not of type FieldError.
+// If it is of type FieldError, the passed paths are prepended to it's
+// ElementPath and err is returned.
+func fieldErrorWrap(err error, path ...string) error {
+	valError, ok := err.(*fieldError)
+	if ok {
+		valError.elementPath = append(path, valError.elementPath...)
+		return err
+	}
+
+	return &fieldError{
+		elementPath: path,
+		err:         err,
+	}
+}
+
+func (f *fieldError) Error() string {
+	return fmt.Sprintf("%s: %s", strings.Join(f.elementPath, "."), f.err)
+}
+
+func (f *fieldError) Unwrap() error {
+	if err := errors.Unwrap(f.err); err != nil {
+		return err
+	}
+
+	return f.err
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/filecopy.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/filecopy.go
@@ -1,0 +1,24 @@
+package cfg
+
+// FileCopy describes a filesystem location where a task output is copied to.
+type FileCopy struct {
+	Path string `toml:"path" comment:"Destination directory"`
+}
+
+func (f *FileCopy) resolve(resolver Resolver) error {
+	var err error
+
+	if f.Path, err = resolver.Resolve(f.Path); err != nil {
+		return fieldErrorWrap(err, "path")
+	}
+
+	return nil
+}
+
+func (f *FileCopy) validate() error {
+	if f.Path == "" {
+		return newFieldError("can not be empty", "path")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/fileinputs.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/fileinputs.go
@@ -1,0 +1,40 @@
+package cfg
+
+import (
+	"strings"
+)
+
+// FileInputs stores glob paths to inputs of a task.
+type FileInputs struct {
+	Paths          []string `toml:"paths" comment:"Glob patterns that match files.\n All Paths are relative to the application directory.\n Golang's Glob syntax (https://golang.org/pkg/path/filepath/#Match)\n and ** is supported to match files recursively."`
+	Optional       bool     `toml:"optional" comment:"When optional is true a path pattern that matches 0 files will not cause an error."`
+	GitTrackedOnly bool     `toml:"git_tracked_only" comment:"Only resolve to files that are part of the Git repository."`
+}
+
+func (f *FileInputs) resolve(resolver Resolver) error {
+	for i, p := range f.Paths {
+		var err error
+
+		if f.Paths[i], err = resolver.Resolve(p); err != nil {
+			return fieldErrorWrap(err, "Paths", p)
+		}
+	}
+
+	return nil
+}
+
+// validate checks if the stored information is valid.
+func (f *FileInputs) validate() error {
+	for _, path := range f.Paths {
+		if len(path) == 0 {
+			return newFieldError("can not be empty", "path")
+
+		}
+
+		if strings.Count(path, "**") > 1 {
+			return newFieldError("'**' can only appear one time in a path", "path")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/fileoutput.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/fileoutput.go
@@ -1,0 +1,57 @@
+package cfg
+
+// FileOutput describes where a file output is stored.
+type FileOutput struct {
+	Path     string     `toml:"path" comment:"Path relative to the application directory."`
+	FileCopy []FileCopy `comment:"Copy the file to a local directory."`
+	S3Upload []S3Upload `comment:"Upload the file to S3."`
+}
+
+func (f *FileOutput) resolve(resolver Resolver) error {
+	var err error
+
+	if f.Path, err = resolver.Resolve(f.Path); err != nil {
+		return fieldErrorWrap(err, "path")
+	}
+
+	for i, fc := range f.FileCopy {
+		if err = fc.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "FileCopy")
+		}
+
+		f.FileCopy[i] = fc
+	}
+
+	for i, s3 := range f.S3Upload {
+		if err = s3.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "S3Upload")
+		}
+
+		f.S3Upload[i] = s3
+	}
+
+	return nil
+}
+
+// validate checks that the stored information is valid.
+func (f *FileOutput) validate() error {
+	if len(f.Path) == 0 {
+		return newFieldError("can not be empty", "path")
+	}
+
+	for _, s3 := range f.S3Upload {
+		err := s3.validate()
+		if err != nil {
+			return fieldErrorWrap(err, "S3Upload")
+		}
+	}
+
+	for _, fc := range f.FileCopy {
+		err := fc.validate()
+		if err != nil {
+			return fieldErrorWrap(err, "Filecopy")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/golangsources.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/golangsources.go
@@ -1,0 +1,53 @@
+package cfg
+
+// GolangSources specifies inputs for Golang Applications
+type GolangSources struct {
+	Queries     []string `toml:"queries" comment:"Go package queries, the source files of matching packages and\n their imported packages are resolved to files.\n Format:\n \tfile=<RELATIVE-PATH>\n \tfileglob=<GLOB-PATTERN>\t -> Supports double-star\n \tEverything else is passed to the Go query tool (go list by default).\n \tSee also the patterns described at:\n \t<https://github.com/golang/tools/blob/bc8aaaa29e0665201b38fa5cb5d47826788fa249/go/packages/doc.go#L17>.\n Files from Golang's stdlib are ignored."`
+	Environment []string `toml:"environment" comment:"Environment when running the go query tool."`
+	BuildFlags  []string `toml:"build_flags" comment:"List of command-line flags to be passed through to the Go query tool."`
+	Tests       bool     `toml:"tests" comment:"If true queries are resolved to test files, otherwise testfiles are ignored."`
+}
+
+func (g *GolangSources) resolve(resolver Resolver) error {
+	for i, env := range g.Environment {
+		var err error
+
+		if g.Environment[i], err = resolver.Resolve(env); err != nil {
+			return fieldErrorWrap(err, "Environment", env)
+		}
+	}
+
+	for i, q := range g.Queries {
+		var err error
+
+		if g.Queries[i], err = resolver.Resolve(q); err != nil {
+			return fieldErrorWrap(err, "Paths", q)
+		}
+	}
+
+	for i, f := range g.BuildFlags {
+		var err error
+
+		if g.BuildFlags[i], err = resolver.Resolve(f); err != nil {
+			return fieldErrorWrap(err, "build_flags", f)
+		}
+	}
+
+	return nil
+}
+
+// validate checks that the stored information is valid.
+func (g *GolangSources) validate() error {
+	if (len(g.Environment) != 0 || len(g.BuildFlags) != 0 || g.Tests) &&
+		len(g.Queries) == 0 {
+		return newFieldError("must be set if environment, build_flags or tests is set", "query")
+	}
+
+	for _, q := range g.Queries {
+		if len(q) == 0 {
+			return newFieldError("empty string is an invalid query", "query")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/include.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/include.go
@@ -1,0 +1,188 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pelletier/go-toml"
+)
+
+const (
+	includeIDSep   = "#"
+	includeSpecFmt = "<RELATIVE-FILEPATH>" + includeIDSep + "<INCLUDE-ID>"
+)
+
+var (
+	includeSpecRegex    = regexp.MustCompile(`(?m)[^` + includeIDSep + `]+[^` + includeIDSep + `#]+`)
+	whitespaceOnlyRegex = regexp.MustCompile(`^\s+$`)
+)
+
+type Include struct {
+	Input  InputIncludes
+	Output OutputIncludes
+	Task   TaskIncludes
+
+	filePath string
+}
+
+// ToFile marshals the Include struct to TOML and writes it to filepath.
+func (incl *Include) ToFile(filepath string, opts ...toFileOpt) error {
+	return toFile(incl, filepath, opts...)
+}
+
+// IncludeFromFile unmarshals an Include struct from a file.
+func IncludeFromFile(path string) (*Include, error) {
+	config := Include{}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	config.setFilepaths(path)
+
+	return &config, err
+}
+
+func (incl *Include) setFilepaths(path string) {
+	incl.filePath = path
+
+	for _, in := range incl.Input {
+		in.filepath = path
+	}
+
+	for _, out := range incl.Output {
+		out.filepath = path
+	}
+
+	for _, task := range incl.Task {
+		task.cfgFiles = map[string]struct{}{path: {}}
+	}
+}
+
+// validateUniqIncludeIDs validates that IDs of all Input, Output and Task
+// includes are unique.
+func (incl *Include) validateUniqIncludeIDs() error {
+	uniqIncludeIDs := map[string]struct{}{}
+
+	for _, in := range incl.Input {
+		if _, exist := uniqIncludeIDs[in.IncludeID]; exist {
+			return newFieldError(
+				fmt.Sprintf("contains multiple includes with the includeID %q, includeIDs must be unique in a file", in.IncludeID),
+				"Input", "include_id",
+			)
+		}
+
+		uniqIncludeIDs[in.IncludeID] = struct{}{}
+	}
+
+	for _, out := range incl.Output {
+		if _, exist := uniqIncludeIDs[out.IncludeID]; exist {
+			return newFieldError(
+				fmt.Sprintf("contains multiple includes with the includeID %q, includeIDs must be unique in a file", out.IncludeID),
+				"Input", "include_id",
+			)
+		}
+
+		uniqIncludeIDs[out.IncludeID] = struct{}{}
+	}
+
+	for _, task := range incl.Task {
+		if _, exist := uniqIncludeIDs[task.IncludeID]; exist {
+			return newFieldError(
+				fmt.Sprintf("contains multiple includes with the includeID %q, includeIDs must be unique in a file", task.IncludeID),
+				"Input", "include_id",
+			)
+		}
+
+		uniqIncludeIDs[task.IncludeID] = struct{}{}
+	}
+
+	return nil
+
+}
+
+// ExampleInclude returns an Include struct with exemplary values.
+func ExampleInclude(id string) *Include {
+	return &Include{
+		Input: []*InputInclude{
+			{
+				Files: []FileInputs{
+					{},
+				},
+				GolangSources: []GolangSources{
+					{},
+				},
+			},
+		},
+		Output: []*OutputInclude{
+			{
+				File: []FileOutput{
+					{
+						S3Upload: []S3Upload{{}},
+						FileCopy: []FileCopy{{}},
+					},
+				},
+				DockerImage: []DockerImageOutput{{
+					RegistryUpload: []DockerImageRegistryUpload{{}},
+				}},
+			},
+		},
+		Task: TaskIncludes{
+			{
+				Command: []string{"make"},
+				Input: Input{
+					Files:         []FileInputs{{}},
+					GolangSources: []GolangSources{{}},
+				},
+				Output: Output{
+					File: []FileOutput{{}},
+					DockerImage: []DockerImageOutput{{
+						RegistryUpload: []DockerImageRegistryUpload{{}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// validateIncludes validates includeSpecs
+func validateIncludes(includes []string) error {
+	for _, in := range includes {
+		if filepath.IsAbs(in) {
+			return newFieldError("include specifier is an absolute path, must be a repository relative path", in)
+		}
+
+		if !includeSpecRegex.MatchString(in) {
+			return newFieldError("invalid include specifier, must be in format "+includeSpecFmt, in)
+		}
+	}
+
+	return nil
+}
+
+// validateIncludeID validates the format of an include ID.
+func validateIncludeID(id string) error {
+	if id == "" {
+		return errors.New("is empty")
+	}
+
+	if strings.Contains(id, includeIDSep) {
+		return errors.New("contains invalid character '#'")
+	}
+
+	if whitespaceOnlyRegex.MatchString(id) {
+		return errors.New("contains only whitespaces, must contain non-whitespace characters")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/includedb.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/includedb.go
@@ -1,0 +1,313 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type LogFn func(format string, v ...interface{})
+
+// IncludeDB loads and stores include config files.
+// It's methods are not concurrency-safe.
+type IncludeDB struct {
+	logf LogFn
+
+	// the first maps use the absolute path to the include file as key, the second maps use the include ID as key
+	inputs  map[string]map[string]*InputInclude
+	outputs map[string]map[string]*OutputInclude
+	tasks   map[string]map[string]*TaskInclude
+}
+
+// ErrIncludeIDNotFound describes that an include with a specific does not exist in an include file.
+var ErrIncludeIDNotFound = errors.New("id not found in include file")
+
+func NewIncludeDB(logf LogFn) *IncludeDB {
+	if logf == nil {
+		logf = func(_ string, _ ...interface{}) {}
+
+	}
+	return &IncludeDB{
+		inputs:  map[string]map[string]*InputInclude{},
+		outputs: map[string]map[string]*OutputInclude{},
+		tasks:   map[string]map[string]*TaskInclude{},
+		logf:    logf,
+	}
+}
+
+// loadTaskInclude loads the TaskInclude with the given ID.
+// If the include was loaded before it is retrieved from the db.
+// If it wasn't the include file is loaded and added to the db.
+// If the file exist but does not have an include with the specified ID,
+// IncludeIDNotFoundError is returned.
+func (db *IncludeDB) loadTaskInclude(resolver Resolver, workingDir, includeSpec string) (*TaskInclude, error) {
+	absPath, id, err := db.parseIncludeSpec(resolver, workingDir, includeSpec)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", includeSpecifier(absPath, id), err)
+	}
+
+	if idMap, exist := db.tasks[absPath]; exist {
+		if include, exist := idMap[id]; exist {
+			return include, nil
+		}
+
+		return nil, ErrIncludeIDNotFound
+	}
+
+	if err := db.load(absPath, resolver); err != nil {
+		return nil, err
+	}
+
+	include, exist := db.taskInclude(absPath, id)
+	if !exist {
+		return nil, ErrIncludeIDNotFound
+	}
+
+	return include, nil
+}
+
+// loadInputInclude loads the InputInclude with the given ID.
+// If the include was loaded before it is retrieved from the db.
+// If it wasn't the include file is loaded and added to the db.
+// If the file exist but does not have an include with the specified ID,
+// IncludeIDNotFoundError is returned.
+func (db *IncludeDB) loadInputInclude(resolver Resolver, workingDir, includeSpec string) (*InputInclude, error) {
+	absPath, id, err := db.parseIncludeSpec(resolver, workingDir, includeSpec)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", includeSpecifier(absPath, id), err)
+	}
+
+	if idMap, exist := db.inputs[absPath]; exist {
+		if include, exist := idMap[id]; exist {
+			return include, nil
+		}
+
+		return nil, ErrIncludeIDNotFound
+	}
+
+	// file was loaded before but does not contain an input include specification
+	if _, exist := db.outputs[absPath]; exist {
+		return nil, ErrIncludeIDNotFound
+	}
+
+	if err := db.load(absPath, resolver); err != nil {
+		return nil, err
+	}
+
+	include, exist := db.inputInclude(absPath, id)
+	if !exist {
+		return nil, ErrIncludeIDNotFound
+	}
+
+	return include, nil
+}
+
+// loadOutputInclude loads the OutputInclude with the given ID.
+// If the include was loaded before it is retrieved from the db.
+// If it wasn't the include file is loaded and added to the db.
+// If the file exist but does not have an include with the specified ID,
+// IncludeIDNotFoundError is returned.
+func (db *IncludeDB) loadOutputInclude(resolver Resolver, workingDir, includeSpec string) (*OutputInclude, error) {
+	absPath, id, err := db.parseIncludeSpec(resolver, workingDir, includeSpec)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", includeSpecifier(absPath, id), err)
+	}
+
+	if idMap, exist := db.outputs[absPath]; exist {
+		if include, exist := idMap[id]; exist {
+			return include, nil
+		}
+
+		return nil, ErrIncludeIDNotFound
+	}
+
+	// file was loaded before but does not contain an output include specification
+	if _, exist := db.inputs[absPath]; exist {
+		return nil, ErrIncludeIDNotFound
+	}
+
+	if err := db.load(absPath, resolver); err != nil {
+		return nil, err
+	}
+
+	include, exist := db.outputInclude(absPath, id)
+	if !exist {
+		return nil, ErrIncludeIDNotFound
+	}
+
+	return include, nil
+
+}
+
+// parseIncludeSpec splits the includeSpecifier to an absolute path and an include ID.
+// If the path is not an absolute path after it was resolved, it is joined with the passed workingDir.
+func (db *IncludeDB) parseIncludeSpec(resolver Resolver, workingDir, include string) (absPath, id string, err error) {
+	spl := strings.Split(include, includeIDSep)
+	if len(spl) != 2 {
+		return "", "", errors.New("not a valid include specifier, does not contain exactly one '#' character")
+	}
+
+	relPath := spl[0]
+	id = spl[1]
+
+	path := relPath
+	if resolver != nil {
+		path, err = resolver.Resolve(relPath)
+		if err != nil {
+			return "", "", fmt.Errorf("resolving variables failed: %w", err)
+		}
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(workingDir, relPath)
+	}
+
+	db.logf("includedb: resolved %q to path: %q, id: %q", include, path, id)
+
+	return path, id, nil
+}
+
+// load loads the include file, resolves it's variables, validates it and adds it to the IncludeDB.
+// Includes referenced in TaskIncludes a recursively loaded and included.
+func (db *IncludeDB) load(path string, resolver Resolver) error {
+	db.logf("includedb: loading %q", path)
+
+	include, err := IncludeFromFile(path)
+	if err != nil {
+		// the error includes the path to the file
+		if os.IsNotExist(err) {
+			return err
+		}
+		return fmt.Errorf("%s: %w", path, err)
+	}
+
+	if err := include.validateUniqIncludeIDs(); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	// Inputs and Outputs are loaded and indexed before the Tasks. This
+	// allows to include inputs and outputs of the same file in the TaskInclude.
+
+	if err := include.Input.validate(); err != nil {
+		return fmt.Errorf("validation failed: %w", fieldErrorWrap(err, "Input"))
+	}
+
+	for _, input := range include.Input {
+		if err := db.addInputInclude(path, input); err != nil {
+			return err
+		}
+	}
+
+	if err := include.Output.validate(); err != nil {
+		return fmt.Errorf("validation failed: %w", fieldErrorWrap(err, "Output"))
+	}
+
+	for _, output := range include.Output {
+		if err := db.addOutputInclude(path, output); err != nil {
+			return err
+		}
+	}
+
+	if err := include.Task.merge(filepath.Dir(path), resolver, db); err != nil {
+		return fmt.Errorf("merge failed: %w", fieldErrorWrap(err, "Task"))
+	}
+
+	if err := include.Task.validate(); err != nil {
+		return fmt.Errorf("validation failed: %w", fieldErrorWrap(err, "Task"))
+	}
+
+	for _, task := range include.Task {
+		if err := db.addTaskInclude(path, task); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db *IncludeDB) addTaskInclude(absPath string, include *TaskInclude) error {
+	idMap, exist := db.tasks[absPath]
+	if !exist {
+		idMap = map[string]*TaskInclude{}
+		db.tasks[absPath] = idMap
+	}
+
+	if _, exist := idMap[include.IncludeID]; exist {
+		return fmt.Errorf("task include %q already exist, include specifiers must be unique", includeSpecifier(absPath, include.IncludeID))
+	}
+
+	idMap[include.IncludeID] = include
+	db.logf("includedb: loaded include %q", includeSpecifier(absPath, include.IncludeID))
+
+	return nil
+}
+
+func (db *IncludeDB) addOutputInclude(absPath string, include *OutputInclude) error {
+	idMap, exist := db.outputs[absPath]
+	if !exist {
+		idMap = map[string]*OutputInclude{}
+		db.outputs[absPath] = idMap
+	}
+
+	if _, exist := idMap[include.IncludeID]; exist {
+		return fmt.Errorf("output include %q already exist, include specifiers must be unique", includeSpecifier(absPath, include.IncludeID))
+	}
+
+	idMap[include.IncludeID] = include
+	db.logf("includedb: loaded include %q", includeSpecifier(absPath, include.IncludeID))
+
+	return nil
+}
+
+func (db *IncludeDB) addInputInclude(absPath string, include *InputInclude) error {
+	idMap, exist := db.inputs[absPath]
+	if !exist {
+		idMap = map[string]*InputInclude{}
+		db.inputs[absPath] = idMap
+	}
+
+	if _, exist := idMap[include.IncludeID]; exist {
+		return fmt.Errorf("input include %q already exist, include specifiers must be unique", includeSpecifier(absPath, include.IncludeID))
+	}
+
+	idMap[include.IncludeID] = include
+	db.logf("includedb: loaded include %q", includeSpecifier(absPath, include.IncludeID))
+
+	return nil
+}
+
+func (db *IncludeDB) taskInclude(absPath, id string) (*TaskInclude, bool) {
+	if idMap, exist := db.tasks[absPath]; exist {
+		if include, exist := idMap[id]; exist {
+			return include, true
+		}
+	}
+
+	return nil, false
+}
+
+func (db *IncludeDB) inputInclude(absPath, id string) (*InputInclude, bool) {
+	if idMap, exist := db.inputs[absPath]; exist {
+		if include, exist := idMap[id]; exist {
+			return include, true
+		}
+	}
+
+	return nil, false
+}
+
+func (db *IncludeDB) outputInclude(absPath, id string) (*OutputInclude, bool) {
+	if idMap, exist := db.outputs[absPath]; exist {
+		if include, exist := idMap[id]; exist {
+			return include, true
+		}
+	}
+
+	return nil, false
+}
+
+func includeSpecifier(absPath, id string) string {
+	return absPath + includeIDSep + id
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/input.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/input.go
@@ -1,0 +1,60 @@
+package cfg
+
+// Input contains information about task inputs
+type Input struct {
+	Files         []FileInputs
+	GolangSources []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
+}
+
+func (in *Input) IsEmpty() bool {
+	return len(in.Files) == 0 && len(in.GolangSources) == 0
+}
+
+func (in *Input) fileInputs() []FileInputs {
+	return in.Files
+}
+
+func (in *Input) golangSourcesInputs() []GolangSources {
+	return in.GolangSources
+}
+
+// merge appends the information in other to in.
+func (in *Input) merge(other inputDef) {
+	in.Files = append(in.Files, other.fileInputs()...)
+	in.GolangSources = append(in.GolangSources, other.golangSourcesInputs()...)
+}
+
+func (in *Input) resolve(resolver Resolver) error {
+	for _, f := range in.Files {
+		if err := f.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "Files")
+		}
+	}
+
+	for i, gs := range in.GolangSources {
+		if err := gs.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "GoLangSources")
+		}
+
+		in.GolangSources[i] = gs
+	}
+
+	return nil
+}
+
+// inputValidate validates the Input section
+func inputValidate(i inputDef) error {
+	for _, f := range i.fileInputs() {
+		if err := f.validate(); err != nil {
+			return fieldErrorWrap(err, "Files")
+		}
+	}
+
+	for _, gs := range i.golangSourcesInputs() {
+		if err := gs.validate(); err != nil {
+			return fieldErrorWrap(err, "GolangSources")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/inputdef.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/inputdef.go
@@ -1,0 +1,6 @@
+package cfg
+
+type inputDef interface {
+	fileInputs() []FileInputs
+	golangSourcesInputs() []GolangSources
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/inputinclude.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/inputinclude.go
@@ -1,0 +1,53 @@
+package cfg
+
+import (
+	"github.com/simplesurance/baur/v2/internal/deepcopy"
+)
+
+// InputInclude is a reusable Input definition.
+type InputInclude struct {
+	IncludeID string `toml:"include_id" comment:"identifier of the include"`
+
+	Files         []FileInputs
+	GolangSources []GolangSources `comment:"Inputs specified by resolving dependencies of Golang source files or packages."`
+
+	filepath string
+}
+
+func (in *InputInclude) fileInputs() []FileInputs {
+	return in.Files
+}
+
+func (in *InputInclude) golangSourcesInputs() []GolangSources {
+	return in.GolangSources
+}
+
+func (in *InputInclude) IsEmpty() bool {
+	return len(in.Files) == 0 && len(in.GolangSources) == 0
+}
+
+// validate checks if the stored information is valid.
+func (in *InputInclude) validate() error {
+	if err := validateIncludeID(in.IncludeID); err != nil {
+		if in.IncludeID != "" {
+			err = fieldErrorWrap(err, in.IncludeID)
+		}
+		return err
+	}
+
+	if in.IsEmpty() {
+		return nil
+	}
+
+	return inputValidate(in)
+}
+
+func (in *InputInclude) clone() *InputInclude {
+	var clone InputInclude
+
+	deepcopy.MustCopy(in, &clone)
+	// filepath is assigned manually because filepath is a private field, MustCopy() only clones exported fields
+	clone.filepath = in.filepath
+
+	return &clone
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/inputincludes.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/inputincludes.go
@@ -1,0 +1,19 @@
+package cfg
+
+// InputIncludes is a list of InputInclude.
+type InputIncludes []*InputInclude
+
+// validate checks that the stored information is valid.
+func (incl InputIncludes) validate() error {
+	for _, in := range incl {
+		if err := in.validate(); err != nil {
+			if in.IncludeID != "" {
+				return fieldErrorWrap(err, in.IncludeID)
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/output.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/output.go
@@ -1,0 +1,59 @@
+package cfg
+
+// Output is the tasks output section
+type Output struct {
+	DockerImage []DockerImageOutput
+	File        []FileOutput
+}
+
+func (out *Output) DockerImageOutputs() []DockerImageOutput {
+	return out.DockerImage
+}
+
+func (out *Output) FileOutputs() []FileOutput {
+	return out.File
+}
+
+func (out *Output) Resolve(resolver Resolver) error {
+	for i, dockerImage := range out.DockerImage {
+		if err := dockerImage.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "DockerImage")
+		}
+
+		// replace the slice element because dockerImage is a copy
+		out.DockerImage[i] = dockerImage
+	}
+
+	for i, file := range out.File {
+		if err := file.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "FileOutput")
+		}
+
+		// replace the slice element because file is a copy
+		out.File[i] = file
+	}
+
+	return nil
+}
+
+// Merge appends the information in other to out.
+func (out *Output) Merge(other OutputDef) {
+	out.DockerImage = append(out.DockerImage, other.DockerImageOutputs()...)
+	out.File = append(out.File, other.FileOutputs()...)
+}
+
+func outputValidate(o OutputDef) error {
+	for _, f := range o.FileOutputs() {
+		if err := f.validate(); err != nil {
+			return fieldErrorWrap(err, "File")
+		}
+	}
+
+	for _, d := range o.DockerImageOutputs() {
+		if err := d.validate(); err != nil {
+			return fieldErrorWrap(err, "DockerImage")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/outputdef.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/outputdef.go
@@ -1,0 +1,6 @@
+package cfg
+
+type OutputDef interface {
+	DockerImageOutputs() []DockerImageOutput
+	FileOutputs() []FileOutput
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/outputinclude.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/outputinclude.go
@@ -1,0 +1,50 @@
+package cfg
+
+import (
+	"errors"
+
+	"github.com/simplesurance/baur/v2/internal/deepcopy"
+)
+
+// OutputInclude is a reusable Output definition
+type OutputInclude struct {
+	IncludeID string `toml:"include_id" comment:"identifier of the include"`
+
+	DockerImage []DockerImageOutput `comment:"Docker images that are produced by the [Task.command]"`
+	File        []FileOutput        `comment:"Files that are produces by the [Task.command]"`
+
+	filepath string
+}
+
+func (out *OutputInclude) DockerImageOutputs() []DockerImageOutput {
+	return out.DockerImage
+}
+
+func (out *OutputInclude) FileOutputs() []FileOutput {
+	return out.File
+}
+
+// validate checks if the stored information is valid.
+func (out *OutputInclude) validate() error {
+	if err := validateIncludeID(out.IncludeID); err != nil {
+		if out.IncludeID != "" {
+			err = fieldErrorWrap(err, out.IncludeID)
+		}
+		return err
+	}
+
+	if len(out.DockerImage) == 0 && len(out.File) == 0 {
+		return errors.New("no output is defined")
+	}
+
+	return outputValidate(out)
+}
+
+func (out *OutputInclude) clone() *OutputInclude {
+	var clone OutputInclude
+
+	deepcopy.MustCopy(out, &clone)
+	clone.filepath = out.filepath
+
+	return &clone
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/outputincludes.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/outputincludes.go
@@ -1,0 +1,19 @@
+package cfg
+
+// OutputIncludes is a list of OutputInclude
+type OutputIncludes []*OutputInclude
+
+// validate checks if the stored information is valid.
+func (incl *OutputIncludes) validate() error {
+	for _, out := range *incl {
+		if err := out.validate(); err != nil {
+			if out.IncludeID != "" {
+				return fieldErrorWrap(err, out.IncludeID)
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/repository.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/repository.go
@@ -1,0 +1,117 @@
+package cfg
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pelletier/go-toml"
+)
+
+const (
+	minSearchDepth = 0
+	maxSearchDepth = 10
+	// Version identifies the format of the configuration files that the
+	// package is able to parse. Whenever an incompatible change is made,
+	// the Version number is increased.
+	Version int = 5
+)
+
+// Repository contains the repository configuration.
+type Repository struct {
+	ConfigVersion int `toml:"config_version" comment:"Internal field, version of baur configuration format"`
+
+	Database Database
+	Discover Discover
+
+	filePath string
+}
+
+// Database contains database configuration
+type Database struct {
+	PGSQLURL string `toml:"postgresql_url" comment:"PostgreSQL database Connection string (https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)\n The setting is overwritten by the environment variable BAUR_POSTGRESQL_URL."`
+}
+
+// Discover stores the [Discover] section of the repository configuration.
+type Discover struct {
+	Dirs        []string `toml:"application_dirs" comment:"Directories in which applications (.app.toml files) are discovered"`
+	SearchDepth int      `toml:"search_depth" comment:"Descend at most search_depth levels to find application configs"`
+}
+
+// RepositoryFromFile reads the repository config from a file and returns it.
+func RepositoryFromFile(cfgPath string) (*Repository, error) {
+	config := Repository{}
+
+	content, err := ioutil.ReadFile(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	config.filePath = cfgPath
+
+	return &config, err
+}
+
+// ExampleRepository returns an exemplary Repository config
+func ExampleRepository() *Repository {
+	return &Repository{
+		ConfigVersion: Version,
+
+		Discover: Discover{
+			Dirs:        []string{"."},
+			SearchDepth: 1,
+		},
+
+		Database: Database{
+			PGSQLURL: "postgres://postgres@localhost:5432/baur?sslmode=disable&connect_timeout=5",
+		},
+	}
+}
+
+// ToFile writes an Repository configuration file to filepath.
+func (r *Repository) ToFile(filepath string, opts ...toFileOpt) error {
+	return toFile(r, filepath, opts...)
+}
+
+func (r *Repository) FilePath() string {
+	return r.filePath
+}
+
+// Validate validates a repository configuration
+func (r *Repository) Validate() error {
+	if r.ConfigVersion == 0 {
+		return newFieldError("can not be unset or 0", "config_version")
+	}
+	if r.ConfigVersion != Version {
+		return fmt.Errorf("incompatible configuration files\n"+
+			"config_version value is %d, expecting version: %d\n"+
+			"Update your baur configuration files or downgrade baur.", r.ConfigVersion, Version)
+	}
+
+	err := r.Discover.validate()
+	if err != nil {
+		return fieldErrorWrap(err, "Discover")
+	}
+
+	return nil
+}
+
+// validate validates the Discover section and sets defaults.
+func (d *Discover) validate() error {
+	if len(d.Dirs) == 0 {
+		return newFieldError("can not be empty", "application_dirs")
+	}
+
+	if d.SearchDepth < minSearchDepth || d.SearchDepth > maxSearchDepth {
+		return newFieldError(fmt.Sprintf("search_depth parameter must be in range (%d, %d]",
+			minSearchDepth, maxSearchDepth),
+			"search_depth",
+		)
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/resolver.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/resolver.go
@@ -1,0 +1,6 @@
+package cfg
+
+// Resolver is an interface for replacing substrings with a special meaning in strings.
+type Resolver interface {
+	Resolve(string) (string, error)
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/s3upload.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/s3upload.go
@@ -1,0 +1,34 @@
+package cfg
+
+// S3Upload contains S3 upload information
+type S3Upload struct {
+	Bucket string `toml:"bucket"`
+	Key    string `toml:"key"`
+}
+
+func (s *S3Upload) resolve(resolver Resolver) error {
+	var err error
+
+	if s.Bucket, err = resolver.Resolve(s.Bucket); err != nil {
+		return fieldErrorWrap(err, "bucket")
+	}
+
+	if s.Key, err = resolver.Resolve(s.Key); err != nil {
+		return fieldErrorWrap(err, "key")
+	}
+
+	return nil
+}
+
+// validate validates a [[Task.Output.File]] section
+func (s *S3Upload) validate() error {
+	if len(s.Key) == 0 {
+		return newFieldError("can not be empty", "key")
+	}
+
+	if len(s.Bucket) == 0 {
+		return newFieldError("can not be empty", "bucket")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/task.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/task.go
@@ -1,0 +1,73 @@
+package cfg
+
+// Task is a task section
+type Task struct {
+	Name     string   `toml:"name" comment:"Task name"`
+	Command  []string `toml:"command" comment:"Command to execute.\n The first element is the command, the following its arguments."`
+	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format FILEPATH#INCLUDE_ID>.\n Paths are relative to the application directory."`
+	Input    Input    `toml:"Input" comment:"Inputs are tracked, when they change the task is rerun."`
+	Output   Output   `toml:"Output" comment:"Artifacts produced by the Task.command and their upload destinations."`
+
+	// multiple include sections of the same file can be included, use a map
+	// instead of a slice to act as a Set datastructure
+	cfgFiles map[string]struct{}
+}
+
+func (t *Task) addCfgFilepath(path string) {
+	if path == "" {
+		panic("path is empty")
+	}
+
+	t.cfgFiles[path] = struct{}{}
+}
+
+// Filepaths returns a list of all parsed config files.
+// This is the app config file and files of the included sections.
+func (t *Task) Filepaths() []string {
+	result := make([]string, 0, len(t.cfgFiles))
+
+	for p := range t.cfgFiles {
+		result = append(result, p)
+	}
+
+	return result
+}
+
+func (t *Task) command() []string {
+	return t.Command
+}
+func (t *Task) name() string {
+	return t.Name
+}
+
+func (t *Task) includes() *[]string {
+	return &t.Includes
+}
+
+func (t *Task) input() *Input {
+	return &t.Input
+}
+
+func (t *Task) output() *Output {
+	return &t.Output
+}
+
+func (t *Task) resolve(resolver Resolver) error {
+	var err error
+
+	for i, elem := range t.Command {
+		if t.Command[i], err = resolver.Resolve(elem); err != nil {
+			return fieldErrorWrap(err, "Command")
+		}
+	}
+
+	if err := t.Input.resolve(resolver); err != nil {
+		return fieldErrorWrap(err, "Input")
+	}
+
+	if err := t.Output.Resolve(resolver); err != nil {
+		return fieldErrorWrap(err, "Output")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/taskdef.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/taskdef.go
@@ -1,0 +1,89 @@
+package cfg
+
+import (
+	"fmt"
+	"strings"
+)
+
+type taskDef interface {
+	command() []string
+	includes() *[]string
+	input() *Input
+	name() string
+	output() *Output
+	addCfgFilepath(path string)
+}
+
+// taskMerge loads the includes of the task and merges them with the task itself.
+func taskMerge(task taskDef, workingDir string, resolver Resolver, includeDB *IncludeDB) error {
+	for _, includeSpec := range *task.includes() {
+		inputInclude, err := includeDB.loadInputInclude(resolver, workingDir, includeSpec)
+		if err == nil {
+			inputInclude = inputInclude.clone()
+			task.input().merge(inputInclude)
+			task.addCfgFilepath(inputInclude.filepath)
+
+			continue
+		}
+
+		// The includeSpec can refer to an input or output.
+		// If no input include for it exist, ErrIncludeIDNotFound is
+		// ignored and we try to load an output include instead.
+		if err != nil && err != ErrIncludeIDNotFound {
+			return fieldErrorWrap(fmt.Errorf("%q: %w", includeSpec, err), "Includes")
+		}
+
+		outputInclude, err := includeDB.loadOutputInclude(resolver, workingDir, includeSpec)
+		if err != nil {
+			if err == ErrIncludeIDNotFound {
+				return fieldErrorWrap(fmt.Errorf("%q: %w", includeSpec, err), "Includes")
+			}
+
+			return err
+		}
+
+		outputInclude = outputInclude.clone()
+		task.output().Merge(outputInclude)
+
+		task.addCfgFilepath(outputInclude.filepath)
+	}
+
+	return nil
+}
+
+// taskValidate validates the task section
+func taskValidate(t taskDef) error {
+	if len(t.command()) == 0 {
+		return newFieldError("can not be empty", "command")
+	}
+
+	if err := validateTaskOrAppName(t.name()); err != nil {
+		return fieldErrorWrap(err, "name")
+	}
+
+	if strings.Contains(t.name(), ".") {
+		return newFieldError("dots are not allowed in task names", "name")
+	}
+
+	if err := validateIncludes(*t.includes()); err != nil {
+		return fieldErrorWrap(err, "includes")
+	}
+
+	if t.input() == nil {
+		return newFieldError("section is empty", "Input")
+	}
+
+	if err := inputValidate(t.input()); err != nil {
+		return fieldErrorWrap(err, "Input")
+	}
+
+	if t.output() == nil {
+		return nil
+	}
+
+	if err := outputValidate(t.output()); err != nil {
+		return fieldErrorWrap(err, "Output")
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/taskinclude.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/taskinclude.go
@@ -1,0 +1,73 @@
+package cfg
+
+import (
+	"github.com/simplesurance/baur/v2/internal/deepcopy"
+)
+
+// TaskInclude is a reusable Tasks definition
+type TaskInclude struct {
+	IncludeID string `toml:"include_id" comment:"identifier of the include"`
+
+	Name     string   `toml:"name" comment:"Task name"`
+	Command  []string `toml:"command" comment:"Command to execute. The first element is the command, the following its arguments.\n If the command element contains no path seperators, its path is looked up via the $PATH environment variable."`
+	Includes []string `toml:"includes" comment:"Input or Output includes that the task inherits.\n Includes are specified in the format <filepath>#<ID>.\n Paths are relative to the include file location."`
+	Input    Input    `toml:"Input" comment:"Specification of task inputs like source files, Makefiles, etc"`
+	Output   Output   `toml:"Output" comment:"Specification of task outputs produced by the Task.command"`
+
+	cfgFiles map[string]struct{}
+}
+
+func (t *TaskInclude) addCfgFilepath(path string) {
+	t.cfgFiles[path] = struct{}{}
+}
+
+func (t *TaskInclude) command() []string {
+	return t.Command
+}
+
+func (t *TaskInclude) name() string {
+	return t.Name
+}
+
+func (t *TaskInclude) includes() *[]string {
+	return &t.Includes
+}
+
+func (t *TaskInclude) input() *Input {
+	return &t.Input
+}
+
+func (t *TaskInclude) output() *Output {
+	return &t.Output
+}
+
+func (t *TaskInclude) validate() error {
+	if err := validateIncludeID(t.IncludeID); err != nil {
+		if t.IncludeID != "" {
+			err = fieldErrorWrap(err, t.IncludeID)
+		}
+		return err
+	}
+
+	return taskValidate(t)
+}
+
+// toTask converts the TaskInclude to a Task.
+// All fields are copied.
+func (t *TaskInclude) toTask() *Task {
+	var result Task
+
+	result.Name = t.Name
+	result.Command = make([]string, len(t.Command))
+	copy(result.Command, t.Command)
+
+	result.cfgFiles = make(map[string]struct{}, len(result.cfgFiles))
+	for k, v := range t.cfgFiles {
+		result.cfgFiles[k] = v
+	}
+
+	deepcopy.MustCopy(t.Input, &result.Input)
+	deepcopy.MustCopy(t.Output, &result.Output)
+
+	return &result
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/taskincludes.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/taskincludes.go
@@ -1,0 +1,32 @@
+package cfg
+
+type TaskIncludes []*TaskInclude
+
+func (tasks TaskIncludes) validate() error {
+	for _, task := range tasks {
+		if err := task.validate(); err != nil {
+			if task.Name != "" {
+				err = fieldErrorWrap(err, "Task")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (tasks TaskIncludes) merge(workingDir string, resolver Resolver, db *IncludeDB) error {
+	for _, task := range tasks {
+		err := taskMerge(task, workingDir, resolver, db)
+		if err != nil {
+			if task.Name != "" {
+				err = fieldErrorWrap(err, task.Name)
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/tasks.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/tasks.go
@@ -1,0 +1,43 @@
+package cfg
+
+import (
+	"fmt"
+)
+
+type Tasks []*Task
+
+func (tasks Tasks) resolve(resolver Resolver) error {
+	for _, t := range tasks {
+		if err := t.resolve(resolver); err != nil {
+			return fieldErrorWrap(err, "Tasks", t.Name)
+		}
+	}
+
+	return nil
+}
+
+func (tasks Tasks) validate() error {
+	duplMap := make(map[string]struct{}, len(tasks))
+
+	for _, task := range tasks {
+		err := taskValidate(task)
+		if err != nil {
+			if task.Name != "" {
+				return fieldErrorWrap(err, "Task", task.Name)
+			}
+
+			return fieldErrorWrap(err, "Task")
+		}
+
+		_, exist := duplMap[task.Name]
+		if exist {
+			return newFieldError(
+				fmt.Sprintf("multiple tasks with name '%s' exist, task names must be unique", task.Name),
+				"Task",
+			)
+		}
+		duplMap[task.Name] = struct{}{}
+	}
+
+	return nil
+}

--- a/vendor/github.com/simplesurance/baur/v2/pkg/cfg/validation.go
+++ b/vendor/github.com/simplesurance/baur/v2/pkg/cfg/validation.go
@@ -1,0 +1,27 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var forbiddenNameRunes = [...]rune{
+	'.',
+	'*',
+	'#',
+}
+
+func validateTaskOrAppName(name string) error {
+	if len(name) == 0 {
+		return errors.New("can not be empty")
+	}
+
+	for _, r := range forbiddenNameRunes {
+		if strings.ContainsRune(name, r) {
+			return fmt.Errorf("'%c' character not allowed in name", r)
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,6 +302,8 @@ github.com/simplesurance/baur/upload/docker
 github.com/simplesurance/baur/upload/scheduler
 # github.com/simplesurance/baur/v2 v2.2.0
 ## explicit; go 1.17
+github.com/simplesurance/baur/v2/internal/deepcopy
+github.com/simplesurance/baur/v2/pkg/cfg
 github.com/simplesurance/baur/v2/pkg/storage
 github.com/simplesurance/baur/v2/pkg/storage/postgres
 # github.com/sirupsen/logrus v1.9.0


### PR DESCRIPTION
```
upgrade cfg: support upgrading to config version 6

Only new config sections were added in version 6, all existing v5 sections are
supported as they.

This makes it easy to upgrade the configuration files, only the config_version
number needs to be incremented.

-------------------------------------------------------------------------------
cfg: increase config version to 6

Older baur versions are not able to parse the Input.EnvironmentVariables and
Input.ExcludedFiles config sections.

Increase the configuration file version to 6.

-------------------------------------------------------------------------------
```

The existing tests internal/command/upgrade_configs_test.go is testing upgrading from cfg ver 4 to 6.