### PR TITLE
formatter: align json implementation

### DIFF
--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/command/term"
 	"github.com/simplesurance/baur/v3/internal/format/csv"
+	"github.com/simplesurance/baur/v3/internal/format/json"
 	"github.com/simplesurance/baur/v3/internal/format/table"
 	"github.com/simplesurance/baur/v3/internal/log"
 	"github.com/simplesurance/baur/v3/internal/prettyprint"
@@ -305,15 +306,8 @@ func mustNewFormatter(formatterName string, hdrs []string) Formatter {
 	case flag.FormatPlain:
 		return table.New(hdrs, stdout)
 	case flag.FormatJSON:
-		return nil
+		return json.New(hdrs, stdout)
 	default:
 		panic(fmt.Sprintf("BUG: newFormatter: unsupported formatter name: %q", formatterName))
 	}
-}
-
-func sliceAppendNilAsEmpty(sl []any, v *string) []any {
-	if v == nil {
-		return append(sl, "")
-	}
-	return append(sl, *v)
 }

--- a/internal/command/ls_apps_test.go
+++ b/internal/command/ls_apps_test.go
@@ -28,7 +28,7 @@ func TestLsAppsJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &res))
 	assert.Len(t, res, 4)
 	assert.Contains(t, res, map[string]any{
-		"AppName": "app3",
-		"Path":    "app3",
+		"Name": "app3",
+		"Path": "app3",
 	})
 }

--- a/internal/format/csv/csv.go
+++ b/internal/format/csv/csv.go
@@ -36,6 +36,11 @@ func (f *Formatter) WriteRow(row ...any) error {
 	str := make([]string, 0, len(row))
 
 	for _, col := range row {
+		if col == nil {
+			str = append(str, "")
+			continue
+		}
+
 		str = append(str, fmt.Sprintf("%v", col))
 	}
 

--- a/internal/format/json/json.go
+++ b/internal/format/json/json.go
@@ -2,24 +2,51 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
-type Mapper interface {
-	// AsMap creates a map of an object that contains the fields fields.
-	AsMap(fields []string) map[string]any
+type Formatter struct {
+	fieldNames []string
+	data       []map[string]any
+	w          io.Writer
 }
 
-// Encode encodes T as JSON and writes it to w.
-func Encode[T ~[]E, E Mapper](w io.Writer, rows T, order []string) error {
-	res := make([]map[string]any, 0, len(rows))
+func New(fieldNames []string, w io.Writer) *Formatter {
+	return &Formatter{
+		fieldNames: fieldNames,
+		w:          w,
+	}
+}
 
-	for _, r := range rows {
-		res = append(res, r.AsMap(order))
+// WriteRow adds a new entry to the internal map.
+// Vals must be in the same order then the fieldNames that were passed when
+// NewFormatter was called.
+func (f *Formatter) WriteRow(vals ...any) error {
+	if len(vals) != len(f.fieldNames) {
+		return fmt.Errorf("got %d values, having %d headers, expecting the same amount", len(vals), len(f.fieldNames))
 	}
 
-	enc := json.NewEncoder(w)
+	entry := make(map[string]any, len(vals))
+	for i, v := range vals {
+		entry[f.fieldNames[i]] = v
+	}
+
+	f.data = append(f.data, entry)
+
+	return nil
+}
+
+// Flush writes the JSON encoding to the io.Writer.
+// On success the internal map is cleared.
+func (f *Formatter) Flush() error {
+	enc := json.NewEncoder(f.w)
 	enc.SetIndent("", "  ")
 
-	return enc.Encode(res)
+	if err := enc.Encode(f.data); err != nil {
+		return err
+	}
+
+	clear(f.data)
+	return nil
 }

--- a/internal/format/table/table.go
+++ b/internal/format/table/table.go
@@ -42,7 +42,9 @@ func (f *Formatter) WriteRow(row ...any) error {
 	var rowStr string
 
 	for i, col := range row {
-		rowStr += fmt.Sprintf("%v", col)
+		if col != nil {
+			rowStr += fmt.Sprintf("%v", col)
+		}
 
 		if i+1 < len(row) {
 			rowStr += "\t"


### PR DESCRIPTION
```
formatter: change table and csv implementation to replace nil with ""

Change the table and csv formatters to represent nil as an empty string.
This will allow to pass a nil value to all WriteRow implementations.
The JSON formatter outputs nil values, the others don't.

-------------------------------------------------------------------------------
formatter: align json implementation

Provide a JSON formatter that implements the same Formatter interface as the
other implentations.
The JSON formatter, accepts during intialization a list of field names.
When WriteRows() is called, it accepts the value to be in the field names
order. For every row it creates a Field-Name:Value map and appends it to an
internal slice.
The slice is marshalled and written to an io.Writer when Flush() is called.

This allows to converge the code for using the JSON formatter with the other
output formats.

The "AppName" field in the JSON output of "ls apps" is also changed to "Name".
```