### PR TITLE
upgrade db: support to pass postgresql URI as argument

### DIFF
--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -26,7 +26,7 @@ by setting the '%s' environment variable.`,
 	term.Highlight(envVarPSQLURL))
 
 var initDbCmd = &cobra.Command{
-	Use:               "db [POSTGRES_URL]",
+	Use:               "db [POSTGRES-URL]",
 	Short:             "create baur tables in a PostgreSQL database",
 	Example:           strings.TrimSpace(initDbExample),
 	Long:              strings.TrimSpace(initDbLongHelp),

--- a/internal/command/upgrade_db.go
+++ b/internal/command/upgrade_db.go
@@ -37,7 +37,7 @@ type upgradeDbCmd struct {
 func newUpgradeDatabaseCmd() *upgradeDbCmd {
 	cmd := upgradeDbCmd{
 		Command: cobra.Command{
-			Use:               "db [POSTGRES_URL]",
+			Use:               "db [POSTGRES-URL]",
 			Short:             "upgrade the database schema",
 			Long:              strings.TrimSpace(upgradeDbLongHelp),
 			Args:              cobra.MaximumNArgs(1),


### PR DESCRIPTION
Support to pass the POSTGRESQL URL to that baur connects for the "upgrade db"
operation as argument.
This aligns it with the usage of "baur init db".
Passing the URL is useful when the baur repository configs only contains the
credential for a read only user.