### PR TITLE
Revert "completion: include help descriptions in generated completion…

### DIFF
--- a/internal/command/init_bashcomp.go
+++ b/internal/command/init_bashcomp.go
@@ -136,7 +136,7 @@ func (c *initBashCompCmd) run(_ *cobra.Command, _ []string) {
 
 	complFile := filepath.Join(complDir, "baur")
 
-	err = rootCmd.GenBashCompletionFileV2(complFile, true)
+	err = rootCmd.GenBashCompletionFileV2(complFile, false)
 	exitOnErr(err, "generating completion script failed")
 
 	stdout.Printf(

--- a/internal/command/init_fishcomp.go
+++ b/internal/command/init_fishcomp.go
@@ -110,7 +110,7 @@ func (c *initFishCompCmd) run(_ *cobra.Command, _ []string) {
 	err = fs.Mkdir(complDir)
 	exitOnErrf(err, "could not create directory %q", complDir)
 
-	err = rootCmd.GenFishCompletionFile(complFile, true)
+	err = rootCmd.GenFishCompletionFile(complFile, false)
 	exitOnErr(err, "generating completion script failed")
 
 	stdout.Printf("fish completion script written to %s\n", term.Highlight(complFile))

--- a/internal/command/init_powershellcomp.go
+++ b/internal/command/init_powershellcomp.go
@@ -35,6 +35,6 @@ func newInitPowerShellCompCmd() *initPowerShellCompCmd {
 }
 
 func (c *initPowerShellCompCmd) run(_ *cobra.Command, _ []string) {
-	err := rootCmd.GenPowerShellCompletionWithDesc(stdout)
+	err := rootCmd.GenPowerShellCompletion(stdout)
 	exitOnErr(err)
 }

--- a/internal/command/init_zshcomp.go
+++ b/internal/command/init_zshcomp.go
@@ -35,6 +35,6 @@ func newInitZshCompCmd() *initZshCompCmd {
 }
 
 func (c *initZshCompCmd) run(_ *cobra.Command, _ []string) {
-	err := rootCmd.GenZshCompletion(stdout)
+	err := rootCmd.GenZshCompletionNoDesc(stdout)
 	exitOnErr(err)
 }


### PR DESCRIPTION
… scripts"

This reverts commit 34d154ec7099925686371659f3add6b47f0c26eb.

Including help descriptions makes the output too noisy, at least when using bash.
Disable it again, if there is interest we could add a parameter to enable/disable including help descriptions when generating completions.