### PR TITLE
add --require-clean-git-worktree flag to run and status commands

### DIFF
--- a/internal/command/term/streams.go
+++ b/internal/command/term/streams.go
@@ -12,7 +12,7 @@ import (
 
 const separator = "------------------------------------------------------------------------------"
 
-var errorPrefix = color.New(color.FgRed).Sprint("ERROR:")
+var ErrorPrefix = color.New(color.FgRed).Sprint("ERROR:")
 
 // Stream is a concurrency-safe output for term.messages.
 type Stream struct {
@@ -49,18 +49,23 @@ func (s *Stream) TaskPrintf(task *baur.Task, format string, a ...interface{}) {
 // The method prints the error in the format: errorPrefix msg: err
 func (s *Stream) ErrPrintln(err error, msg ...interface{}) {
 	if len(msg) == 0 {
-		s.Println(errorPrefix, err)
+		s.Println(ErrorPrefix, err)
 		return
 	}
 
 	wholeMsg := fmt.Sprint(msg...)
-	s.Printf("%s %s: %s\n", errorPrefix, wholeMsg, err)
+	s.Printf("%s %s: %s\n", ErrorPrefix, wholeMsg, err)
 }
 
 // ErrPrintf prints an error with an optional printf-style message.
 // The method prints the error in the format: errorPrefix msg: err
 func (s *Stream) ErrPrintf(err error, format string, a ...interface{}) {
 	s.ErrPrintln(err, fmt.Sprintf(format, a...))
+}
+
+// PrintErrln prints as message that is prefixed with "ERROR: "
+func (s *Stream) PrintErrln(msg ...interface{}) {
+	s.Println(ErrorPrefix, fmt.Sprint(msg...))
 }
 
 // PrintSep prints a separator line

--- a/internal/prettyprint/prettyprint.go
+++ b/internal/prettyprint/prettyprint.go
@@ -3,6 +3,7 @@ package prettyprint
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // AsString returns in as indented JSON
@@ -13,4 +14,15 @@ func AsString(in interface{}) string {
 	}
 
 	return string(res)
+}
+
+// TruncatedStrSlice returns sl as string, joined by ", ".
+// If sl has more then maxElems, only the first maxElems elements will be
+// returned and additional truncation marker.
+func TruncatedStrSlice(sl []string, maxElems int) string {
+	if len(sl) <= maxElems {
+		return strings.Join(sl, ", ")
+	}
+
+	return strings.Join(sl[:maxElems], ", ") + ", [...]"
 }

--- a/internal/vcs/git/git.go
+++ b/internal/vcs/git/git.go
@@ -93,8 +93,8 @@ func WorktreeIsDirty(dir string) (bool, error) {
 	return true, nil
 }
 
-// UntrackedFiles returns a list of untracked files in the repository found at dir.
-// The returned paths are relative to dir.
+// UntrackedFiles returns a list of untracked and modified files in the git repository.
+// Files that exist and are in a .gitignore file are included.
 func UntrackedFiles(dir string) ([]string, error) {
 	const untrackedFilePrefix = "?? "
 	const ignoredFilePrefix = "!! "

--- a/internal/vcs/git/repository.go
+++ b/internal/vcs/git/repository.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+const Name = "git"
+
 // Repository reads information from a Git repository.
 type Repository struct {
 	path string
@@ -113,4 +115,14 @@ func (g *Repository) initUntrackedFiles() error {
 	}
 
 	return nil
+}
+
+// UntrackedFiles returns a list of untracked and modified files in the git repository.
+// Files that exist and are in a .gitignore file are included.
+func (g *Repository) UntrackedFiles() ([]string, error) {
+	return UntrackedFiles(g.path)
+}
+
+func (g *Repository) Name() string {
+	return Name
 }

--- a/internal/vcs/novcsstate.go
+++ b/internal/vcs/novcsstate.go
@@ -22,3 +22,11 @@ func (*NoVCsState) WorktreeIsDirty() (bool, error) {
 func (NoVCsState) WithoutUntracked(_ ...string) ([]string, error) {
 	return nil, ErrVCSRepositoryNotExist
 }
+
+func (*NoVCsState) Name() string {
+	return "none"
+}
+
+func (*NoVCsState) UntrackedFiles() ([]string, error) {
+	return nil, ErrVCSRepositoryNotExist
+}

--- a/internal/vcs/state.go
+++ b/internal/vcs/state.go
@@ -13,6 +13,8 @@ type StateFetcher interface {
 	CommitID() (string, error)
 	WorktreeIsDirty() (bool, error)
 	WithoutUntracked(paths ...string) ([]string, error)
+	Name() string
+	UntrackedFiles() ([]string, error)
 }
 
 var state = struct {

--- a/pkg/baur/taskrunner_test.go
+++ b/pkg/baur/taskrunner_test.go
@@ -1,0 +1,17 @@
+package baur
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunningTaskFailsWhenGitWorktreeIsDirty(t *testing.T) {
+	tr := NewTaskRunner()
+	tr.GitUntrackedFilesFn = func(_ string) ([]string, error) {
+		return []string{"1"}, nil
+	}
+	_, err := tr.Run(&Task{})
+	var eu *ErrUntrackedGitFilesExist
+	require.ErrorAs(t, err, &eu)
+}


### PR DESCRIPTION
Add a new flag to "baur run" and "baur status" called --require-clean-git-worktree.
If passed, the commands fail if the baur repository contains untracked or modified tracked git files, this includes files that are in .gitignore.

"baur run", checks the state on start and before executing a task, to catch cases were multiple tasks are run and of them modifies or creates new files in the git repository.

This helps to ensure that tasks are executed in an clean reproducible environment.

Closes #142 