### PR TITLE
ls outputs: support json format

### DIFF
--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -106,12 +106,10 @@ func (c *lsAppsCmd) createHeader() []string {
 }
 
 func (c *lsAppsCmd) run(_ *cobra.Command, args []string) {
-
 	repo := mustFindRepository()
 	apps := mustArgToApps(repo, args)
 
 	headers := c.createHeader()
-
 	formatter := mustNewFormatter(c.format.Val, headers)
 
 	baur.SortAppsByName(apps)


### PR DESCRIPTION
Similar to the implementations for "ls apps" and "status", "ls outputs" now
supports JSON format.
The --csv flag is deprecated.

Closes #506 