### PR TITLE
postgres: log redacted postgresql connect debug message

### DIFF
--- a/pkg/storage/postgres/client.go
+++ b/pkg/storage/postgres/client.go
@@ -3,6 +3,7 @@ package postgres
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -20,6 +21,14 @@ type Logger interface {
 	Debugln(v ...any)
 }
 
+func redactedURL(strURL string) (string, error) {
+	url, err := url.Parse(strURL)
+	if err != nil {
+		return "", err
+	}
+	return url.Redacted(), nil
+}
+
 // New returns a new postgres client.
 // If logger is nil, logging is disabled.
 func New(ctx context.Context, url string, logger Logger) (*Client, error) {
@@ -31,6 +40,11 @@ func New(ctx context.Context, url string, logger Logger) (*Client, error) {
 	if logger != nil {
 		cfg.ConnConfig.Logger = &pgxLogger{logger: logger}
 		cfg.ConnConfig.LogLevel = pgx.LogLevelInfo
+
+		if rURL, err := redactedURL(url); err == nil {
+			logger.Debugln("postgres: establishing connection to", rURL)
+		}
+
 	}
 
 	con, err := pgxpool.ConnectConfig(ctx, cfg)


### PR DESCRIPTION
Before connecting to the postgresql server, log that the connection is established with the redacted postgresql url as debug message.