### PR TITLE
status: support JSON output format

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/exec"
 	"github.com/simplesurance/baur/v3/internal/testutils/dbtest"
 	"github.com/simplesurance/baur/v3/internal/testutils/gittest"
@@ -85,7 +86,7 @@ func baurCSVStatusCmd(t *testing.T, cmd *statusCmd) []*csvStatus {
 
 	stdoutBuf, _ := interceptCmdOutput(t)
 
-	cmd.csv = true
+	cmd.format = &flag.Format{Val: flag.FormatCSV}
 	err := cmd.Execute()
 	require.NoError(t, err)
 

--- a/internal/command/flag/format.go
+++ b/internal/command/flag/format.go
@@ -1,0 +1,57 @@
+package flag
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	FormatCSV   = "csv"
+	FormatJSON  = "json"
+	FormatPlain = "plain"
+)
+
+const formatUsage = "one of: " + FormatCSV + ", " + FormatJSON + ", " + FormatPlain
+
+type Format struct {
+	Val string
+}
+
+func NewFormatFlag() *Format {
+	return &Format{Val: FormatPlain}
+}
+
+// Set parses the passed string and sets the SortFlagValue
+func (f *Format) Set(val string) error {
+	switch v := strings.ToLower(val); v {
+	case FormatPlain, FormatJSON, FormatCSV:
+		f.Val = v
+	default:
+		return errors.New("format must be " + formatUsage)
+	}
+
+	return nil
+}
+
+func (f *Format) String() string {
+	return f.Val
+}
+
+func (f *Format) Type() string {
+	return "FORMAT"
+}
+
+func (f *Format) Usage(highlightFn func(a ...any) string) string {
+	return fmt.Sprintf("output format\none of: %s, %s, %s",
+		highlightFn(FormatCSV), highlightFn(FormatJSON), highlightFn(FormatPlain),
+	)
+}
+
+func (f *Format) RegisterFlagCompletion(cmd *cobra.Command) error {
+	return cmd.RegisterFlagCompletionFunc("format", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{FormatCSV, FormatJSON, FormatPlain}, cobra.ShellCompDirectiveDefault
+	})
+}

--- a/internal/command/upgrade_configs_test.go
+++ b/internal/command/upgrade_configs_test.go
@@ -43,7 +43,7 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(t, os.Chdir(gitDir))
 
 	upgradeCmd := newUpgradeConfigsCmd()
-	upgradeCmd.Command.Run(&upgradeCmd.Command, nil)
+	upgradeCmd.Run(&upgradeCmd.Command, nil)
 
 	output := stdoutBuf.String()
 	t.Log(output)
@@ -56,9 +56,9 @@ func TestUpgrade(t *testing.T) {
 
 	stdoutBuf.Truncate(0)
 	statusCmd := newStatusCmd()
-	statusCmd.csv = true
+	statusCmd.format = &flag.Format{Val: flag.FormatCSV}
 	statusCmd.fields = &flag.Fields{Fields: []string{statusTaskIDParam}}
-	statusCmd.Command.Run(&statusCmd.Command, nil)
+	statusCmd.Run(&statusCmd.Command, nil)
 
 	taskIDs := strings.Split(strings.TrimSpace(stdoutBuf.String()), "\n")
 


### PR DESCRIPTION
status now supports to print the information in JSON format.
The format can be selected via the new parameter "--format", it accepts "plain",
"csv" and "json" as value.
In the JSON output fields that are not specified via "--fields" are omitted.
Fields that have no value, e.g. RunID when a task status is pending, is nil.

Because we want to distinguish between fields that should be omitted, fields
that undefined and empty values, we can not marshal a struct directly. It can
not distinguish between omitted fields and undefined fields.
To realize that the structs holding the output data is converted to a map and
then marshaled, fields that are omitted are not added to the map.

--format replaces the previous "--csv" parameters.
The "--csv" parameter for status is deprecated.

Example:
```
$ ./baur status --format json currency-service
[
  {
    "GitCommit": null,
    "Path": "go/code/currency",
    "RunID": null,
    "Status": "Pending",
    "TaskID": "currency-service.build"
  },
  {
    "GitCommit": null,
    "Path": "go/code/currency",
    "RunID": null,
    "Status": "Pending",
    "TaskID": "currency-service.check"
  },
  {
    "GitCommit": null,
    "Path": "go/code/currency",
    "RunID": null,
    "Status": "Pending",
    "TaskID": "currency-service.check_deploy"
  }
]
```

Closes #503 