### PR TITLE
Add global --repository parameter

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -25,6 +25,7 @@ var rootCmd = &cobra.Command{
 var verboseFlag bool
 var cpuProfilingFlag bool
 var noColorFlag bool
+var repositoryPath string
 
 var defCPUProfFile = filepath.Join(os.TempDir(), "baur-cpu.prof")
 
@@ -52,6 +53,10 @@ func initSb(_ *cobra.Command, _ []string) {
 		err = pprof.StartCPUProfile(cpuProfFile)
 		exitOnErr(err)
 	}
+
+	if repositoryPath != "" {
+		exitOnErr(os.Chdir(repositoryPath))
+	}
 }
 
 // Execute parses commandline flags and execute their actions
@@ -67,6 +72,7 @@ func Execute() {
 	rootCmd.PersistentFlags().BoolVar(&cpuProfilingFlag, "cpu-prof", false,
 		fmt.Sprintf("enable cpu profiling, result is written to %q", defCPUProfFile))
 	rootCmd.PersistentFlags().BoolVar(&noColorFlag, "no-color", false, "disable color output (env. variable NO_COLOR is also supported)")
+	rootCmd.PersistentFlags().StringVar(&repositoryPath, "repository", "", "path to the baur repository root directory")
 
 	err := rootCmd.Execute()
 	exitOnErr(err)

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -54,3 +54,23 @@ func TestShowArgs(t *testing.T) {
 	})
 
 }
+
+func TestShowWithRepositoryArg(t *testing.T) {
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	app := r.CreateSimpleApp(t)
+
+	require.NoError(t, os.Chdir(os.TempDir()))
+	oldRepoPath := repositoryPath
+	t.Cleanup(func() {
+		repositoryPath = oldRepoPath
+		rootCmd.SetArgs(os.Args[1:])
+	})
+
+	rootCmd.SetArgs([]string{"show", app.Name})
+	_, stderrBuf := interceptCmdOutput(t)
+	require.Panics(t, func() { require.NoError(t, rootCmd.Execute()) })
+	require.Contains(t, stderrBuf.String(), "baur repository not found")
+
+	repositoryPath = r.Dir
+	require.NoError(t, rootCmd.Execute())
+}


### PR DESCRIPTION
Add a new "--repository" parameter to all baur commands. As value the path to a baur root repository can be passed.

This can be used to run baur from outside a baur repository, which can be sometimes in scripts.