### PR TITLE
golangcilint: enable errorlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,11 +6,13 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - errorlint
     - exportloopref
     - gocritic
     - goimports
     - goprintffuncname
     - gosimple
+    - govet
     - ineffassign
     - misspell
     - nolintlint
@@ -26,7 +28,6 @@ linters:
     - unconvert
     - unused
     - usestdlibvars
-    - govet
 
 linters-settings:
   goimports:

--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -292,7 +292,7 @@ func getPreviousTaskRun(psql storage.Storer, argDetails *diffInputArgDetails) *s
 		},
 	)
 
-	if err != nil && errors.Unwrap(err) != found {
+	if err != nil && errors.Unwrap(err) != found { //nolint:errorlint
 		exitOnErr(err)
 	}
 
@@ -331,7 +331,7 @@ func getTaskRunByID(psql storage.Storer, id int) *storage.TaskRunWithID {
 		},
 	)
 
-	if err != nil && err == storage.ErrNotExist {
+	if errors.Is(err, storage.ErrNotExist) {
 		err = fmt.Errorf("task-run %d does not exist", id)
 	}
 	exitOnErr(err)

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"os"
 	"strconv"
 
@@ -59,7 +60,7 @@ func (c *lsOutputsCmd) run(_ *cobra.Command, args []string) {
 
 	_, err = pgClient.TaskRun(ctx, taskRunID)
 	if err != nil {
-		if err == storage.ErrNotExist {
+		if errors.Is(err, storage.ErrNotExist) {
 			stderr.Printf("task run with ID %d does not exist", taskRunID)
 			exitFunc(1)
 		}
@@ -67,7 +68,7 @@ func (c *lsOutputsCmd) run(_ *cobra.Command, args []string) {
 
 	outputs, err := pgClient.Outputs(ctx, taskRunID)
 	if err != nil {
-		if err == storage.ErrNotExist {
+		if errors.Is(err, storage.ErrNotExist) {
 			log.Debugf("task run with ID %d has no outputs", taskRunID)
 		} else {
 			exitOnErr(err)

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -168,7 +169,7 @@ func (c *lsRunsCmd) run(_ *cobra.Command, args []string) {
 	)
 
 	if err != nil {
-		if err == storage.ErrNotExist {
+		if errors.Is(err, storage.ErrNotExist) {
 			stderr.Println("no matching task runs exist")
 			exitFunc(1)
 		}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -334,7 +334,7 @@ func (*showCmd) showBuild(taskRunID int) {
 
 	taskRun, err := storageClt.TaskRun(ctx, taskRunID)
 	if err != nil {
-		if err == storage.ErrNotExist {
+		if errors.Is(err, storage.ErrNotExist) {
 			stderr.Printf("task run with id %d does not exist\n", taskRunID)
 			exitFunc(1)
 		}

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -112,13 +112,12 @@ func (c *Cmd) logf(format string, a ...any) {
 
 func exitCodeFromErr(waitErr error) (exitCode int, err error) {
 	var ee *exec.ExitError
-	var ok bool
 
 	if waitErr == nil {
 		return 0, err
 	}
 
-	if ee, ok = waitErr.(*exec.ExitError); !ok {
+	if !errors.As(waitErr, &ee) {
 		return -1, waitErr
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -174,7 +175,7 @@ func FileReadLine(path string) (string, error) {
 
 	r := bufio.NewReader(fd)
 	content, err := r.ReadString('\n')
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return "", err
 	}
 

--- a/internal/testutils/logwriter/logwrap.go
+++ b/internal/testutils/logwriter/logwrap.go
@@ -2,6 +2,7 @@ package logwriter
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -45,7 +46,7 @@ func (l *Logger) Write(p []byte) (int, error) {
 	for {
 		line, err := l.buf.ReadString('\n')
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				panic(fmt.Sprintf("logwrap: reading from buffer failed: %s", err))
 			}
 			// add chunk without line-ending back to buffer

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	_ "embed" // is required to initialize the rawVersion variable with content from the ver file
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -77,7 +78,7 @@ func New(ver string) (*SemVer, error) {
 
 	ver = strings.TrimSpace(ver)
 	matches, err := fmt.Sscanf(ver, "%d.%d.%d-%s", &major, &minor, &patch, &appendix)
-	if (err != nil && err != io.ErrUnexpectedEOF) || matches < 1 {
+	if (err != nil && !errors.Is(err, io.ErrUnexpectedEOF)) || matches < 1 {
 		return nil, fmt.Errorf("invalid format, should be <Major>[.<Minor>[.<Patch>[-appendix]]]: %w", err)
 	}
 

--- a/pkg/baur/cfgupgrade.go
+++ b/pkg/baur/cfgupgrade.go
@@ -46,10 +46,10 @@ func (u *CfgUpgrader) upgradeAppConfigs(
 
 		if err := appCfg.Validate(); err != nil {
 			if appCfg.Name != "" {
-				return fmt.Errorf("%s: %s", appCfg.Name, err)
+				return fmt.Errorf("%s: %w", appCfg.Name, err)
 			}
 
-			return fmt.Errorf("%s: %s", cfgPath, err)
+			return fmt.Errorf("%s: %w", cfgPath, err)
 		}
 
 		newAppCfg := v4.UpgradeAppConfig(appCfg)
@@ -142,7 +142,7 @@ func (u *CfgUpgrader) upgradeV4() error {
 		}
 
 		if err := oldInclude.Validate(); err != nil {
-			return fmt.Errorf("%s: %s", includePath, err)
+			return fmt.Errorf("%s: %w", includePath, err)
 		}
 
 		newInclude := v4.UpgradeIncludeConfig(oldInclude)

--- a/pkg/baur/taskstatusevaluator.go
+++ b/pkg/baur/taskstatusevaluator.go
@@ -2,6 +2,7 @@ package baur
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/simplesurance/baur/v3/pkg/storage"
@@ -79,7 +80,7 @@ func (t *TaskStatusEvaluator) getTaskStatus(ctx context.Context, inputs *Inputs,
 
 	run, err := t.store.LatestTaskRunByDigest(ctx, task.AppName, task.Name, totalInputDigest.String())
 	if err != nil {
-		if err == storage.ErrNotExist {
+		if errors.Is(err, storage.ErrNotExist) {
 			return TaskStatusExecutionPending, nil, nil
 		}
 

--- a/pkg/cfg/fielderror.go
+++ b/pkg/cfg/fielderror.go
@@ -25,9 +25,9 @@ func newFieldError(msg string, path ...string) *fieldError {
 // If it is of type FieldError, the passed paths are prepended to it's
 // ElementPath and err is returned.
 func fieldErrorWrap(err error, path ...string) error {
-	valError, ok := err.(*fieldError)
-	if ok {
-		valError.elementPath = append(path, valError.elementPath...)
+	var fErr *fieldError
+	if errors.As(err, &fErr) {
+		fErr.elementPath = append(path, fErr.elementPath...)
 		return err
 	}
 

--- a/pkg/cfg/taskdef.go
+++ b/pkg/cfg/taskdef.go
@@ -1,6 +1,7 @@
 package cfg
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -29,13 +30,13 @@ func taskMerge(task taskDef, workingDir string, resolver Resolver, includeDB *In
 		// The includeSpec can refer to an input or output.
 		// If no input include for it exist, ErrIncludeIDNotFound is
 		// ignored and we try to load an output include instead.
-		if err != nil && err != ErrIncludeIDNotFound {
+		if err != nil && !errors.Is(err, ErrIncludeIDNotFound) {
 			return fieldErrorWrap(fmt.Errorf("%q: %w", includeSpec, err), "Includes")
 		}
 
 		outputInclude, err := includeDB.loadOutputInclude(resolver, workingDir, includeSpec)
 		if err != nil {
-			if err == ErrIncludeIDNotFound {
+			if errors.Is(err, ErrIncludeIDNotFound) {
 				return fieldErrorWrap(fmt.Errorf("%q: %w", includeSpec, err), "Includes")
 			}
 

--- a/pkg/storage/postgres/query.go
+++ b/pkg/storage/postgres/query.go
@@ -101,7 +101,7 @@ func (c *Client) inputStrings(ctx context.Context, taskRunID int) ([]*storage.In
 
 	rows, err := c.db.Query(ctx, query, taskRunID)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, storage.ErrNotExist
 		}
 
@@ -140,7 +140,7 @@ func (c *Client) inputFiles(ctx context.Context, taskRunID int) ([]*storage.Inpu
 
 	rows, err := c.db.Query(ctx, query, taskRunID)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, storage.ErrNotExist
 		}
 
@@ -178,7 +178,7 @@ func (c *Client) inputEnvVars(ctx context.Context, taskRunID int) ([]*storage.In
 
 	rows, err := c.db.Query(ctx, query, taskRunID)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, storage.ErrNotExist
 		}
 


### PR DESCRIPTION
adapt code to errorlint suggestion

Adapt the code to the errorlint suggest.
Using errors.Is/As is often unnecessary in the current code but it will make the
code more resilient if code is changed to wrap errors instead.

-------------------------------------------------------------------------------
golangcilint: enable errorlint linter