### PR TITLE
tests: add file and symlink inputresolver testcases

### DIFF
--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -1,0 +1,52 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package baur
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v3/internal/log"
+)
+
+func TestSymlinkTargetFileOwnerChange(t *testing.T) {
+	t.Skip("fails because of bug: https://github.com/simplesurance/baur/issues/493")
+	log.RedirectToTestingLog(t)
+
+	user, err := user.Current()
+	require.NoError(t, err)
+	gids, err := user.GroupIds()
+	require.NoError(t, err)
+	require.NotEmpty(t, gids, "requiring the user to be at least in 1 additional group, to run the testcase")
+
+	info := prepareSymlinkTestDir(t)
+	require.NoError(t, err)
+
+	fi, err := os.Stat(info.SymlinkTargetFilePath)
+	require.NoError(t, err)
+	statt := fi.Sys().(*syscall.Stat_t)
+	currentOwnerGid := statt.Gid
+
+	newGid := -1
+	for _, g := range gids {
+		gidNr, err := strconv.Atoi(g)
+		require.NoError(t, err)
+
+		if int64(gidNr) != int64(currentOwnerGid) {
+			newGid = gidNr
+			break
+		}
+	}
+	require.NotEqualf(t, -1, newGid, "could not find a supplementary group of the user that is the current group owner of the file (%v) ", currentOwnerGid)
+
+	require.NoError(t, os.Chown(info.SymlinkTargetFilePath, -1, newGid))
+	t.Logf("changed group owner of %v to %v", info.SymlinkTargetFilePath, newGid)
+
+	digestAfter := resolveInputs(t, info.Task)
+	require.NotEqual(t, info.TotalInputDigest.String(), digestAfter.String())
+}


### PR DESCRIPTION
Add several testcases for the InputResolver, that verify that a change is detected when:
- file content changes,
- a symlink is replaced by it's target,
- target path of a symlink changes but the target file content stays the same,
- content of a symlink target changes,
- file permissions change,
- file owner changes

Several of the tests are failed.
They are disabled and GitHub issues for it have been created.