### PR TITLE
exec: fix: command output not shown when MultiWriter fails

### DIFF
--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -208,10 +208,10 @@ func (c *Cmd) Run(ctx context.Context) (*Result, error) {
 
 	// if a write to one of the writers of the MultiWriter fails, the command will fail
 	stdoutPss := prefixSuffixSaver{N: c.maxStoredErrBytesPerStream}
-	cmd.Stdout = newMultiWriter(c.stdout, stdoutLogWriter, &stdoutPss)
+	cmd.Stdout = newMultiWriter(&stdoutPss, c.stdout, stdoutLogWriter)
 
 	stderrPss := prefixSuffixSaver{N: c.maxStoredErrBytesPerStream}
-	cmd.Stderr = newMultiWriter(c.stderr, stderrLogWriter, &stderrPss)
+	cmd.Stderr = newMultiWriter(&stderrPss, c.stderr, stderrLogWriter)
 
 	// lock to thread because of:
 	// https://github.com/golang/go/issues/27505#issuecomment-713706104


### PR DESCRIPTION
When an error happened writing the output of the command to the MultiWriter, the last output is missing in the error message.

Reorder the MultiWriters, to first write to the stdoutPss, stderrPss writer that are the buffers for the error message.
That way the buffers contain the last output if a write operation to the following writers fail.