### PR TITLE
ls apps: support json format

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -22,17 +22,6 @@ import (
 	"github.com/simplesurance/baur/v3/pkg/baur"
 )
 
-var testdataDir string
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(wd)
-	}
-
-	testdataDir = filepath.Join(wd, "testdata")
-}
-
 func runInitDb(t *testing.T) {
 	t.Helper()
 
@@ -48,7 +37,7 @@ func baurCSVLsApps(t *testing.T) [][]string {
 	stdoutBuf, _ := interceptCmdOutput(t)
 
 	lsAppsCmd := newLsAppsCmd()
-	lsAppsCmd.csv = true
+	lsAppsCmd.format.Val = flag.FormatCSV
 
 	lsAppsCmd.Command.Run(&lsAppsCmd.Command, nil)
 

--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/simplesurance/baur/v3/internal/format"
 	"github.com/simplesurance/baur/v3/internal/format/csv"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/vcs"
@@ -341,7 +340,7 @@ func getTaskRunByID(psql storage.Storer, id int) *storage.TaskRunWithID {
 
 func (c *diffInputsCmd) printOutput(diffs []*baur.InputDiff) {
 	if !c.quiet {
-		var formatter format.Formatter
+		var formatter Formatter
 
 		if c.csv {
 			formatter = csv.New(nil, stdout)

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/command/term"
 	"github.com/simplesurance/baur/v3/internal/format"
+	"github.com/simplesurance/baur/v3/internal/format/csv"
+	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/log"
 	"github.com/simplesurance/baur/v3/internal/prettyprint"
 	"github.com/simplesurance/baur/v3/internal/vcs"
@@ -289,4 +292,17 @@ func mustUntrackedFilesNotExist(requireCleanGitWorktree bool, vcsState vcs.State
 func untrackedFilesExistErrMsg(untrackedFiles []string) string {
 	return fmt.Sprintf("%s was specified, expecting only tracked unmodified files but found the following untracked or modified files:\n%s",
 		term.Highlight("--"+flagNameRequireCleanGitWorktree), term.Highlight(prettyprint.TruncatedStrSlice(untrackedFiles, 10)))
+}
+
+func mustNewFormatter(formatterName string, hdrs []string) format.Formatter {
+	switch formatterName {
+	case flag.FormatCSV:
+		return csv.New(hdrs, stdout)
+	case flag.FormatPlain:
+		return table.New(hdrs, stdout)
+	case flag.FormatJSON:
+		return nil
+	default:
+		panic(fmt.Sprintf("BUG: newFormatter: unsupported formatter name: %q", formatterName))
+	}
 }

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -306,3 +306,10 @@ func mustNewFormatter(formatterName string, hdrs []string) format.Formatter {
 		panic(fmt.Sprintf("BUG: newFormatter: unsupported formatter name: %q", formatterName))
 	}
 }
+
+func sliceAppendNilAsEmpty(sl []any, v *string) []any {
+	if v == nil {
+		return append(sl, "")
+	}
+	return append(sl, *v)
+}

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/command/term"
-	"github.com/simplesurance/baur/v3/internal/format"
 	"github.com/simplesurance/baur/v3/internal/format/csv"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/log"
@@ -20,6 +19,11 @@ import (
 	"github.com/simplesurance/baur/v3/pkg/storage"
 	"github.com/simplesurance/baur/v3/pkg/storage/postgres"
 )
+
+type Formatter interface {
+	WriteRow(Row ...any) error
+	Flush() error
+}
 
 var targetHelp = fmt.Sprintf(`%s is in the format %s
 Examples:
@@ -219,7 +223,7 @@ func mustArgToApps(repo *baur.Repository, args []string) []*baur.App {
 	return apps
 }
 
-func mustWriteRow(fmt format.Formatter, row ...any) {
+func mustWriteRow(fmt Formatter, row ...any) {
 	err := fmt.WriteRow(row...)
 	exitOnErr(err)
 }
@@ -294,7 +298,7 @@ func untrackedFilesExistErrMsg(untrackedFiles []string) string {
 		term.Highlight("--"+flagNameRequireCleanGitWorktree), term.Highlight(prettyprint.TruncatedStrSlice(untrackedFiles, 10)))
 }
 
-func mustNewFormatter(formatterName string, hdrs []string) format.Formatter {
+func mustNewFormatter(formatterName string, hdrs []string) Formatter {
 	switch formatterName {
 	case flag.FormatCSV:
 		return csv.New(hdrs, stdout)

--- a/internal/command/ls_apps_test.go
+++ b/internal/command/ls_apps_test.go
@@ -1,0 +1,34 @@
+package command
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/simplesurance/baur/v3/internal/command/flag"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLsAppsJSON(t *testing.T) {
+	initTest(t)
+
+	repoDir := filepath.Join(testdataDir, "multitasks")
+	err := os.Chdir(repoDir)
+	require.NoError(t, err)
+
+	lsAppsCmd := newLsAppsCmd()
+	lsAppsCmd.format = &flag.Format{Val: flag.FormatJSON}
+	stdoutBuf, _ := interceptCmdOutput(t)
+	require.NoError(t, lsAppsCmd.Execute())
+
+	var res []map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &res))
+	assert.Len(t, res, 4)
+	assert.Contains(t, res, map[string]any{
+		"AppName": "app3",
+		"Path":    "app3",
+	})
+}

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/baur/v3/internal/command/term"
-	"github.com/simplesurance/baur/v3/internal/format"
 	"github.com/simplesurance/baur/v3/internal/format/csv"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/pkg/baur"
@@ -103,7 +102,7 @@ func (c *lsInputsCmd) mustGetTaskInputs(taskSpec string) []baur.Input {
 }
 
 func (c *lsInputsCmd) mustPrintTaskInputs(inputs *baur.Inputs) {
-	var formatter format.Formatter
+	var formatter Formatter
 	var headers []string
 	writeHeaders := !c.quiet && !c.csv
 

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/baur/v3/internal/command/term"
-	"github.com/simplesurance/baur/v3/internal/format"
 	"github.com/simplesurance/baur/v3/internal/format/csv"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/log"
@@ -102,7 +101,7 @@ func (c *lsOutputsCmd) run(_ *cobra.Command, args []string) {
 	exitOnErr(err)
 }
 
-func getLsOutputsFormatter(isQuiet, isCsv bool) format.Formatter {
+func getLsOutputsFormatter(isQuiet, isCsv bool) Formatter {
 	var headers []string
 
 	if isCsv {

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/command/term"
-	"github.com/simplesurance/baur/v3/internal/format"
 	"github.com/simplesurance/baur/v3/internal/format/csv"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/pkg/storage"
@@ -139,7 +138,7 @@ func (c *lsRunsCmd) run(_ *cobra.Command, args []string) {
 	psql := mustNewCompatibleStorage(repo)
 	defer psql.Close()
 
-	var formatter format.Formatter
+	var formatter Formatter
 	if c.csv {
 		formatter = csv.New(nil, stdout)
 	} else {
@@ -180,7 +179,7 @@ func (c *lsRunsCmd) run(_ *cobra.Command, args []string) {
 	exitOnErr(formatter.Flush())
 }
 
-func printHeader(formatter format.Formatter) {
+func printHeader(formatter Formatter) {
 	mustWriteRow(
 		formatter,
 		"Id",
@@ -193,7 +192,7 @@ func printHeader(formatter format.Formatter) {
 	)
 }
 
-func (c *lsRunsCmd) printTaskRun(formatter format.Formatter, taskRun *storage.TaskRunWithID) {
+func (c *lsRunsCmd) printTaskRun(formatter Formatter, taskRun *storage.TaskRunWithID) {
 	if c.quiet {
 		mustWriteRow(formatter, taskRun.ID)
 	}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/baur/v3/internal/command/term"
-	"github.com/simplesurance/baur/v3/internal/format"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/fs"
 	"github.com/simplesurance/baur/v3/pkg/baur"
@@ -86,7 +85,7 @@ func copyAppendSlice(slice []any, elems ...any) []any {
 	return append(res, elems...)
 }
 
-func mustWriteStringSliceRows(fmt format.Formatter, header string, indentlvl int, sl []string) {
+func mustWriteStringSliceRows(fmt Formatter, header string, indentlvl int, sl []string) {
 	defRowArgs := make([]any, 0, indentlvl+1+1)
 
 	for i := 0; i < indentlvl; i++ {
@@ -179,7 +178,7 @@ func (c *showCmd) sortConfigFileSlice(in []string) []string {
 	return in
 }
 
-func (c *showCmd) printTask(formatter format.Formatter, task *baur.Task) {
+func (c *showCmd) printTask(formatter Formatter, task *baur.Task) {
 	mustWriteRow(formatter, term.Underline("Task"))
 	mustWriteRow(formatter, "", "Name:", term.Highlight(task.Name), "", "")
 	mustWriteRow(formatter, "", "Command:", term.Highlight(

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -335,6 +335,8 @@ func (r *statusRow) asMap(order []string) map[string]any {
 			m["RunID"] = r.RunID
 		case statusGitCommitParam:
 			m["GitCommit"] = r.GitCommit
+		default:
+			panic(fmt.Sprintf("BUG: asMap: got unsupported field name %q in order list", f))
 		}
 	}
 
@@ -357,6 +359,8 @@ func (r *statusRow) asOrderedSlice(order []string) []any {
 			result = sliceAppendNilAsEmpty(result, r.RunID)
 		case statusGitCommitParam:
 			result = sliceAppendNilAsEmpty(result, r.GitCommit)
+		default:
+			panic(fmt.Sprintf("BUG: asOrderedSlice: got unsupported field name %q in order list", f))
 		}
 	}
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/command/term"
-	"github.com/simplesurance/baur/v3/internal/format"
-	"github.com/simplesurance/baur/v3/internal/format/csv"
-	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/log"
 	"github.com/simplesurance/baur/v3/pkg/baur"
 	"github.com/simplesurance/baur/v3/pkg/storage"
@@ -154,7 +151,6 @@ func (c *statusCmd) statusCreateHeader() []string {
 
 func (c *statusCmd) run(_ *cobra.Command, args []string) {
 	var headers []string
-	var formatter format.Formatter
 	var storageClt storage.Storer
 
 	repo := mustFindRepository()
@@ -184,12 +180,7 @@ func (c *statusCmd) run(_ *cobra.Command, args []string) {
 		headers = c.statusCreateHeader()
 	}
 
-	switch c.format.Val {
-	case flag.FormatCSV:
-		formatter = csv.New(headers, stdout)
-	case flag.FormatPlain:
-		formatter = table.New(headers, stdout)
-	}
+	formatter := mustNewFormatter(c.format.Val, headers)
 
 	showProgress := len(tasks) >= 5 && !c.quiet && c.format.Val == flag.FormatPlain
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -362,10 +362,3 @@ func (r *statusRow) asOrderedSlice(order []string) []any {
 
 	return result
 }
-
-func sliceAppendNilAsEmpty(sl []any, v *string) []any {
-	if v == nil {
-		return append(sl, "")
-	}
-	return append(sl, *v)
-}

--- a/internal/command/util_test.go
+++ b/internal/command/util_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/simplesurance/baur/v3/internal/command/term"
@@ -11,6 +13,17 @@ import (
 	"github.com/simplesurance/baur/v3/internal/log"
 	"github.com/simplesurance/baur/v3/internal/testutils/logwriter"
 )
+
+var testdataDir string
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(wd)
+	}
+
+	testdataDir = filepath.Join(wd, "testdata")
+}
 
 // interceptCmdOutput changes the stdout and stderr streams to that the
 // commands write to the returned buffers, all output is additionally still

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,8 +1,0 @@
-// Package format outputs data in formatted table structures
-package format
-
-// Formatter is an interface for formatters
-type Formatter interface {
-	WriteRow(Row ...any) error
-	Flush() error
-}

--- a/internal/format/json/json.go
+++ b/internal/format/json/json.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Mapper interface {
+	// AsMap creates a map of an object that contains the fields fields.
+	AsMap(fields []string) map[string]any
+}
+
+// Encode encodes T as JSON and writes it to w.
+func Encode[T ~[]E, E Mapper](w io.Writer, rows T, order []string) error {
+	res := make([]map[string]any, 0, len(rows))
+
+	for _, r := range rows {
+		res = append(res, r.AsMap(order))
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(res)
+}


### PR DESCRIPTION
Similar to the implementation for "baur status", add support for JSON format to
"baur ls apps".

The --csv parameter is deprecated.

Closes #504 