### PR TITLE
status + ls outputs: improve JSON field types

### DIFF
--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -291,7 +291,11 @@ func (c *statusCmd) assembleRow(repositoryDir string, task *baur.Task, taskRun *
 
 		case statusRunIDParam:
 			if buildStatus == baur.TaskStatusRunExist {
-				row = append(row, taskRun.ID)
+				// convert Id to string to not be represented
+				// as integer in the JSON format, ID is an
+				// opaque identifier that could also container
+				// other chars then numbers
+				row = append(row, fmt.Sprint(taskRun.ID))
 			} else {
 				row = append(row, nil)
 			}


### PR DESCRIPTION
ls outputs: change bytes and duration JSON types to numerical ones

Instead of using string as types for duration (seconds) and Bytes, use a float
for the duration and an uint64 for bytes.

-------------------------------------------------------------------------------
status: change RunID JSON type from int to string

It is an opaque type that should also support non numerical characters, change
the RunID type in JSON format to string.

-------------------------------------------------------------------------------