### PR TITLE
inputs: track executable permission of file owner on unix

### DIFF
--- a/internal/fs/fs_nonunix.go
+++ b/internal/fs/fs_nonunix.go
@@ -1,0 +1,18 @@
+//go:build !unix
+
+package fs
+
+import (
+	"errors"
+	"io/fs"
+)
+
+// FileHasOwnerExecPerm always returns false, errors.ErrUnsupported.
+func FileHasOwnerExecPerm(p string) (bool, error) {
+	return false, errors.ErrUnsupported
+}
+
+// OwnerHasExecPerm always returns false.
+func OwnerHasExecPerm(m fs.FileMode) bool {
+	return false
+}

--- a/internal/fs/fs_unix.go
+++ b/internal/fs/fs_unix.go
@@ -1,0 +1,24 @@
+//go:build unix
+
+package fs
+
+import (
+	"io/fs"
+	"os"
+)
+
+// FileHasOwnerExecPerm returns true if the executable mode bit for the file
+// owner is set.
+func FileHasOwnerExecPerm(p string) (bool, error) {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return false, err
+	}
+
+	return OwnerHasExecPerm(fi.Mode()), nil
+}
+
+// OwnerHasExecPerm returns true if the executable mode bit in m is set.
+func OwnerHasExecPerm(m fs.FileMode) bool {
+	return m&0100 == 0100
+}

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -208,7 +208,7 @@ func (r *Repo) WriteAdditionalFileContents(t *testing.T, appName, fileName, cont
 	t.Helper()
 
 	absPath := filepath.Join(r.Dir, appName, fileName)
-	file := baur.NewInputFile(absPath, filepath.Join(appName, fileName), baur.WithHashFn(sha384.File))
+	file := baur.NewInputFile(absPath, filepath.Join(appName, fileName), false, baur.WithHashFn(sha384.File))
 	fstest.WriteToFile(t, []byte(contents), absPath)
 
 	digest, err := file.CalcDigest()

--- a/pkg/baur/inputfile.go
+++ b/pkg/baur/inputfile.go
@@ -82,14 +82,14 @@ func (f *InputFile) CalcDigest() (*digest.Digest, error) {
 
 	h := sha384.New()
 
-	if err := h.AddBytes([]byte("Path:")); err != nil {
+	if err := h.AddBytes([]byte("P:")); err != nil {
 		return nil, err
 	}
 	if err := h.AddBytes([]byte(f.repoRelPath)); err != nil {
 		return nil, err
 	}
 
-	if err := h.AddBytes([]byte("SymlinkTarget:")); err != nil {
+	if err := h.AddBytes([]byte("ST:")); err != nil {
 		return nil, err
 	}
 
@@ -117,7 +117,7 @@ func (f *InputFile) CalcDigest() (*digest.Digest, error) {
 		}
 	}
 
-	if err := h.AddBytes([]byte("Content:")); err != nil {
+	if err := h.AddBytes([]byte("C:")); err != nil {
 		return nil, err
 	}
 	if err := h.AddBytes(f.contentDigest.Sum); err != nil {

--- a/pkg/baur/inputfile_test.go
+++ b/pkg/baur/inputfile_test.go
@@ -26,8 +26,8 @@ func TestDigestDoesNotDependOnRepoPath(t *testing.T) {
 	fstest.WriteToFile(t, []byte("hello"), absFilepath1)
 	fstest.WriteToFile(t, []byte("hello"), absFilepath2)
 
-	f1 := NewInputFile(absFilepath1, relFilepath1, WithHashFn(sha384.File))
-	f2 := NewInputFile(absFilepath2, relFilepath2, WithHashFn(sha384.File))
+	f1 := NewInputFile(absFilepath1, relFilepath1, false, WithHashFn(sha384.File))
+	f2 := NewInputFile(absFilepath2, relFilepath2, false, WithHashFn(sha384.File))
 
 	d1, err := f1.Digest()
 	require.NoError(t, err)

--- a/pkg/baur/inputresolver_test.go
+++ b/pkg/baur/inputresolver_test.go
@@ -916,17 +916,6 @@ func TestSymlinkTargetFileContentChanges(t *testing.T) {
 	}
 }
 
-func TestSymlinkTargetFilePermissionsChange(t *testing.T) {
-	t.Skip("fails because of bug: https://github.com/simplesurance/baur/issues/492")
-	log.RedirectToTestingLog(t)
-
-	info := prepareSymlinkTestDir(t, false, false)
-	require.NoError(t, os.Chmod(info.SymlinkTargetFilePath, 0777))
-
-	digestAfter := resolveInputs(t, info.Task)
-	require.NotEqual(t, info.TotalInputDigest.String(), digestAfter.String())
-}
-
 func TestHashGitUntrackedFilesDisabled(t *testing.T) {
 	const fname = "hello"
 

--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -26,7 +26,7 @@ func TestSymlinkTargetFilePermissionsChange(t *testing.T) {
 				if tc.AddToGitAfterChange {
 					gittest.CommitFilesToGit(t, info.TempDir)
 				}
-				digestAfter := resolveInputs(t, info.Task)
+				_, digestAfter := resolveInputs(t, info.Task)
 				require.NotEqual(t, info.TotalInputDigest.String(), digestAfter.String())
 			})
 	}

--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+package baur
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/simplesurance/baur/v3/internal/exec"
+	"github.com/simplesurance/baur/v3/internal/log"
+	"github.com/simplesurance/baur/v3/internal/testutils/gittest"
+)
+
+func TestSymlinkTargetFilePermissionsChange(t *testing.T) {
+	for _, tc := range newGitFileTcVariations() {
+		t.Run(fmt.Sprintf("gitrepo:%+v,commitbeforechange:%v,commitafterchange:%v",
+			tc.CreateGitRepo, tc.AddToGitBeforeChange, tc.AddToGitAfterChange),
+			func(t *testing.T) {
+				exec.DefaultLogFn = t.Logf
+				log.RedirectToTestingLog(t)
+				info := prepareSymlinkTestDir(t, tc.CreateGitRepo, tc.AddToGitBeforeChange)
+				require.NoError(t, os.Chmod(info.SymlinkTargetFilePath, 0755))
+				if tc.AddToGitAfterChange {
+					gittest.CommitFilesToGit(t, info.TempDir)
+				}
+				digestAfter := resolveInputs(t, info.Task)
+				require.NotEqual(t, info.TotalInputDigest.String(), digestAfter.String())
+			})
+	}
+}


### PR DESCRIPTION
On Unix systems baur now tracks the executable owner bit of files.
This enables that tasks are rerun if the executable owner bit changes.

The normal use case is to clone a git repository in CI and then run
baur.
Git only tracks the executable owner bit, other permission changes are not
stored and applied. Therefore baur also only tracks the same information.

If the file is a tracked, unmodified git object the permission mode is taken
from git otherwise stat/lstat are called to obtain them after input file
discovery.

On non Unix systems the information if a file is executable is not tracked. It's
not easily obtainable via the Golang stdlib.
