### PR TITLE
inputresolver: remove repositoryDir parameter from Resolve method

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -215,7 +215,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 	if argDetails.task != nil {
 		inputResolver := baur.NewInputResolver(c.vcsState, repo.Path)
 
-		inputFiles, err := inputResolver.Resolve(ctx, repo.Path, argDetails.task)
+		inputFiles, err := inputResolver.Resolve(ctx, argDetails.task)
 		if err != nil {
 			stderr.TaskPrintf(argDetails.task, err.Error())
 			os.Exit(1)

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -96,7 +96,7 @@ func (c *lsInputsCmd) mustGetTaskInputs(taskSpec string) []baur.Input {
 	task := mustArgToTask(repo, vcsState, taskSpec)
 	inputResolver := baur.NewInputResolver(vcsState, repo.Path)
 
-	inputs, err := inputResolver.Resolve(ctx, repo.Path, task)
+	inputs, err := inputResolver.Resolve(ctx, task)
 	exitOnErr(err)
 
 	return inputs

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -69,7 +69,7 @@ func NewInputResolver(vcsState vcs.StateFetcher, repoDir string) *InputResolver 
 // Resolve resolves the input definition of the task to concrete Files.
 // If an input definition does not resolve to >=1 paths, an error is returned.
 // The resolved Files are deduplicated.
-func (i *InputResolver) Resolve(ctx context.Context, repositoryDir string, task *Task) ([]Input, error) {
+func (i *InputResolver) Resolve(ctx context.Context, task *Task) ([]Input, error) {
 	goSourcePaths, err := i.resolveGoSrcInputs(ctx, task.Directory, task.UnresolvedInputs.GolangSources)
 	if err != nil {
 		return nil, fmt.Errorf("resolving golang source inputs failed: %w", err)
@@ -85,7 +85,7 @@ func (i *InputResolver) Resolve(ctx context.Context, repositoryDir string, task 
 	allInputsPaths = append(allInputsPaths, goSourcePaths...)
 	allInputsPaths = append(allInputsPaths, task.CfgFilepaths...)
 
-	uniqInputs, err := i.pathsToUniqInputs(repositoryDir, allInputsPaths, fs.AbsPaths(task.Directory, task.UnresolvedInputs.ExcludedFiles.Paths))
+	uniqInputs, err := i.pathsToUniqInputs(allInputsPaths, fs.AbsPaths(task.Directory, task.UnresolvedInputs.ExcludedFiles.Paths))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (i *InputResolver) resolveGoSrcInputs(ctx context.Context, appDir string, i
 	return result, nil
 }
 
-func (i *InputResolver) pathsToUniqInputs(repositoryRoot string, paths, excludePatterns []string) ([]Input, error) {
+func (i *InputResolver) pathsToUniqInputs(paths, excludePatterns []string) ([]Input, error) {
 	pathsCount := len(paths)
 
 	res := make([]Input, 0, pathsCount)
@@ -239,7 +239,7 @@ func (i *InputResolver) pathsToUniqInputs(repositoryRoot string, paths, excludeP
 			continue
 		}
 
-		relPath, err := filepath.Rel(repositoryRoot, path)
+		relPath, err := filepath.Rel(i.repoDir, path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/baur/taskstatusevaluator.go
+++ b/pkg/baur/taskstatusevaluator.go
@@ -45,7 +45,7 @@ func (t *TaskStatusEvaluator) Status(ctx context.Context, task *Task) (TaskStatu
 	var taskStatus TaskStatus
 	var run *storage.TaskRunWithID
 
-	inputFiles, err := t.inputResolver.Resolve(ctx, t.repositoryDir, task)
+	inputFiles, err := t.inputResolver.Resolve(ctx, task)
 	if err != nil {
 		return TaskStatusUndefined, nil, nil, err
 	}


### PR DESCRIPTION
The parameter is not needed anymore, since 2ec86012 it is stored in the InputResolver struct, remove it.

Inputresolver testcases were adapted and some also adapted to to use a subdirectory of the repositoryDir that is passed, to also test resolving of relate paths.