### PR TITLE
command: use fatal function, add fatalf equivalent and use it

### DIFF
--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -163,11 +163,11 @@ func mustArgToTasks(repo *baur.Repository, vcs vcs.StateFetcher, args []string) 
 	exitOnErr(err)
 
 	if len(tasks) == 0 {
-		exitOnErr(fmt.Errorf("could not find any tasks\n"+
+		fatalf("could not find any tasks\n"+
 			"- ensure the [Discover] section is correct in %s\n"+
 			"- ensure that you have >1 application dirs "+
 			"containing a %s file with task definitions",
-			repo.CfgPath, baur.AppCfgFile))
+			repo.CfgPath, baur.AppCfgFile)
 	}
 
 	return tasks
@@ -225,6 +225,11 @@ func fatal(msg ...interface{}) {
 	exitFunc(1)
 }
 
+func fatalf(format string, v ...interface{}) {
+	stderr.Printf(format, v...)
+	exitFunc(1)
+}
+
 func exitOnErr(err error, msg ...interface{}) {
 	if err == nil {
 		return
@@ -261,9 +266,7 @@ func mustUntrackedFilesNotExist(requireCleanGitWorktree bool, vcsState vcs.State
 	}
 
 	if vcsState.Name() != git.Name {
-		exitOnErr(
-			fmt.Errorf("--%s was specified but baur repository is not a git repository", flagNameRequireCleanGitWorktree),
-		)
+		fatalf("--%s was specified but baur repository is not a git repository", flagNameRequireCleanGitWorktree)
 	}
 
 	untracked, err := vcsState.UntrackedFiles()

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -67,8 +67,7 @@ func initDb(_ *cobra.Command, args []string) {
 
 	err = storageClt.Init(ctx)
 	if errors.Is(err, storage.ErrExists) {
-		stderr.ErrPrintln(errors.New("database already exists"))
-		exitFunc(1)
+		fatal("database already exists")
 	}
 	exitOnErr(err)
 

--- a/internal/command/upgrade_db.go
+++ b/internal/command/upgrade_db.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -51,11 +50,9 @@ func (*upgradeDbCmd) run(_ *cobra.Command, _ []string) {
 
 	curVer, err := clt.SchemaVersion(ctx)
 	if errors.Is(err, storage.ErrNotExist) {
-		stderr.ErrPrintln(fmt.Errorf(
-			"database not found, run '%s' to create the database",
+		fatalf("database not found, run '%s' to create the database",
 			term.Highlight("baur init db"),
-		))
-		exitFunc(1)
+		)
 	}
 	exitOnErr(err, "querying database schema version failed")
 
@@ -65,8 +62,7 @@ func (*upgradeDbCmd) run(_ *cobra.Command, _ []string) {
 	}
 
 	if curVer > clt.RequiredSchemaVersion() {
-		stderr.Println("database schema is from a newer baur version, please update baur")
-		exitFunc(1)
+		fatal("database schema is from a newer baur version, please update baur")
 	}
 
 	err = clt.Upgrade(ctx)


### PR DESCRIPTION
Use the newly added fatal function and fatalf equivalent, instead of creating a new error only to be able to call stderr.ErrPrintln