### PR TITLE
exec: improve information on command execution error

### DIFF
--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -134,7 +134,7 @@ func (c *Cmd) startOutputStreamLogging(name string, useColorStderrColorfn bool) 
 
 		for sc.Scan() {
 			if useColorStderrColorfn && c.logFnStderrStreamColorfn != nil {
-				c.logf(c.logFnStderrStreamColorfn(sc.Text(), "\n"))
+				c.logf(c.logFnStderrStreamColorfn(sc.Text()) + "\n")
 			} else {
 				c.logf(sc.Text() + "\n")
 			}

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"time"
@@ -173,6 +174,18 @@ func (c *Cmd) startOutputStreamLogging(name string, useColorStderrColorfn bool) 
 	}
 }
 
+func (c *Cmd) resolveDir(d string) string {
+	if d != "" {
+		return d
+	}
+	d, err := os.Getwd()
+	if err != nil {
+		c.logFn("WARN: determining current working directory failed: %s", err)
+		return ""
+	}
+	return d
+}
+
 // Run executes the command.
 // If the command could not be started an error is returned.
 // If the command was started successfully, and terminated unsuccessfully no
@@ -181,7 +194,7 @@ func (c *Cmd) Run(ctx context.Context) (*Result, error) {
 	cmd := exec.CommandContext(ctx, c.name, c.args...)
 	cmd.SysProcAttr = defSysProcAttr()
 	cmd.WaitDelay = time.Minute
-	cmd.Dir = c.dir
+	cmd.Dir = c.resolveDir(c.dir)
 	cmd.Env = c.env
 
 	stdoutLogWriterCloseFn := func() error { return nil }

--- a/internal/exec/command_linux_test.go
+++ b/internal/exec/command_linux_test.go
@@ -18,6 +18,7 @@ func TestCombinedStderrOutput(t *testing.T) {
 
 	res, err := Command("sh", "-c", fmt.Sprintf("echo -n '%s' 1>&2", echoStr)).RunCombinedOut(ctx)
 	require.NoError(t, err)
+	require.NotNil(t, res)
 
 	if res.ExitCode != 0 {
 		t.Fatal(res.ExpectSuccess())
@@ -50,6 +51,7 @@ func TestLongStdoutOutputIsTruncated(t *testing.T) {
 		"dd", "if=/dev/urandom", "bs=1024", fmt.Sprintf("count=%d", outBytes/1024),
 	).Run(ctx)
 	require.NoError(t, err)
+	require.NotNil(t, res)
 	require.NoError(t, res.ExpectSuccess())
 
 	assert.GreaterOrEqual(t, len(res.stdout.Bytes()), maxErrOutputBytesPerStream)

--- a/internal/exec/command_linux_test.go
+++ b/internal/exec/command_linux_test.go
@@ -19,11 +19,7 @@ func TestCombinedStderrOutput(t *testing.T) {
 	res, err := Command("sh", "-c", fmt.Sprintf("echo -n '%s' 1>&2", echoStr)).RunCombinedOut(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-
-	if res.ExitCode != 0 {
-		t.Fatal(res.ExpectSuccess())
-	}
-
+	require.Equal(t, 0, res.ExitCode, "unexpected exit code")
 	assert.Equal(t, echoStr, res.StrOutput(), "unexpected output")
 }
 

--- a/internal/exec/command_test.go
+++ b/internal/exec/command_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCombinedStdoutOutput(t *testing.T) {
@@ -53,6 +55,8 @@ func TestCommandFails(t *testing.T) {
 	if len(res.CombinedOutput) != 0 {
 		t.Fatalf("expected no output from command but got '%s'", res.StrOutput())
 	}
+	require.Error(t, res.ExpectSuccess())
+	t.Log(res.ExpectSuccess())
 }
 
 func TestExpectSuccess(t *testing.T) {

--- a/internal/exec/command_test.go
+++ b/internal/exec/command_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"runtime"
@@ -57,4 +58,18 @@ func TestExpectSuccess(t *testing.T) {
 	}
 	require.Error(t, err)
 	assert.Nil(t, res)
+}
+
+func TestOutputStream(t *testing.T) {
+	ctx := context.Background()
+	const echoStr = "hello\nline2"
+
+	buf := bytes.Buffer{}
+
+	_, err := Command("bash", "-c",
+		fmt.Sprintf("echo '%s'", echoStr)).LogPrefix("").
+		LogFn(func(f string, a ...any) { fmt.Fprintf(&buf, f, a...) }).ExpectSuccess().Run(ctx)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), echoStr)
+
 }

--- a/internal/exec/result.go
+++ b/internal/exec/result.go
@@ -15,7 +15,11 @@ func (e *ExitCodeError) Error() string {
 	var result strings.Builder
 	var stdoutExists bool
 
-	result.WriteString("execution failed: ")
+	result.WriteString("executing \"")
+	result.WriteString(e.Command)
+	result.WriteString("\" in \"")
+	result.WriteString(e.Dir)
+	result.WriteString("\" failed: ")
 	result.WriteString(e.ee.String())
 
 	if len(e.stdout.Bytes()) == 0 && len(e.stderr.Bytes()) == 0 {


### PR DESCRIPTION
```
exec: include stream name and WARN: in outputstream log messages

If an error happens when streaming the output, always include the stream name
and WARN in the related log message.

Some internal variable names are also shortened.

-------------------------------------------------------------------------------
tests: add simple exec stdout streaming testcase

-------------------------------------------------------------------------------
exec: fix: duplicate newlines in streaming output

When "--verbose" was passed to "baur run" the logger was used as logf function.
The logger appends a "\n" when the last character is not already a newline.
Because "\n" character was colorized with the logFnStderrStreamColorfn, the
logger did not detect the newline anymore and appended a second one.

Do not pass "\n" to c.logFnStderrStreamColorfn.

-------------------------------------------------------------------------------
run: improve command error output format

Move colorizing the output of command errors to the command package.
This allows more fine granular coloring

-------------------------------------------------------------------------------
exec: include command and execution directory in error message

When a command exited unsuccessfully, include the executed command and the
directory in which it was run in the error message.

-------------------------------------------------------------------------------
test: use testify in exec tests

-------------------------------------------------------------------------------
exec: improve error handling

- extend the error message to contain the information that the process was
  killed by signal or because of a broken pipe by using the message from
  exec.ExitError
- instead of checking if a process exited with code 0, check for success by
  calling ProcessState.Success(), this is platform independent and also works as
  expected if a platform uses another code then 0 to indicate success

-------------------------------------------------------------------------------
tests: add exec testcase for recorded and streamed output

Add testcases that verfify that the streamed output and the prefixSaver outputs
are complete when the the process mixes stdout and stderr output.

-------------------------------------------------------------------------------
```