### PR TITLE
show: do not show Excluded Files section if it is empty

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -240,9 +240,11 @@ func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
 			mustWriteRow(formatter, "", "", "", "")
 		}
 
-		mustWriteRow(formatter, "", "", "", "")
-		mustWriteRow(formatter, "", "", "Type:", term.Highlight("Excluded Files"))
-		mustWriteStringSliceRows(formatter, "Paths:", 2, task.UnresolvedInputs.ExcludedFiles.Paths)
+		if len(task.UnresolvedInputs.ExcludedFiles.Paths) > 0 {
+			mustWriteRow(formatter, "", "", "", "")
+			mustWriteRow(formatter, "", "", "Type:", term.Highlight("Excluded Files"))
+			mustWriteStringSliceRows(formatter, "Paths:", 2, task.UnresolvedInputs.ExcludedFiles.Paths)
+		}
 
 	}
 


### PR DESCRIPTION
"baur show" always printed a "Type: Excluded Files" line

Only show it if files are excluded, otherwise omit the section, as it is done for all other sections.