### PR TITLE
exec: only stream output when log function is set

### DIFF
--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -21,7 +21,7 @@ type PrintfFn func(format string, a ...any)
 
 var (
 	// DefaultLogFn is the default debug print function.
-	DefaultLogFn = func(string, ...interface{}) {}
+	DefaultLogFn PrintfFn
 	// DefaultLogPrefix is the default prefix that is prepended to messages passed to the debugf function.
 	DefaultLogPrefix = "exec: "
 	// DefaultStderrColorFn is the default function that is used to colorize stderr output that is streamed to the log function.
@@ -104,6 +104,9 @@ func (c *Cmd) Env(env []string) *Cmd {
 }
 
 func (c *Cmd) logf(format string, a ...any) {
+	if c.logFn == nil {
+		return
+	}
 	c.logFn(c.logPrefix+format, a...)
 }
 


### PR DESCRIPTION
By default the log function was an function that did nothing. If logFn was not nil, the output was always splitted in lines and logged via logFn. This is unnecessary.

Instead of setting DefaultLogFn to an noop function, set it to nil. This allows to determine if logFn is set and prevent unnecessary processing of the stdout and stderr of the process.