### PR TITLE
gitobject: query db always for resolved symlink paths + disable calculating git object ids on --require-clean-git-worktree

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -213,7 +213,7 @@ func parseDiffSpec(s string) (app, task, runID string) {
 
 func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diffInputArgDetails) (*baur.Inputs, *storage.TaskRunWithID) {
 	if argDetails.task != nil {
-		inputResolver := baur.NewInputResolver(c.vcsState, repo.Path)
+		inputResolver := baur.NewInputResolver(c.vcsState, repo.Path, true)
 
 		inputFiles, err := inputResolver.Resolve(ctx, argDetails.task)
 		if err != nil {

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -94,7 +94,7 @@ func (c *lsInputsCmd) mustGetTaskInputs(taskSpec string) []baur.Input {
 	repo := mustFindRepository()
 	vcsState := mustGetRepoState(repo.Path)
 	task := mustArgToTask(repo, vcsState, taskSpec)
-	inputResolver := baur.NewInputResolver(vcsState, repo.Path)
+	inputResolver := baur.NewInputResolver(vcsState, repo.Path, true)
 
 	inputs, err := inputResolver.Resolve(ctx, task)
 	exitOnErr(err)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -452,7 +452,12 @@ func (c *runCmd) filterPendingTasks(tasks []*baur.Task) ([]*pendingTask, error) 
 	const sep = " => "
 
 	taskIDColLen := maxTaskIDLen(tasks) + len(sep)
-	statusEvaluator := baur.NewTaskStatusEvaluator(c.repoRootPath, c.storage, baur.NewInputResolver(mustGetRepoState(c.repoRootPath), c.repoRootPath), c.inputStr, c.lookupInputStr)
+	statusEvaluator := baur.NewTaskStatusEvaluator(
+		c.repoRootPath,
+		c.storage,
+		baur.NewInputResolver(mustGetRepoState(c.repoRootPath), c.repoRootPath, !c.requireCleanGitWorktree),
+		c.inputStr, c.lookupInputStr,
+	)
 
 	stdout.Printf("Evaluating status of tasks:\n\n")
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -177,7 +177,12 @@ func (c *statusCmd) run(_ *cobra.Command, args []string) {
 
 	showProgress := len(tasks) >= 5 && !c.quiet && !c.csv
 
-	statusMgr := baur.NewTaskStatusEvaluator(repo.Path, storageClt, baur.NewInputResolver(mustGetRepoState(repo.Path), repo.Path), c.inputStr, c.lookupInputStr)
+	statusMgr := baur.NewTaskStatusEvaluator(
+		repo.Path,
+		storageClt,
+		baur.NewInputResolver(mustGetRepoState(repo.Path), repo.Path, !c.requireCleanGitWorktree),
+		c.inputStr, c.lookupInputStr,
+	)
 
 	baur.SortTasksByID(tasks)
 

--- a/internal/digest/gitobjectid/gitobjectid.go
+++ b/internal/digest/gitobjectid/gitobjectid.go
@@ -111,21 +111,15 @@ func (h *Calc) File(absPath string) (*digest.Digest, error) {
 		return digest.FromStrDigest(objectID, digest.GitObjectID)
 	}
 
-	if _, isSymlink := h.symlinkPaths[absPath]; !isSymlink {
-		d, err := h.fileWithoutCache(absPath)
-		if err != nil {
-			return nil, fmt.Errorf("git object id does not exist in cache and could not be calculated: %w", err)
-		}
-		return d, nil
-	}
-
-	// if it is a known symlink, the db might contain the entry for the target path
+	// file might be a symlink, check if it's resolved path exist in the db
 	p, err := fs.RealPath(absPath)
 	if err != nil {
 		return nil, err
 	}
-	if objectID, exists = h.objectIDs[p]; exists {
-		return digest.FromStrDigest(objectID, digest.GitObjectID)
+	if p != absPath {
+		if objectID, exists = h.objectIDs[p]; exists {
+			return digest.FromStrDigest(objectID, digest.GitObjectID)
+		}
 	}
 
 	d, err := h.fileWithoutCache(absPath)

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -46,13 +46,17 @@ type InputResolver struct {
 
 // NewInputResolver returns an InputResolver that caches resolver
 // results.
-func NewInputResolver(vcsState vcs.StateFetcher, repoDir string) *InputResolver {
+func NewInputResolver(vcsState vcs.StateFetcher, repoDir string, hashGitUntrackedFiles bool) *InputResolver {
 	var hasher FileHashFn
 	if _, gitUnavail := vcsState.(*vcs.NoVCsState); gitUnavail {
 		hasher = sha384.File
 		log.Debugf("inputresolver: using sha384 file hasher\n")
 	} else {
-		hasher = gitobjectid.New(repoDir, log.Debugf).File
+		if hashGitUntrackedFiles {
+			hasher = gitobjectid.New(repoDir, log.Debugf).File
+		} else {
+			hasher = gitobjectid.New(repoDir, log.Debugf).FileDigestFromCache
+		}
 		log.Debugf("inputresolver: using gitobject file hasher\n")
 	}
 


### PR DESCRIPTION
disable calculating git object ids on --require-clean-git-worktree

When --require-clean-git-worktree is specified as commandline parameter, disable
calculating git object IDs for files that were not returned "git ls-files".

This is a safe guard, to ensure that only git object IDs are used that already
exist in the git repository, calculating them manually is expensive.

-------------------------------------------------------------------------------
gitobject: query db always for resolved symlink paths

If a path for that the digest was requested contained a directory symlink, the
file was not found in the db, despite it contains an entry for the symlink
target path.

gitobject only resolved paths to symlinks if "git ls files" returned a symlink
stauts for them. It's only returned for symlinks though, not for paths to a file
that contain a directory symlink path.

If a path can not be found in the db, always resolve symlink in it's path and
check if an entry for the resolved path exist.

-------------------------------------------------------------------------------