### PR TITLE
inputfiles: use git object IDs as input file content digests

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -213,7 +213,7 @@ func parseDiffSpec(s string) (app, task, runID string) {
 
 func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diffInputArgDetails) (*baur.Inputs, *storage.TaskRunWithID) {
 	if argDetails.task != nil {
-		inputResolver := baur.NewInputResolver(c.vcsState)
+		inputResolver := baur.NewInputResolver(c.vcsState, repo.Path)
 
 		inputFiles, err := inputResolver.Resolve(ctx, repo.Path, argDetails.task)
 		if err != nil {

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -94,7 +94,7 @@ func (c *lsInputsCmd) mustGetTaskInputs(taskSpec string) []baur.Input {
 	repo := mustFindRepository()
 	vcsState := mustGetRepoState(repo.Path)
 	task := mustArgToTask(repo, vcsState, taskSpec)
-	inputResolver := baur.NewInputResolver(vcsState)
+	inputResolver := baur.NewInputResolver(vcsState, repo.Path)
 
 	inputs, err := inputResolver.Resolve(ctx, repo.Path, task)
 	exitOnErr(err)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -452,7 +452,7 @@ func (c *runCmd) filterPendingTasks(tasks []*baur.Task) ([]*pendingTask, error) 
 	const sep = " => "
 
 	taskIDColLen := maxTaskIDLen(tasks) + len(sep)
-	statusEvaluator := baur.NewTaskStatusEvaluator(c.repoRootPath, c.storage, baur.NewInputResolver(mustGetRepoState(c.repoRootPath)), c.inputStr, c.lookupInputStr)
+	statusEvaluator := baur.NewTaskStatusEvaluator(c.repoRootPath, c.storage, baur.NewInputResolver(mustGetRepoState(c.repoRootPath), c.repoRootPath), c.inputStr, c.lookupInputStr)
 
 	stdout.Printf("Evaluating status of tasks:\n\n")
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -177,7 +177,7 @@ func (c *statusCmd) run(_ *cobra.Command, args []string) {
 
 	showProgress := len(tasks) >= 5 && !c.quiet && !c.csv
 
-	statusMgr := baur.NewTaskStatusEvaluator(repo.Path, storageClt, baur.NewInputResolver(mustGetRepoState(repo.Path)), c.inputStr, c.lookupInputStr)
+	statusMgr := baur.NewTaskStatusEvaluator(repo.Path, storageClt, baur.NewInputResolver(mustGetRepoState(repo.Path), repo.Path), c.inputStr, c.lookupInputStr)
 
 	baur.SortTasksByID(tasks)
 

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -16,6 +16,8 @@ const (
 	SHA256
 	// SHA384 is the sha384 algorithm
 	SHA384
+
+	GitObjectID
 )
 
 // String returns the textual representation
@@ -26,6 +28,8 @@ func (t Algorithm) String() string {
 
 	case SHA384:
 		return "sha384"
+	case GitObjectID:
+		return "gitobjectid"
 	default:
 		return "undefined"
 	}
@@ -45,7 +49,6 @@ func (d *Digest) String() string {
 // FromString converts a "<Algorithm>:<hash> string to Digest
 func FromString(in string) (*Digest, error) {
 	var algorithm Algorithm
-
 	spl := strings.Split(strings.TrimSpace(in), ":")
 	if len(spl) != 2 {
 		return nil, errors.New("invalid format, must contain exactly 1 ':'")
@@ -76,5 +79,16 @@ func FromString(in string) (*Digest, error) {
 	return &Digest{
 		Sum:       sum,
 		Algorithm: algorithm,
+	}, nil
+}
+
+func FromStrDigest(digest string, algo Algorithm) (*Digest, error) {
+	b, err := hex.DecodeString(digest)
+	if err != nil {
+		return nil, fmt.Errorf("converting digest (%q) to hex failed: %w", digest, err)
+	}
+	return &Digest{
+		Sum:       b,
+		Algorithm: algo,
 	}, nil
 }

--- a/internal/digest/gitobjectid/gitobjectid.go
+++ b/internal/digest/gitobjectid/gitobjectid.go
@@ -1,0 +1,146 @@
+package gitobjectid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/simplesurance/baur/v3/internal/digest"
+	"github.com/simplesurance/baur/v3/internal/fs"
+	"github.com/simplesurance/baur/v3/internal/vcs/git"
+)
+
+type PrintfFn func(format string, a ...any)
+
+// Calc calculates git object IDs for files.
+// Object IDs are read the first time a digest is requested from the git repository.
+type Calc struct {
+	objectIDs    map[string]string
+	symlinkPaths map[string]struct{}
+	loadDbOnce   sync.Once
+	loadErr      error
+
+	repositoryDir string
+	debugLogf     PrintfFn
+}
+
+func New(gitRepositoryDir string, debugLogf PrintfFn) *Calc {
+	return &Calc{
+		repositoryDir: gitRepositoryDir,
+		debugLogf:     debugLogf,
+		objectIDs:     map[string]string{},
+		symlinkPaths:  map[string]struct{}{},
+	}
+}
+
+func (h *Calc) loadFromRepositoryOnce(ctx context.Context) error {
+	h.loadDbOnce.Do(func() { h.loadErr = h.loadFromRepository(ctx) })
+	return h.loadErr
+}
+
+func (h *Calc) loadFromRepository(ctx context.Context) error {
+	ch := make(chan *git.Object)
+	finishedCh := make(chan struct{})
+	go h.createDb(ch, finishedCh)
+
+	err := git.LsFiles(ctx, h.repositoryDir, true, ch)
+	if err != nil {
+		return err
+	}
+
+	<-finishedCh
+
+	h.debugLogf("gitobjectid: loaded %d object IDs from git repository (%s)\n", len(h.objectIDs), h.repositoryDir)
+
+	return nil
+}
+
+func (h *Calc) createDb(ch <-chan *git.Object, finishedCh chan struct{}) {
+	m := map[string]string{}
+	outdated := map[string]struct{}{}
+
+	defer close(finishedCh)
+
+	for obj := range ch {
+		if obj.IsSymlink() {
+			h.symlinkPaths[filepath.Join(h.repositoryDir, obj.RelPath)] = struct{}{}
+			continue
+		}
+		if !obj.IsFile() {
+			continue
+		}
+
+		absPath := filepath.Join(h.repositoryDir, obj.RelPath)
+		if obj.Status == git.ObjectStatusCached {
+			if _, exists := outdated[absPath]; exists {
+				continue
+			}
+			m[absPath] = obj.Name
+			continue
+		}
+
+		outdated[absPath] = struct{}{}
+		delete(m, absPath)
+	}
+
+	h.objectIDs = m
+}
+
+// File returns a git object ID as digest for the the file at absPath.
+//
+// On the first call of this function, the git object IDs are loaded from
+// the git repository.
+func (h *Calc) File(absPath string) (*digest.Digest, error) {
+	// if the ID does not exist in the cache, it is calculated.
+	// The calculated ID could be added to the cache afterwards to be available for further loookups.
+	// This is not done because baur already has the
+	// InputFileSingletonCache on top, which prevents multiple digest
+	// calculations for the same path.
+	if !filepath.IsAbs(absPath) {
+		return nil, errors.New("file path is not absolute")
+	}
+
+	if err := h.loadFromRepositoryOnce(context.TODO()); err != nil {
+		return nil, fmt.Errorf("loading git object ids failed: %w", err)
+	}
+
+	objectID, exists := h.objectIDs[absPath]
+	if exists {
+		return digest.FromStrDigest(objectID, digest.GitObjectID)
+	}
+
+	if _, isSymlink := h.symlinkPaths[absPath]; !isSymlink {
+		d, err := h.fileWithoutCache(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("git object id does not exist in cache and could not be calculated: %w", err)
+		}
+		return d, nil
+	}
+
+	// if it is a known symlink, the db might contain the entry for the target path
+	p, err := fs.RealPath(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if objectID, exists = h.objectIDs[p]; exists {
+		return digest.FromStrDigest(objectID, digest.GitObjectID)
+	}
+
+	d, err := h.fileWithoutCache(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("git object id does not exist in cache and could not be calculated: %w", err)
+	}
+	return d, nil
+}
+
+func (h *Calc) fileWithoutCache(absPath string) (*digest.Digest, error) {
+	h.debugLogf("gitobjectid: object id not in cache, calculating ID for %q", absPath)
+	objectID, err := git.ObjectID(context.TODO(), absPath, h.repositoryDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return digest.FromStrDigest(objectID, digest.GitObjectID)
+}

--- a/internal/digest/gitobjectid/gitobjectid_test.go
+++ b/internal/digest/gitobjectid/gitobjectid_test.go
@@ -1,0 +1,62 @@
+package gitobjectid
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/simplesurance/baur/v3/internal/testutils/fstest"
+	"github.com/simplesurance/baur/v3/internal/testutils/gittest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculatedUntrackedAndReadTrackedFileIDsAreSame(t *testing.T) {
+	const fRel = "file"
+	tempDir := t.TempDir()
+
+	gittest.CreateRepository(t, tempDir)
+
+	f := filepath.Join(tempDir, fRel)
+	fstest.WriteToFile(t, []byte("110"), f)
+
+	calc := New(tempDir, t.Logf)
+	dUntracked, err := calc.File(f)
+	require.NoError(t, err)
+	require.Empty(t, calc.objectIDs)
+	require.Empty(t, calc.symlinkPaths)
+
+	gittest.CommitFilesToGit(t, tempDir)
+	calc = New(tempDir, t.Logf)
+	dTracked, err := calc.File(f)
+	require.NoError(t, err)
+	require.Len(t, calc.objectIDs, 1)
+	require.Empty(t, calc.symlinkPaths)
+
+	require.Equal(t, dUntracked.String(), dTracked.String())
+
+}
+
+func TestObjectIDsOfModifiedFilesAreNotUsed(t *testing.T) {
+	const fRel = "file"
+	tempDir := t.TempDir()
+
+	gittest.CreateRepository(t, tempDir)
+
+	f := filepath.Join(tempDir, fRel)
+	fstest.WriteToFile(t, []byte("110"), f)
+	gittest.CommitFilesToGit(t, tempDir)
+
+	calc := New(tempDir, t.Logf)
+	oldD, err := calc.File(f)
+	require.NoError(t, err)
+
+	fstest.WriteToFile(t, []byte("112"), f)
+
+	calc = New(tempDir, t.Logf)
+	newD, err := calc.File(f)
+	require.NoError(t, err)
+	require.Empty(t, calc.objectIDs)
+	require.Empty(t, calc.symlinkPaths)
+
+	require.NotEqual(t, oldD, newD)
+}

--- a/internal/digest/sha384/sha384.go
+++ b/internal/digest/sha384/sha384.go
@@ -17,7 +17,7 @@ type Hash struct {
 	hash stdhash.Hash
 }
 
-// New returns a  sha384.Hash to compute a digest
+// New returns a sha384.Hash to compute a digest
 func New() *Hash {
 	return &Hash{hash: sha512.New384()}
 }

--- a/internal/digest/sha384/sha384.go
+++ b/internal/digest/sha384/sha384.go
@@ -58,6 +58,15 @@ func (h *Hash) AddBytes(b []byte) error {
 	return nil
 }
 
+// File returns the sha384 of the file at path.
+func File(path string) (*digest.Digest, error) {
+	h := New()
+	if err := h.AddFile(path); err != nil {
+		return nil, err
+	}
+	return h.Digest(), nil
+}
+
 // Sum aggregates multiple digests to a single SHA384 digest
 func Sum(digests []*digest.Digest) (*digest.Digest, error) {
 	hash := New()

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/simplesurance/baur/v3/internal/digest"
+	"github.com/simplesurance/baur/v3/internal/digest/sha384"
 	"github.com/simplesurance/baur/v3/internal/fs"
 	"github.com/simplesurance/baur/v3/internal/testutils/dbtest"
 	"github.com/simplesurance/baur/v3/internal/testutils/fstest"
@@ -207,7 +208,7 @@ func (r *Repo) WriteAdditionalFileContents(t *testing.T, appName, fileName, cont
 	t.Helper()
 
 	absPath := filepath.Join(r.Dir, appName, fileName)
-	file := baur.NewInputFile(absPath, filepath.Join(appName, fileName))
+	file := baur.NewInputFile(absPath, filepath.Join(appName, fileName), sha384.File)
 	fstest.WriteToFile(t, []byte(contents), absPath)
 
 	digest, err := file.CalcDigest()

--- a/internal/vcs/git/files.go
+++ b/internal/vcs/git/files.go
@@ -1,0 +1,190 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/simplesurance/baur/v3/internal/exec"
+)
+
+const (
+	// source of the descriptions: git-ls-files manpage (Git 2.43.0)
+
+	// H tracked file that is not either unmerged or skip-worktree
+	ObjectStatusCached byte = 'H'
+	// S tracked file that is skip-worktree
+	ObjectStatusSkipWorktree byte = 'S'
+	// M tracked file that is unmerged
+	ObjectStatusUnmerged byte = 'M'
+	// R tracked file with unstaged removal/deletion
+	ObjectStatusRemoved byte = 'R'
+	// C tracked file with unstaged modification/change
+	ObjectStatusChanged byte = 'C'
+	// K untracked paths which are part of file/directory conflicts which
+	// prevent checking out tracked files
+	ObjectStatusToBeKilled byte = 'K'
+	// ? untracked file
+	ObjectStatusUntracked byte = '?'
+	// U file with resolve-undo information
+	ObjectStatusWithResolveUndoInfo byte = 'U'
+)
+
+const (
+	ObjectTypeSymlink = 0120000
+	ObjectTypeFile    = 0100000
+)
+
+type Object struct {
+	Status byte
+	Mode   uint32
+	// Name is the hash of the object
+	Name    string
+	RelPath string
+}
+
+func (o *Object) String() string {
+	return fmt.Sprintf("status: %c mode: %o name: %s path: %s", o.Status, o.Mode, o.Name, o.RelPath)
+}
+
+func (o *Object) IsSymlink() bool {
+	return o.Mode&ObjectTypeSymlink == ObjectTypeSymlink
+}
+
+func (o *Object) IsFile() bool {
+	return o.Mode&ObjectTypeFile == ObjectTypeFile
+}
+
+func scanNullTerminatedLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\x00'); i >= 0 {
+		return i + 1, data[0:i], nil
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
+// LsFiles retrieves information about files in the index and working tree.
+// The information is sent to ch.
+// For a path multiple objects might be sent, if the status in the index and working tree differs.
+// Listing files in git submodules is not supported.
+// The function closes ch when it terminates.
+func LsFiles(ctx context.Context, dir string, skipUntracked bool, ch chan<- *Object) error {
+	defer close(ch)
+	reader, writer := io.Pipe()
+
+	parseCh := make(chan error)
+	go func() {
+		err := parseLsFilesLines(reader, skipUntracked, ch)
+		reader.CloseWithError(err)
+		parseCh <- err
+		close(parseCh)
+	}()
+
+	_, err := exec.Command(
+		"git", "ls-files",
+		"--cached", "--modified", "--other",
+		"--exclude-standard",
+		"--full-name",
+		"-t",
+		"--stage",
+		"-z",
+	).
+		Directory(dir).
+		ExpectSuccess().
+		Stdout(writer).
+		Run(ctx)
+	_ = writer.Close()
+	parseErr := <-parseCh
+	return errors.Join(err, parseErr)
+}
+
+func parseLsFilesLines(reader io.Reader, skipUntracked bool, ch chan<- *Object) error {
+	sc := bufio.NewScanner(reader)
+	sc.Split(scanNullTerminatedLines)
+
+	for sc.Scan() {
+		var o Object
+		// example line: H 100644 53bba79de99f79b670f62958e917c81ecc04c6e7 0	internal/vcs/git/files.go
+		line := sc.Text()
+		substr := line
+
+		f1End := strings.IndexRune(substr, ' ')
+		if f1End == -1 {
+			return errors.New("field 1 not found")
+		}
+		status := substr[:f1End]
+		if len(status) != 1 {
+			return fmt.Errorf("expected status field value have a length of 1, got: %q", status)
+		}
+		o.Status = status[0]
+
+		if skipUntracked && o.Status == ObjectStatusUntracked {
+			continue
+		}
+
+		if len(substr) < f1End-1 {
+			return fmt.Errorf("line has 1 field, expecting 2 or 5: %q", line)
+		}
+		substr = substr[f1End+1:]
+
+		// objectmodes: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+		// > In this case, you’re specifying a mode of 100644, which
+		// > means it’s a normal file. Other options are 100755, which
+		// > means it’s an executable file; and 120000, which specifies a
+		// > symbolic link. The mode is taken from normal UNIX modes but
+		// > is much less flexible — these three modes are the only ones
+		// > that are valid for files (blobs) in Git (although other
+		// > modes are used for directories and submodules).
+		var mode string
+		f2End := strings.IndexRune(substr, ' ')
+		if f2End == -1 {
+			mode = substr
+		} else {
+			mode = substr[:f2End]
+		}
+
+		modeUint, err := strconv.ParseUint(mode, 8, 32)
+		if err != nil {
+			return fmt.Errorf("could not parse mode %q from substr: %q, line %q: %w", mode, substr, line, err)
+		}
+		o.Mode = uint32(modeUint)
+
+		if f2End == -1 || len(substr) < f2End-1 {
+			ch <- &o
+			continue
+		}
+		substr = substr[f2End+1:]
+
+		f3End := strings.IndexRune(substr, ' ')
+		if f3End == -1 {
+			return fmt.Errorf("line has 4 fields, expecting 2 or 5 fields: %q", line)
+		}
+		o.Name = substr[:f3End]
+
+		if len(substr) < f3End-1 {
+			return fmt.Errorf("line has 4 fields, expecting 2 or 5: %q", line)
+		}
+		substr = substr[f3End+1:]
+		// we skip field 4 (stageNr, we don't need it)
+
+		f5Start := strings.IndexRune(substr, '\t')
+		if f5Start == -1 {
+			return fmt.Errorf("line is missing '\t' character: %q", line)
+		}
+		o.RelPath = substr[f5Start+1:]
+
+		ch <- &o
+	}
+
+	return sc.Err()
+}

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -134,3 +134,22 @@ func UntrackedFiles(dir string) ([]string, error) {
 
 	return res, nil
 }
+
+// ObjectID calculates the git ID (hash) of a fille.
+func ObjectID(ctx context.Context, absFilePath, repoRelFilePath string) (string, error) {
+	// TODO: calculate the object ID instead of running an external command
+	// git hash-object, or by calculating the ID on our own as described in https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+	result, err := exec.Command("git", "hash-object", "--path", repoRelFilePath, absFilePath).
+		ExpectSuccess().
+		RunCombinedOut(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	objectID := strings.TrimSpace(result.StrOutput())
+	if objectID == "" {
+		return "", errors.New("git returned nothing")
+	}
+
+	return objectID, nil
+}

--- a/pkg/baur/inputfile_singletoncache.go
+++ b/pkg/baur/inputfile_singletoncache.go
@@ -1,17 +1,25 @@
 package baur
 
+import (
+	"github.com/simplesurance/baur/v3/internal/digest"
+)
+
 const inputFileSingletonCacheInitialSize = 250
+
+type FileHashFn func(path string) (*digest.Digest, error)
 
 // InputFileSingletonCache stores previously created InputFiles and returns
 // them for the same path instead of creating another instance.
 type InputFileSingletonCache struct {
-	cache map[string]*InputFile
+	cache      map[string]*InputFile
+	fileHasher FileHashFn
 }
 
 // newInputFile SingletonCache creates a inputFileSingletonCache.
-func NewInputFileSingletonCache() *InputFileSingletonCache {
+func NewInputFileSingletonCache(fileHasher FileHashFn) *InputFileSingletonCache {
 	return &InputFileSingletonCache{
-		cache: make(map[string]*InputFile, inputFileSingletonCacheInitialSize),
+		cache:      make(map[string]*InputFile, inputFileSingletonCacheInitialSize),
+		fileHasher: fileHasher,
 	}
 }
 
@@ -23,7 +31,7 @@ func (c *InputFileSingletonCache) CreateOrGetInputFile(absPath, relPath string) 
 		return f
 	}
 
-	f := NewInputFile(absPath, relPath)
+	f := NewInputFile(absPath, relPath, c.fileHasher)
 	c.cache[absPath] = f
 
 	return f

--- a/pkg/baur/inputfile_singletoncache_test.go
+++ b/pkg/baur/inputfile_singletoncache_test.go
@@ -4,11 +4,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/simplesurance/baur/v3/internal/digest/sha384"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestInputFileSingletonCache(t *testing.T) {
-	c := NewInputFileSingletonCache()
+	c := NewInputFileSingletonCache(sha384.File)
 	f1Path := filepath.Join("etc", "issue")
 	f2Path := filepath.Join("etc", "motd")
 	f1 := c.CreateOrGetInputFile(f1Path, "issue")

--- a/pkg/baur/inputfile_test.go
+++ b/pkg/baur/inputfile_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/simplesurance/baur/v3/internal/digest/sha384"
 	"github.com/simplesurance/baur/v3/internal/testutils/fstest"
 )
 
@@ -25,8 +26,8 @@ func TestDigestDoesNotDependOnRepoPath(t *testing.T) {
 	fstest.WriteToFile(t, []byte("hello"), absFilepath1)
 	fstest.WriteToFile(t, []byte("hello"), absFilepath2)
 
-	f1 := NewInputFile(absFilepath1, relFilepath1)
-	f2 := NewInputFile(absFilepath2, relFilepath2)
+	f1 := NewInputFile(absFilepath1, relFilepath1, sha384.File)
+	f2 := NewInputFile(absFilepath2, relFilepath2, sha384.File)
 
 	d1, err := f1.Digest()
 	require.NoError(t, err)

--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -24,7 +24,7 @@ func TestSymlinkTargetFileOwnerChange(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, gids, "requiring the user to be at least in 1 additional group, to run the testcase")
 
-	info := prepareSymlinkTestDir(t)
+	info := prepareSymlinkTestDir(t, false, false)
 	require.NoError(t, err)
 
 	fi, err := os.Stat(info.SymlinkTargetFilePath)


### PR DESCRIPTION
If the baur repository is also a git repository and the git binary is available,
baur now uses git object IDs as file content digest.
The object IDs for all tracked files are read from the git repository.
If an inputfile is tracked and unmodified, the existing git object ID can be
used.
This does not work for files that are part of a git submodule.
Depending on the number of input files and hardware this can be much faster.
It saves CPU time because the digest does not need be
calculated and disk I/O because all input files don't have to be read anymore.
Only "git ls-files" needs to be executed and it's output parsed.
The digest of an InputFile is still a SHA384. It is the hash of the aggregation
of the git object id of the content and the SHA384 of it's relative file path.

If an file is not tracked, tracked but modified or part of a git submodule,
 "git hash-object" is executed to calculate the object ID. 
This ensures that the stored baur object ID for the
file is the same, if it is later added to the repository and the task is rerun.

Executing "git hash-object" is slower then calculating the sha384 digest in baur
itself. The typical baur usecase is that it runs in CI for a checked out git
repository, where all files are tracked. Thereore it is neglegtible.
This can be improved in a follow-up by calculating the object ID in baur without
running an external command.

If the baur repository is not a git repository, file digests are calculated as
before.