### PR TITLE
storage: fix: too much memory preallocated for query args

### DIFF
--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -332,7 +332,7 @@ func insertTaskRunInputStringsIfNotExist(ctx context.Context, db dbConn, taskRun
 		}
 	}
 
-	queryArgs := make([]any, 1, (len(inputStringIDs)*2)+1)
+	queryArgs := make([]any, 1, len(inputStringIDs)+1)
 	queryArgs[0] = taskRunID
 
 	for _, inputID := range inputStringIDs {


### PR DESCRIPTION
insertTaskRunInputStringsIfNotExist() preallocates ~2x the memory for the inputStringIDs args than needed.
Change it to only preallocate as much memory as needed.