### PR TITLE
run: fix: panic on some exec errors

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -324,12 +324,12 @@ func (c *runCmd) runTask(task *baur.Task) (*baur.RunResult, error) {
 		return nil, err
 	}
 
-	stderr.Printf("%s: executing %q %s: %s\n",
+	stderr.Printf("%s: executing command %s: %s\n",
 		term.Highlight(task),
-		term.Highlight(result.Command),
 		statusStrFailed,
 		err,
 	)
+
 	return nil, err
 }
 


### PR DESCRIPTION
When executing a task command failed and the error isn't an ExitCodeError, ErrTaskRunSkipped and neither a ErrUntrackedGitFilesExist error a nil pointer dereference panic happened.

In the stderr.Printf() call a nil result pointer was accessed. Do not access result if err is != nil, it is always nil in this case.