### PR TITLE
ci: update tools & don't run tests with '-v'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.3
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -19,4 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.49
+          version: v1.50

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.3
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.3
       - name: Checkout Git
         uses: actions/checkout@v3
       - name: Setup Git
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.3
       - name: Checkout Git
         uses: actions/checkout@v3
       - name: Setup Git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
       - name: Run Tests with Race Detector
         run: |
-          go test -v -tags=dbtest -race -timeout 5m ./...
+          go test -tags=dbtest -race -timeout 5m ./...
         shell: bash
       - name: Run Tests without Race Detector and CGO
         env:


### PR DESCRIPTION
```
ci: update golangci-lint to 1.50.*

-------------------------------------------------------------------------------
ci: update go to 1.19.13

-------------------------------------------------------------------------------
ci/windows: run tests without "-v" flag

Run the tests without "-v" parameters, as we do in all other CI tasks already.
"-v" generates to much output, making it hard to find the relevant messages when
a test failed.

-------------------------------------------------------------------------------
```