### PR TITLE
ci: increase golangci-lint timeout

### DIFF
--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -19,3 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52
+          args: --timeout 3m


### PR DESCRIPTION
ci: increase golangci-lint timeout

golangci-lint started to fail because it timed out since it was updated.
Increase the timeout from 1m to 3m.