### PR TITLE
inputresolver: fix: git objects for files in symlinked directory not found

### DIFF
--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -110,8 +110,8 @@ date +%s >> "$runtime_logfile"
 	}
 
 	for i := 1; i < len(taskruntimes); i++ {
-		require.GreaterOrEqual(t, taskruntimes[0].startTime, taskruntimes[i].startTime)
-		require.LessOrEqual(t, taskruntimes[0].endTime, taskruntimes[i].endTime)
+		require.GreaterOrEqual(t, taskruntimes[0].startTime+1, taskruntimes[i].startTime)
+		require.LessOrEqual(t, taskruntimes[0].endTime-1, taskruntimes[i].endTime)
 		t.Logf("task %d run in parallel with task 0: starttime %d >= %d, endtime %d <= %d",
 			i,
 			taskruntimes[i].startTime, taskruntimes[0].startTime, taskruntimes[i].endTime, taskruntimes[0].endTime,

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -134,9 +134,9 @@ func (c *Cmd) startOutputStreamLogging(name string, useColorStderrColorfn bool) 
 
 		for sc.Scan() {
 			if useColorStderrColorfn && c.logFnStderrStreamColorfn != nil {
-				c.logf(c.logFnStderrStreamColorfn(sc.Text()) + "\n")
+				c.logf("%s\n", c.logFnStderrStreamColorfn(sc.Text()))
 			} else {
-				c.logf(sc.Text() + "\n")
+				c.logf("%s\n", sc.Text())
 			}
 		}
 

--- a/internal/fs/fileglob.go
+++ b/internal/fs/fileglob.go
@@ -33,13 +33,6 @@ func FileGlob(pattern string) ([]string, error) {
 		return nil, err
 	}
 
-	for _, path := range globRes {
-		_, err = os.Stat(path)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return globRes, err
 }
 

--- a/internal/testutils/fstest/fstest.go
+++ b/internal/testutils/fstest/fstest.go
@@ -15,12 +15,27 @@ func WriteToFile(t *testing.T, data []byte, path string) {
 
 	dir := filepath.Dir(path)
 
-	err := os.MkdirAll(dir, 0775)
+	MkdirAll(t, dir)
+
+	err := os.WriteFile(path, data, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
+}
 
-	err = os.WriteFile(path, data, 0644)
+func MkdirAll(t *testing.T, path string) {
+	t.Helper()
+
+	err := os.MkdirAll(path, 0775)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Symlink(t *testing.T, oldname, newname string) {
+	t.Helper()
+
+	err := os.Symlink(oldname, newname)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vcs/git/files.go
+++ b/internal/vcs/git/files.go
@@ -43,9 +43,20 @@ const (
 type Mode uint32
 
 const (
-	ObjectTypeSymlink Mode = 0120000
-	ObjectTypeFile    Mode = 0100000
+	ObjectTypeSymlink    Mode = 0o120000
+	ObjectTypeFile       Mode = 0o100000
+	ObjectTypeExectuable Mode = 0o100755
 )
+
+// IsRegularFile returns true if m is ObjectTypeFile or ObjectTypeExectuable.
+func (m Mode) IsRegularFile() bool {
+	return (m & (ObjectTypeSymlink ^ ObjectTypeFile)) == 0
+}
+
+// IsSymlink returns true if m is ObjectTypeSymlink.
+func (m Mode) IsSymlink() bool {
+	return (m & ObjectTypeSymlink) == ObjectTypeSymlink
+}
 
 type Object struct {
 	Status byte

--- a/internal/vcs/git/files_test.go
+++ b/internal/vcs/git/files_test.go
@@ -1,0 +1,19 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRegularFile(t *testing.T) {
+	assert.False(t, ObjectTypeSymlink.IsRegularFile())
+	assert.True(t, ObjectTypeExectuable.IsRegularFile())
+	assert.True(t, ObjectTypeFile.IsRegularFile())
+}
+
+func TestIsSymlink(t *testing.T) {
+	assert.True(t, ObjectTypeSymlink.IsSymlink())
+	assert.False(t, ObjectTypeExectuable.IsSymlink())
+	assert.False(t, ObjectTypeFile.IsSymlink())
+}

--- a/pkg/baur/inputfile.go
+++ b/pkg/baur/inputfile.go
@@ -11,10 +11,10 @@ type InputFileOpt func(*InputFile)
 
 // InputFile represent a file.
 type InputFile struct {
-	absPath                  string
-	repoRelPath              string
-	repoRelSymlinkTargetPath string
-	ownerHasExecutablePerm   bool
+	absPath                string
+	repoRelPath            string
+	repoRelRealPath        string
+	ownerHasExecutablePerm bool
 
 	fileHasher FileHashFn
 	digest     *digest.Digest
@@ -34,9 +34,12 @@ func WithContentDigest(d *digest.Digest) InputFileOpt {
 	}
 }
 
-func WithSymlinkTargetPath(repoRelTargetPath string) InputFileOpt {
+// WithRealpath specifies the real path for the file.
+// If one or more components of its repository relative path are symlinks (the
+// file or path components), this is the repository relative path with all components resolved.
+func WithRealpath(repoRelRealPath string) InputFileOpt {
 	return func(i *InputFile) {
-		i.repoRelSymlinkTargetPath = repoRelTargetPath
+		i.repoRelRealPath = repoRelRealPath
 	}
 }
 
@@ -89,12 +92,12 @@ func (f *InputFile) CalcDigest() (*digest.Digest, error) {
 		return nil, err
 	}
 
-	if err := h.AddBytes([]byte("ST:")); err != nil {
+	if err := h.AddBytes([]byte("R:")); err != nil {
 		return nil, err
 	}
 
-	if f.repoRelSymlinkTargetPath != "" {
-		if err := h.AddBytes([]byte(f.repoRelSymlinkTargetPath)); err != nil {
+	if f.repoRelRealPath != "" {
+		if err := h.AddBytes([]byte(f.repoRelRealPath)); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/baur/inputresolver.go
+++ b/pkg/baur/inputresolver.go
@@ -308,14 +308,14 @@ func (i *InputResolver) newInputFile(absPath, relPath string) (*InputFile, error
 	if lfi.Mode()&os.ModeSymlink == os.ModeSymlink {
 		relTargetPath, err := fs.RealPathRel(i.repoDir, absPath)
 		if err != nil {
-			return nil, fmt.Errorf("%q: %w", absPath, err)
+			return nil, fmt.Errorf("%s: %w", relPath, err)
 		}
 
 		executable, err := fs.FileHasOwnerExecPerm(absPath)
 		// FileHasOwnerExecPerm is only implemented on Unix, on other
 		// platforms it returns ErrUnsupported.
 		if err != nil && err != errors.ErrUnsupported { //nolint: errorlint // errors.Is() not needed here and more expensive
-			return nil, fmt.Errorf("%q: determining if owner has exec permissions failed %w", absPath, err)
+			return nil, fmt.Errorf("%s: determining if owner has exec permissions failed %w", absPath, err)
 		}
 
 		return NewInputFile(absPath, relPath,
@@ -345,7 +345,7 @@ func (i *InputResolver) newInputFileWithTrackedOjb(ctx context.Context, absPath,
 
 		relTargetPath, err := filepath.Rel(i.repoDir, targetPath)
 		if err != nil {
-			return nil, fmt.Errorf("%q: %w", absPath, err)
+			return nil, fmt.Errorf("%s: %w", absPath, err)
 		}
 
 		targetObj, err := i.gitTrackedDb.Get(ctx, targetPath)
@@ -364,7 +364,7 @@ func (i *InputResolver) newInputFileWithTrackedOjb(ctx context.Context, absPath,
 		), nil
 	}
 
-	return nil, fmt.Errorf("internal error: got unsupport git.TrackedObject (%q) mode: %o", absPath, obj.Mode)
+	return nil, fmt.Errorf("%s: got unsupport git.TrackedObject mode: %o", relPath, obj.Mode)
 }
 
 func (i *InputResolver) setEnvVars() {

--- a/pkg/baur/inputresolver_test.go
+++ b/pkg/baur/inputresolver_test.go
@@ -830,7 +830,7 @@ func prepareSymlinkTestDir(t *testing.T, createGitRepo, commitFilesToGit bool) *
 	symlink := filepath.Join(tempDir, symlinkRel)
 
 	fstest.WriteToFile(t, []byte("hello"), f)
-	require.NoError(t, os.Symlink(f, symlink))
+	fstest.Symlink(t, f, symlink)
 
 	if commitFilesToGit {
 		gittest.CommitFilesToGit(t, tempDir)
@@ -897,7 +897,7 @@ func TestSymlinkTargetPathChangesFileIsSame(t *testing.T) {
 
 	require.NoError(t, os.Rename(info.SymlinkTargetFilePath, newTargetFilePath))
 	require.NoError(t, os.Remove(info.SymlinkPath))
-	require.NoError(t, os.Symlink(newTargetFilePath, info.SymlinkPath))
+	fstest.Symlink(t, newTargetFilePath, info.SymlinkPath)
 
 	_, digestAfter := resolveInputs(t, info.Task)
 	require.NotEqual(t, info.TotalInputDigest.String(), digestAfter.String())

--- a/pkg/baur/inputresolver_unix_test.go
+++ b/pkg/baur/inputresolver_unix_test.go
@@ -26,7 +26,7 @@ func TestSymlinkTargetFilePermissionsChange(t *testing.T) {
 				if tc.AddToGitAfterChange {
 					gittest.CommitFilesToGit(t, info.TempDir)
 				}
-				_, digestAfter := resolveInputs(t, info.Task)
+				_, digestAfter := resolveInputs(t, info.Task, !tc.AddToGitAfterChange)
 				require.NotEqual(t, info.TotalInputDigest.String(), digestAfter.String())
 			})
 	}


### PR DESCRIPTION
```
inputresolver: extend tests to if git object is not found for file

If files are added to git in a testcase configured the InputResolver to not hash
untracked files, this ensures that tests fail if a git object should be found
for a path but isn't.

-------------------------------------------------------------------------------
inputresolver: fix: git objects for files in symlinked directory not found

Since "inputfiles: track symlink target paths" (e834583c), git objects for files
in a symlinked directory were not found anymore.

It was caused by multiple issues:
- it was only checked if the last component of the path was a symlinked, if
  another component was, it was missing to resolve the realpath and try another
  lookup in the gitTrackedDb
- When the gitTrackedDb was queried and the path not found, it was never checked
  if an entry for the Symlink target path existed because of an erroneous
  obj.Mode check, this is fixed

The Input.repoRelSymlinkTargetPath field and related methods and fields are
renamed to Input.repoRelRealPath, this naming also covers cases where any part
of a path component is a symlink.

Testcases to cover the functionality are added.

-------------------------------------------------------------------------------
fs: remove unnecessary os.Stat() call in FileGlob

It's not clear to me why we call os.Stat() for each glob result and check if an
error happened. I assume it's to check for broken symlinks.
This is now also done by the inputresolver.

-------------------------------------------------------------------------------
gi: add Mode.IsFile(), Mode.IsSymlink() methods

Add helper methods and tests to check if a git object is file or symlink.
The octal literal prefixes for the Object consts are also changed to "0o", "0"
has the same meaning in Golang but "0o" is common in other programming
languages.

-------------------------------------------------------------------------------
inputresolver: use unquoted relPath as error prefix instead of quoted abspath

-------------------------------------------------------------------------------
tests: use fstest.Symlink

-------------------------------------------------------------------------------
testutils: add MkdirAll and Symlink helper functions

```