### PR TITLE
loader: fix that the same app can be discovered multiple times

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/aws/smithy-go v1.13.5
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/simplesurance/baur/v2 v2.2.0
+	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/baur/init_test.go
+++ b/pkg/baur/init_test.go
@@ -1,0 +1,24 @@
+package baur
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+var testdataDir string
+
+func init() {
+	_, testfile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("could not get test filename")
+	}
+
+	absPath, err := filepath.Abs(testfile)
+	if err != nil {
+		panic(fmt.Sprintf(
+			" could not get absolute path of testfile (%s): %s",
+			testfile, err))
+	}
+	testdataDir = filepath.Join(filepath.Dir(absPath), "testdata")
+}

--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,23 +15,6 @@ import (
 	"github.com/simplesurance/baur/v3/internal/vcs"
 	"github.com/simplesurance/baur/v3/pkg/cfg"
 )
-
-var testdataDir string
-
-func init() {
-	_, testfile, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("could not get test filename")
-	}
-
-	absPath, err := filepath.Abs(testfile)
-	if err != nil {
-		panic(fmt.Sprintf(
-			" could not get absolute path of testfile (%s): %s",
-			testfile, err))
-	}
-	testdataDir = filepath.Join(filepath.Dir(absPath), "testdata")
-}
 
 func relPathsFromInputs(t *testing.T, in []Input) []string {
 	res := make([]string, len(in))

--- a/pkg/baur/loader_test.go
+++ b/pkg/baur/loader_test.go
@@ -1,0 +1,26 @@
+package baur
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v3/internal/log"
+)
+
+func TestFindAppConfigsRemovesDups(t *testing.T) {
+	log.RedirectToTestingLog(t)
+
+	repoDir := filepath.Join(testdataDir, "app_matches_multiple_app_dirs")
+	err := os.Chdir(repoDir)
+	require.NoError(t, err)
+
+	searchDirs := []string{".", "app1", "app1/.", "app1/..", "app1/../app1/."}
+
+	result, err := findAppConfigs(searchDirs, 5, log.StdLogger)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+}

--- a/pkg/baur/loader_test.go
+++ b/pkg/baur/loader_test.go
@@ -19,7 +19,7 @@ func TestFindAppConfigsRemovesDups(t *testing.T) {
 
 	searchDirs := []string{".", "app1", "app1/.", "app1/..", "app1/../app1/."}
 
-	result, err := findAppConfigs(searchDirs, 5, log.StdLogger)
+	result, err := findAppConfigs(repoDir, searchDirs, 5, log.StdLogger)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)

--- a/pkg/baur/testdata/app_matches_multiple_app_dirs/app1/.app.toml
+++ b/pkg/baur/testdata/app_matches_multiple_app_dirs/app1/.app.toml
@@ -1,0 +1,9 @@
+name = "app1"
+
+[[Task]]
+  name = "build"
+  command = [ "./build.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]

--- a/vendor/golang.org/x/exp/LICENSE
+++ b/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/exp/PATENTS
+++ b/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/exp/maps/maps.go
+++ b/vendor/golang.org/x/exp/maps/maps.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package maps defines various functions useful with maps of any type.
+package maps
+
+// Keys returns the keys of the map m.
+// The keys will be in an indeterminate order.
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+// Values returns the values of the map m.
+// The values will be in an indeterminate order.
+func Values[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}
+
+// Equal reports whether two maps contain the same key/value pairs.
+// Values are compared using ==.
+func Equal[M1, M2 ~map[K]V, K, V comparable](m1 M1, m2 M2) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v1 := range m1 {
+		if v2, ok := m2[k]; !ok || v1 != v2 {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualFunc is like Equal, but compares values using eq.
+// Keys are still compared with ==.
+func EqualFunc[M1 ~map[K]V1, M2 ~map[K]V2, K comparable, V1, V2 any](m1 M1, m2 M2, eq func(V1, V2) bool) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v1 := range m1 {
+		if v2, ok := m2[k]; !ok || !eq(v1, v2) {
+			return false
+		}
+	}
+	return true
+}
+
+// Clear removes all entries from m, leaving it empty.
+func Clear[M ~map[K]V, K comparable, V any](m M) {
+	for k := range m {
+		delete(m, k)
+	}
+}
+
+// Clone returns a copy of m.  This is a shallow clone:
+// the new keys and values are set using ordinary assignment.
+func Clone[M ~map[K]V, K comparable, V any](m M) M {
+	// Preserve nil in case it matters.
+	if m == nil {
+		return nil
+	}
+	r := make(M, len(m))
+	for k, v := range m {
+		r[k] = v
+	}
+	return r
+}
+
+// Copy copies all key/value pairs in src adding them to dst.
+// When a key in src is already present in dst,
+// the value in dst will be overwritten by the value associated
+// with the key in src.
+func Copy[M1 ~map[K]V, M2 ~map[K]V, K comparable, V any](dst M1, src M2) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+// DeleteFunc deletes any key/value pairs from m for which del returns true.
+func DeleteFunc[M ~map[K]V, K comparable, V any](m M, del func(K, V) bool) {
+	for k, v := range m {
+		if del(k, v) {
+			delete(m, k)
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,6 +302,9 @@ github.com/stretchr/testify/require
 # golang.org/x/crypto v0.6.0
 ## explicit; go 1.17
 golang.org/x/crypto/pbkdf2
+# golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
+## explicit; go 1.20
+golang.org/x/exp/maps
 # golang.org/x/mod v0.8.0
 ## explicit; go 1.17
 golang.org/x/mod/semver


### PR DESCRIPTION
loader: deduplicate application_dirs

If the application_dirs configuration contains the same directory multiple
times, baur searched for app config files in it multiple times. This operation
can be quite costly. Deduplicate application_dirs and log a debug message if
duplicates are found.

-------------------------------------------------------------------------------
loader: fix that the same app can be discovered multiple times

If an application directory is matched by multiple entries in
application_directories from the .baur.toml file, "baur ls apps" and "baur
status" would show it multiple times.

Fix it by deduplicating the list of discovered application configs.