### PR TITLE
storage: drop duplicate indices

### DIFF
--- a/pkg/storage/postgres/migrations/3.sql
+++ b/pkg/storage/postgres/migrations/3.sql
@@ -10,3 +10,7 @@ CREATE TABLE task_run_task_input (
 	input_task_id integer NOT NULL REFERENCES input_task(id) ON DELETE CASCADE,
 	CONSTRAINT task_run_task_input_task_run_id_input_task_id_uniq UNIQUE (task_run_id, input_task_id)
 );
+
+DROP INDEX task_run_file_input_task_run_id_idx;
+DROP INDEX idx_task_run_string_input;
+DROP INDEX idx_task_run_output_task_run_id;


### PR DESCRIPTION
Delete the task_run_file_input_task_run_id_idx, idx_task_run_string_input, idx_task_run_output_task_run_id database indices.

The fields that they index are already covered by unique indices.

Closes #551 