### PR TITLE
completion: include help descriptions in generated completion scripts

### DIFF
--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -135,7 +135,7 @@ func (c *initBashCompCmd) run(_ *cobra.Command, _ []string) {
 
 	complFile := filepath.Join(complDir, "baur")
 
-	err = rootCmd.GenBashCompletionFileV2(complFile, false)
+	err = rootCmd.GenBashCompletionFileV2(complFile, true)
 	exitOnErr(err, "generating completion script failed")
 
 	stdout.Printf("bash completion script written to %s\n", term.Highlight(complFile))

--- a/internal/command/init_fishcomp.go
+++ b/internal/command/init_fishcomp.go
@@ -109,7 +109,7 @@ func (c *initFishCompCmd) run(_ *cobra.Command, _ []string) {
 	err = fs.Mkdir(complDir)
 	exitOnErrf(err, "could not create directory %q", complDir)
 
-	err = rootCmd.GenFishCompletionFile(complFile, false)
+	err = rootCmd.GenFishCompletionFile(complFile, true)
 	exitOnErr(err, "generating completion script failed")
 
 	stdout.Printf("fish completion script written to %s\n", term.Highlight(complFile))

--- a/internal/command/init_powershellcomp.go
+++ b/internal/command/init_powershellcomp.go
@@ -34,6 +34,6 @@ func newInitPowerShellCompCmd() *initPowerShellCompCmd {
 }
 
 func (c *initPowerShellCompCmd) run(_ *cobra.Command, _ []string) {
-	err := rootCmd.GenPowerShellCompletion(stdout)
+	err := rootCmd.GenPowerShellCompletionWithDesc(stdout)
 	exitOnErr(err)
 }

--- a/internal/command/init_zshcomp.go
+++ b/internal/command/init_zshcomp.go
@@ -34,6 +34,6 @@ func newInitZshCompCmd() *initZshCompCmd {
 }
 
 func (c *initZshCompCmd) run(_ *cobra.Command, _ []string) {
-	err := rootCmd.GenZshCompletionNoDesc(stdout)
+	err := rootCmd.GenZshCompletion(stdout)
 	exitOnErr(err)
 }


### PR DESCRIPTION
enable to include help descriptions for subcommands and parameters in the generated completion code.

Bash completion now looks like:
```
  $ baur -<TAB>
  --cpu-prof  (enable cpu profiling, result is written to "/tmp/baur-cpu.prof")  --verbose   (verbose output)
  --help      (help for baur)                                                    --version   (version for baur)
  -h          (help for baur)                                                    -v          (verbose output)
  --no-color  (disable color output (env. variable NO_COLOR is also supported))
```

  ```
$ baur <TAB>
  diff     (list inputs that differ between two task-runs)                      run      (run tasks)
  help     (Help about any command)                                             show     (show information about apps or recorded task runs)
  init     (initialize configuration files, the baur database, bashcompletion)  status   (list status of tasks)
  ls       (list apps, builds, inputs)                                          upgrade  (upgrade configuration files and the database schema)
```