### PR TITLE
add "release create" command

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -148,8 +148,6 @@ func (c *diffInputsCmd) run(_ *cobra.Command, args []string) {
 	if len(diffs) > 0 {
 		exitFunc(2)
 	}
-
-	exitFunc(0)
 }
 
 func (c *diffInputsCmd) getDiffInputArgDetails(repo *baur.Repository, args []string) []*diffInputArgDetails {

--- a/internal/command/exitcodes.go
+++ b/internal/command/exitcodes.go
@@ -1,0 +1,6 @@
+package command
+
+const (
+	exitCodeAlreadyExist     = 2
+	exitCodeTaskRunIsPending = 3
+)

--- a/internal/command/exitcodes.go
+++ b/internal/command/exitcodes.go
@@ -1,6 +1,8 @@
 package command
 
 const (
+	exitCodeSuccess          = 0
+	exitCodeError            = 1
 	exitCodeAlreadyExist     = 2
 	exitCodeTaskRunIsPending = 3
 )

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -87,7 +87,7 @@ func mustArgToTask(repo *baur.Repository, gitRepo *git.Repository, arg string) *
 	tasks := mustArgToTasks(repo, gitRepo, []string{arg})
 	if len(tasks) > 1 {
 		stderr.Printf("argument %q matches multiple tasks, must match only 1 task\n", arg)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	// mustArgToApps ensures that >=1 apps are returned
@@ -98,7 +98,7 @@ func mustArgToApp(repo *baur.Repository, arg string) *baur.App {
 	apps := mustArgToApps(repo, []string{arg})
 	if len(apps) > 1 {
 		stderr.Printf("argument %q matches multiple apps, must match only 1 app\n", arg)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	// mustArgToApps ensures that >=1 apps are returned
@@ -137,7 +137,7 @@ func mustGetPSQLURI(cfg *cfg.Repository) string {
 		stderr.Printf("PostgreSQL connection information is missing.\n"+
 			"- set postgres_url in your repository config or\n"+
 			"- set the $%s environment variable", envVarPSQLURL)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	return uri
@@ -246,17 +246,17 @@ func exitOnErrf(err error, format string, v ...any) {
 	}
 
 	stderr.ErrPrintf(err, format, v...)
-	exitFunc(1)
+	exitFunc(exitCodeError)
 }
 
 func fatal(msg ...any) {
 	stderr.PrintErrln(msg...)
-	exitFunc(1)
+	exitFunc(exitCodeError)
 }
 
 func fatalf(format string, v ...any) {
 	stderr.Printf(format, v...)
-	exitFunc(1)
+	exitFunc(exitCodeError)
 }
 
 func exitOnErr(err error, msg ...any) {
@@ -265,7 +265,7 @@ func exitOnErr(err error, msg ...any) {
 	}
 
 	stderr.ErrPrintln(err, msg...)
-	exitFunc(1)
+	exitFunc(exitCodeError)
 }
 
 func mustTaskRepoRelPath(repositoryDir string, task *baur.Task) string {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -255,7 +255,7 @@ func fatal(msg ...any) {
 }
 
 func fatalf(format string, v ...any) {
-	stderr.Printf(format, v...)
+	stderr.PrintErrf(format, v...)
 	exitFunc(exitCodeError)
 }
 

--- a/internal/command/init_app.go
+++ b/internal/command/init_app.go
@@ -51,11 +51,11 @@ func initApp(_ *cobra.Command, args []string) {
 	if err != nil {
 		if os.IsExist(err) {
 			stderr.Printf("%s already exist\n", baur.AppCfgFile)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 
 		stderr.Println(err)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	stdout.Printf("Application configuration file was written to %s\n",

--- a/internal/command/init_db.go
+++ b/internal/command/init_db.go
@@ -51,11 +51,11 @@ func initDb(_ *cobra.Command, args []string) {
 				stderr.Printf("could not find '%s' repository config file.\n"+
 					"Run '%s' first or pass the Postgres URL as argument.\n",
 					term.Highlight(baur.RepositoryCfgFile), term.Highlight(cmdInitRepo))
-				exitFunc(1)
+				exitFunc(exitCodeError)
 			}
 
 			stderr.Println(err)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 
 		dbURL = mustGetPSQLURI(repo.Cfg)

--- a/internal/command/init_include.go
+++ b/internal/command/init_include.go
@@ -45,11 +45,11 @@ func initInclude(_ *cobra.Command, args []string) {
 	if err != nil {
 		if os.IsExist(err) {
 			stderr.Printf("%s already exist\n", filename)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 
 		stderr.Println(err)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	stdout.Printf("Include configuration file was written to %s\n",

--- a/internal/command/init_repo.go
+++ b/internal/command/init_repo.go
@@ -49,11 +49,11 @@ func initRepo(_ *cobra.Command, args []string) {
 	if err != nil {
 		if os.IsExist(err) {
 			stderr.Printf("%s already exist\n", repoCfgPath)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 
 		stderr.Println(err)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	stdout.Printf("Repository configuration was written to %s\n",

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -60,7 +60,7 @@ func (c *lsOutputsCmd) run(_ *cobra.Command, args []string) {
 	taskRunID, err := strconv.Atoi(args[0])
 	if err != nil {
 		stderr.Printf("'%s' is not a numeric task run ID\n", args[0])
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	repo := mustFindRepository()
@@ -71,7 +71,7 @@ func (c *lsOutputsCmd) run(_ *cobra.Command, args []string) {
 	if err != nil {
 		if errors.Is(err, storage.ErrNotExist) {
 			stderr.Printf("task run with ID %d does not exist", taskRunID)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 	}
 

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -117,7 +117,7 @@ func parseSpec(s string) (app, task string) {
 
 	default:
 		stderr.Printf("invalid argument: %q\n", s)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	// is never executed because of the default case
@@ -170,10 +170,10 @@ func (c *lsRunsCmd) run(_ *cobra.Command, args []string) {
 	if err != nil {
 		if errors.Is(err, storage.ErrNotExist) {
 			stderr.Println("no matching task runs exist")
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 		stderr.Println(err)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	exitOnErr(formatter.Flush())

--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -4,11 +4,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var releaseCMd = &cobra.Command{
+var releaseCmd = &cobra.Command{
 	Use:   "release",
 	Short: "manage releases",
 }
 
 func init() {
-	rootCmd.AddCommand(releaseCMd)
+	rootCmd.AddCommand(releaseCmd)
 }

--- a/internal/command/release.go
+++ b/internal/command/release.go
@@ -1,0 +1,14 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var releaseCMd = &cobra.Command{
+	Use:   "release",
+	Short: "manage releases",
+}
+
+func init() {
+	rootCmd.AddCommand(releaseCMd)
+}

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -85,7 +85,7 @@ func newReleaseCreateCmd() *releaseCreateCmd {
 	const includeFlagName = "include"
 	cmd.Flags().StringArrayVar(&cmd.includes, includeFlagName, nil,
 		"Target to be included in the release, by default all are included.\n"+
-			"It supports the same TARGET syntax then 'baur run',\n"+
+			"It supports the same TARGET syntax as 'baur run',\n"+
 			"the flag can be specified multiple times")
 	_ = cmd.RegisterFlagCompletionFunc(
 		includeFlagName,
@@ -145,7 +145,7 @@ func (c *releaseCreateCmd) run(cmd *cobra.Command, args []string) {
 
 	err = storageClt.CreateRelease(ctx, releaseName, runIDs, metadataReader)
 	if errors.Is(err, storage.ErrExists) {
-		stderr.PrintErrf("release with name %q already exist, release names must be unique\n", releaseName)
+		stderr.PrintErrf("release with name %q already exists, release names must be unique\n", releaseName)
 		exitFunc(exitCodeAlreadyExist)
 	}
 	exitOnErr(err, "storing release information in database failed")

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -59,7 +59,7 @@ type releaseCreateCmd struct {
 }
 
 func init() {
-	releaseCMd.AddCommand(&newReleaseCreateCmd().Command)
+	releaseCmd.AddCommand(&newReleaseCreateCmd().Command)
 }
 
 func newReleaseCreateCmd() *releaseCreateCmd {
@@ -180,11 +180,11 @@ func (c *releaseCreateCmd) mustFetchTaskIDs(
 	for _, task := range tasks {
 		status, _, taskRun, err := statusMgr.Status(ctx, task)
 		if err != nil {
-			stdout.Println("")
+			stdout.Println()
 			exitOnErrf(err, "%s: evaluating task status failed", task)
 		}
 		if status != baur.TaskStatusRunExist {
-			stdout.Println("")
+			stdout.Println()
 			stderr.PrintErrf("%s: task status is %s, expecting %s\n",
 				task.ID, status, baur.TaskStatusRunExist)
 			exitFunc(exitCodeTaskRunIsPending)
@@ -194,7 +194,7 @@ func (c *releaseCreateCmd) mustFetchTaskIDs(
 		runIDs = append(runIDs, taskRun.ID)
 
 	}
-	stdout.Println("")
+	stdout.Println()
 
 	return runIDs
 }

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -1,0 +1,200 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/simplesurance/baur/v3/internal/command/term"
+	"github.com/simplesurance/baur/v3/internal/log"
+	"github.com/simplesurance/baur/v3/pkg/baur"
+	"github.com/simplesurance/baur/v3/pkg/storage"
+
+	"github.com/spf13/cobra"
+)
+
+const releaseCreateExample = `
+baur release create stable		      create a release named 'stable',
+					      including all tasks
+baur release create --include '*.build' v3    create a release named 'v3',
+					      including only tasks called
+					      'build'`
+
+var releaseCreateLongHelp = fmt.Sprintf(`
+Creates a named snapshot of the status of tasks.
+The snapshot includes information about the tasks, their outputs and upload
+destinations.
+
+All tasks included in the release must have a run state of 'Exist'.
+Users can specify a file containing additional metadata, which will be stored
+with the release. It's recommended to keep the amount of metadata small,
+as it is stored in the database.
+
+By default, all tasks are included in the release.
+Pass the --include flag to include only specific tasks.
+See %s for more information about the TARGET syntax.
+
+Exit Codes:
+  %d - Success
+  %d - Error
+  %d - Release with the same name already exist
+  %d - One or more tasks are in pending state
+`,
+	term.Highlight("baur run --help"),
+	exitCodeSuccess,
+	exitCodeError,
+	exitCodeAlreadyExist,
+	exitCodeTaskRunIsPending,
+)
+
+type releaseCreateCmd struct {
+	cobra.Command
+	requireCleanGitWorktree bool
+
+	metadataFile string
+	includes     []string
+}
+
+func init() {
+	releaseCMd.AddCommand(&newReleaseCreateCmd().Command)
+}
+
+func newReleaseCreateCmd() *releaseCreateCmd {
+	cmd := releaseCreateCmd{
+		Command: cobra.Command{
+			Use:     "create NAME",
+			Short:   "create a release",
+			Long:    strings.TrimSpace(releaseCreateLongHelp),
+			Args:    cobra.ExactArgs(1),
+			Example: strings.TrimSpace(releaseCreateExample),
+			ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			},
+		},
+	}
+
+	cmd.Flags().BoolVarP(&cmd.requireCleanGitWorktree, flagNameRequireCleanGitWorktree, "c", false,
+		"fail if the git repository contains modified or untracked files")
+	cmd.Flags().StringVarP(&cmd.metadataFile, "metadata", "m", "",
+		"path to a file containing additional data that is stored with the release",
+	)
+
+	const includeFlagName = "include"
+	cmd.Flags().StringArrayVar(&cmd.includes, includeFlagName, nil,
+		"Target to be included in the release, by default all are included.\n"+
+			"It supports the same TARGET syntax then 'baur run',\n"+
+			"the flag can be specified multiple times")
+	_ = cmd.RegisterFlagCompletionFunc(
+		includeFlagName,
+		newCompleteTargetFunc(completeTargetFuncOpts{withoutPaths: true}),
+	)
+
+	cmd.Run = cmd.run
+
+	return &cmd
+}
+
+func (c *releaseCreateCmd) run(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	releaseName := args[0]
+
+	if strings.TrimSpace(releaseName) != releaseName {
+		fatalf("release name must not contain leading or trailing whitespaces, got: %q\n",
+			releaseName)
+	}
+
+	stdout.Printf("creating release: %s\n", term.Highlight(releaseName))
+
+	repo := mustFindRepository()
+	vcsState := mustGetRepoState(repo.Path)
+
+	mustUntrackedFilesNotExist(c.requireCleanGitWorktree, vcsState)
+
+	loader, err := baur.NewLoader(
+		repo.Cfg,
+		vcsState.CommitID,
+		log.StdLogger,
+	)
+	exitOnErr(err)
+
+	stdout.Println("loading application configs...")
+	tasks, err := loader.LoadTasks(c.includes...)
+	exitOnErr(err)
+
+	if len(tasks) == 0 {
+		if len(c.includes) != 0 {
+			fatalf("could not find any tasks matching %s\n", strings.Join(c.includes, ","))
+		}
+		fatal("could not find any tasks in the baur repository")
+	}
+
+	storageClt := mustNewCompatibleStorage(repo)
+	runIDs := c.mustFetchTaskIDs(ctx, repo, storageClt, tasks)
+
+	var metadataReader io.Reader
+	if c.metadataFile != "" {
+		fd, err := os.Open(c.metadataFile)
+		exitOnErrf(err, "opening metadata file failed\n")
+
+		defer fd.Close()
+		metadataReader = fd
+	}
+
+	err = storageClt.CreateRelease(ctx, releaseName, runIDs, metadataReader)
+	if errors.Is(err, storage.ErrExists) {
+		stderr.PrintErrf("release with name %q already exist, release names must be unique\n", releaseName)
+		exitFunc(exitCodeAlreadyExist)
+	}
+	exitOnErr(err, "storing release information in database failed")
+
+	stdout.Printf(
+		"release %s created %s\n",
+		term.Highlight(releaseName),
+		term.GreenHighlight("successfully"),
+	)
+}
+
+func (c *releaseCreateCmd) mustFetchTaskIDs(
+	ctx context.Context,
+	repo *baur.Repository,
+	storageClt storage.Storer,
+	tasks []*baur.Task,
+) []int {
+	statusMgr := baur.NewTaskStatusEvaluator(
+		repo.Path,
+		storageClt,
+		baur.NewInputResolver(
+			mustGetRepoState(repo.Path),
+			repo.Path,
+			nil,
+			!c.requireCleanGitWorktree,
+		),
+		"",
+	)
+
+	runIDs := make([]int, 0, len(tasks))
+	stdout.Printf("evaluating task statuses")
+	for _, task := range tasks {
+		status, _, taskRun, err := statusMgr.Status(ctx, task)
+		if err != nil {
+			stdout.Println("")
+			exitOnErrf(err, "%s: evaluating task status failed", task)
+		}
+		if status != baur.TaskStatusRunExist {
+			stdout.Println("")
+			stderr.PrintErrf("%s: task status is %s, expecting %s\n",
+				task.ID, status, baur.TaskStatusRunExist)
+			exitFunc(exitCodeTaskRunIsPending)
+		}
+
+		stdout.Printf(".")
+		runIDs = append(runIDs, taskRun.ID)
+
+	}
+	stdout.Println("")
+
+	return runIDs
+}

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/simplesurance/baur/v3/internal/command/term"
 	"github.com/simplesurance/baur/v3/internal/log"
@@ -98,14 +99,24 @@ func newReleaseCreateCmd() *releaseCreateCmd {
 	return &cmd
 }
 
+func mustValidateReleaseName(releaseName string) {
+	for pos, r := range releaseName {
+		if (pos == 0 || pos == len(releaseName)-1) && unicode.IsSpace(r) {
+			fatalf("release name must not contain leading or trailing whitespaces, got: %q\n",
+				releaseName)
+		}
+
+		if !unicode.IsPrint(r) {
+			fatalf("release name contains non-printable character: %q\n", r)
+		}
+	}
+}
+
 func (c *releaseCreateCmd) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	releaseName := args[0]
 
-	if strings.TrimSpace(releaseName) != releaseName {
-		fatalf("release name must not contain leading or trailing whitespaces, got: %q\n",
-			releaseName)
-	}
+	mustValidateReleaseName(releaseName)
 
 	stdout.Printf("creating release: %s\n", term.Highlight(releaseName))
 

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -84,9 +84,10 @@ func newReleaseCreateCmd() *releaseCreateCmd {
 
 	const includeFlagName = "include"
 	cmd.Flags().StringArrayVar(&cmd.includes, includeFlagName, nil,
-		"Target to be included in the release, by default all are included.\n"+
-			"It supports the same TARGET syntax as 'baur run',\n"+
-			"the flag can be specified multiple times")
+		"tasks matching a TARGET string to include in the release,\n"+
+			"TARGET has the same syntax as used in 'baur run',\n"+
+			"the flag can be specified multiple times",
+	)
 	_ = cmd.RegisterFlagCompletionFunc(
 		includeFlagName,
 		newCompleteTargetFunc(completeTargetFuncOpts{withoutPaths: true}),

--- a/internal/command/release_create_test.go
+++ b/internal/command/release_create_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/release_create_test.go
+++ b/internal/command/release_create_test.go
@@ -1,0 +1,63 @@
+//go:build dbtest
+// +build dbtest
+
+package command
+
+import (
+	"testing"
+
+	"github.com/simplesurance/baur/v3/internal/testutils/repotest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateRelease(t *testing.T) {
+	initTest(t)
+
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+	r.CreateSimpleApp(t)
+	runInitDb(t)
+
+	t.Run("failsWhenTaskRunsArePending", func(t *testing.T) {
+		initTest(t)
+		releaseCmd := newReleaseCreateCmd()
+		releaseCmd.SetArgs([]string{"all"})
+
+		execCheck(t, releaseCmd, exitCodeTaskRunIsPending)
+	})
+
+	runCmd := newRunCmd()
+	require.NotPanics(t, func() { require.NoError(t, runCmd.Execute()) })
+
+	// TODO: extend the testcases to verify the data of the created
+	// release, when "release show" was implemented
+
+	t.Run("allTasks", func(t *testing.T) {
+		initTest(t)
+		releaseCmd := newReleaseCreateCmd()
+
+		releaseCmd.SetArgs([]string{"all"})
+		require.NotPanics(t, func() { require.NoError(t, releaseCmd.Execute()) })
+	})
+
+	t.Run("releaseAlreadyExistsErr", func(t *testing.T) {
+		initTest(t)
+
+		releaseCmd := newReleaseCreateCmd()
+		releaseCmd.SetArgs([]string{"all"})
+
+		execCheck(t, releaseCmd, exitCodeAlreadyExist)
+	})
+
+	t.Run("metadataAndMultipleIncludes", func(t *testing.T) {
+		initTest(t)
+		releaseCmd := newReleaseCreateCmd()
+
+		releaseCmd.SetArgs([]string{
+			"--include", "*.build", "--include", "*.check", "buildCheck",
+			"-m", r.AppCfgs[0].FilePath(),
+		})
+		require.NotPanics(t, func() { require.NoError(t, releaseCmd.Execute()) })
+	})
+
+}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -148,7 +148,7 @@ func (c *runCmd) run(_ *cobra.Command, args []string) {
 
 	if c.taskRunnerGoRoutines == 0 {
 		stderr.Printf("--parallel-runs must be greater than 0\n")
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	startTime := time.Now()
@@ -290,7 +290,7 @@ func (c *runCmd) run(_ *cobra.Command, args []string) {
 	)
 
 	if c.errorHappened {
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 }
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -352,11 +352,11 @@ func (*showCmd) showBuild(taskRunID int) {
 	if err != nil {
 		if errors.Is(err, storage.ErrNotExist) {
 			stderr.Printf("task run with id %d does not exist\n", taskRunID)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 
 		stderr.Println(err)
-		exitFunc(1)
+		exitFunc(exitCodeError)
 	}
 
 	outputs, err := storageClt.Outputs(ctx, taskRun.ID)

--- a/internal/command/term/streams.go
+++ b/internal/command/term/streams.go
@@ -3,6 +3,7 @@ package term
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/fatih/color"
@@ -60,7 +61,7 @@ func (s *Stream) ErrPrintln(err error, msg ...any) {
 // ErrPrintf prints an error with an optional printf-style message.
 // The method prints the error in the format: errorPrefix msg: err
 func (s *Stream) ErrPrintf(err error, format string, a ...any) {
-	s.ErrPrintln(err, fmt.Sprintf(format, a...))
+	s.ErrPrintln(err, fmt.Sprintf(strings.TrimSuffix(format, "\n"), a...))
 }
 
 // PrintErrln prints as message that is prefixed with "ERROR: "
@@ -70,7 +71,7 @@ func (s *Stream) PrintErrln(msg ...any) {
 
 // PrintErrf prints as message that is prefixed with "ERROR: "
 func (s *Stream) PrintErrf(format string, a ...any) {
-	s.Println(ErrorPrefix, fmt.Sprintf(format, a...))
+	s.Printf(ErrorPrefix+" "+format, a...)
 }
 
 // PrintSep prints a separator line

--- a/internal/command/term/streams.go
+++ b/internal/command/term/streams.go
@@ -68,6 +68,11 @@ func (s *Stream) PrintErrln(msg ...any) {
 	s.Println(ErrorPrefix, fmt.Sprint(msg...))
 }
 
+// PrintErrf prints as message that is prefixed with "ERROR: "
+func (s *Stream) PrintErrf(format string, a ...any) {
+	s.Println(ErrorPrefix, fmt.Sprintf(format, a...))
+}
+
 // PrintSep prints a separator line
 func (s *Stream) PrintSep() {
 	fmt.Fprintln(s.stream, separator)

--- a/internal/command/upgrade_db.go
+++ b/internal/command/upgrade_db.go
@@ -62,11 +62,11 @@ func (*upgradeDbCmd) run(_ *cobra.Command, args []string) {
 				stderr.Printf("could not find '%s' repository config file.\n"+
 					"Run '%s' first or pass the Postgres URL as argument.\n",
 					term.Highlight(baur.RepositoryCfgFile), term.Highlight(cmdInitRepo))
-				exitFunc(1)
+				exitFunc(exitCodeError)
 			}
 
 			stderr.Println(err)
-			exitFunc(1)
+			exitFunc(exitCodeError)
 		}
 
 		dbURL = mustGetPSQLURI(repo.Cfg)

--- a/internal/command/upgrade_db_test.go
+++ b/internal/command/upgrade_db_test.go
@@ -64,5 +64,5 @@ func TestUpgradeDb(t *testing.T) {
 	upgradeDbCmd := newUpgradeDatabaseCmd()
 	upgradeDbCmd.Command.Run(&upgradeDbCmd.Command, nil)
 
-	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 3")
+	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 4")
 }

--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -3,11 +3,14 @@ package postgres
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"sort"
 	"strings"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 
 	"github.com/simplesurance/baur/v3/pkg/storage"
@@ -61,6 +64,29 @@ func queryValueStr(pairsCount, argsPerPair int) string {
 		}
 
 		res.WriteRune(')')
+
+		if i < pairsCount-1 {
+			res.WriteString(", ")
+		}
+	}
+
+	return res.String()
+}
+
+// queryValuePairFirstConstStr returns the argument for an SQL VALUES statement
+// It creates pairsCount "($1, $n), ($1, $n+1), ($1 $n+...)" string pairs.
+// The first argument is constant and refers the first query argument.
+func queryValuePairFirstConstStr(pairsCount int) string {
+	var res strings.Builder
+
+	// not exact, does not take number of digits required for pairsCount
+	// into account
+	res.Grow((6 * pairsCount) + 2*pairsCount)
+
+	argNr := 2
+	for i := 0; i < pairsCount; i++ {
+		fmt.Fprintf(&res, "($1, $%d)", argNr)
+		argNr++
 
 		if i < pairsCount-1 {
 			res.WriteString(", ")
@@ -321,16 +347,8 @@ func insertTaskRunInputStringsIfNotExist(ctx context.Context, db dbConn, taskRun
 		return err
 	}
 
-	var stmtVals strings.Builder
-	argNr := 2
-	for i := 0; i < len(inputStringIDs); i++ {
-		fmt.Fprintf(&stmtVals, "($1, $%d)", argNr)
-		argNr++
-
-		if i < len(inputStringIDs)-1 {
-			stmtVals.WriteString(", ")
-		}
-	}
+	stmtVals := queryValuePairFirstConstStr(len(inputStringIDs))
+	query := stmt1 + stmtVals
 
 	queryArgs := make([]any, 1, len(inputStringIDs)+1)
 	queryArgs[0] = taskRunID
@@ -338,8 +356,6 @@ func insertTaskRunInputStringsIfNotExist(ctx context.Context, db dbConn, taskRun
 	for _, inputID := range inputStringIDs {
 		queryArgs = append(queryArgs, inputID)
 	}
-
-	query := stmt1 + stmtVals.String()
 
 	_, err = db.Exec(ctx, query, queryArgs...)
 	if err != nil {
@@ -717,4 +733,78 @@ func (c *Client) SaveTaskRun(ctx context.Context, taskRun *storage.TaskRunFull) 
 		id, err = c.saveTaskRun(ctx, tx, taskRun)
 		return err
 	})
+}
+
+func (c *Client) CreateRelease(ctx context.Context, releaseName string, taskRunIDs []int, metadata io.Reader) error {
+	return c.db.BeginFunc(ctx, func(tx pgx.Tx) error {
+		releaseID, err := c.insertRelease(ctx, tx, releaseName, metadata)
+		if err != nil {
+			return err
+		}
+
+		return c.insertReleaseTaskRun(ctx, tx, releaseID, taskRunIDs)
+	})
+}
+
+func (*Client) insertRelease(ctx context.Context, tx pgx.Tx, name string, metadata io.Reader) (int, error) {
+	const query = `
+		INSERT INTO release (name, user_data)
+	        VALUES($1, $2)
+	     RETURNING id
+	`
+
+	var data []byte
+	var err error
+	var releaseID int
+
+	if metadata != nil {
+		data, err = io.ReadAll(metadata)
+		if err != nil {
+			return -1, fmt.Errorf("reading metadata failed: %w", err)
+		}
+	}
+
+	err = tx.QueryRow(ctx, query, name, data).Scan(&releaseID)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "release_name_uniq" {
+				return -1, storage.ErrExists
+			}
+		}
+
+		if metadata == nil {
+			return -1, newQueryError(query, err, name)
+		}
+
+		return -1, newQueryError(query, err, []any{name, "<OMITTED-RELEASE-METADATA>"}...)
+	}
+
+	return releaseID, nil
+}
+
+func (*Client) insertReleaseTaskRun(ctx context.Context, tx pgx.Tx, releaseID int, taskRunIDs []int) error {
+	const stmt1 = `
+		INSERT INTO release_task_run (release_id, task_run_id)
+		VALUES`
+
+	if len(taskRunIDs) == 0 {
+		return errors.New("no task run IDs were specified")
+	}
+
+	stmtVals := queryValuePairFirstConstStr(len(taskRunIDs))
+
+	queryArgs := make([]any, 1, len(taskRunIDs)+1)
+	queryArgs[0] = releaseID
+	for _, inputID := range taskRunIDs {
+		queryArgs = append(queryArgs, inputID)
+	}
+
+	query := stmt1 + stmtVals
+	_, err := tx.Exec(ctx, query, queryArgs...)
+	if err != nil {
+		return newQueryError(query, err, queryArgs...)
+	}
+
+	return nil
 }

--- a/pkg/storage/postgres/insert_test.go
+++ b/pkg/storage/postgres/insert_test.go
@@ -61,33 +61,6 @@ func TestSaveTaskRun(t *testing.T) {
 			},
 			expectSuccess: []bool{true},
 		},
-
-		{
-			name: "no_outputs",
-			taskRuns: []*storage.TaskRunFull{
-				{
-					TaskRun: storage.TaskRun{
-						ApplicationName:  "baurHimself",
-						TaskName:         "build",
-						VCSRevision:      "1",
-						VCSIsDirty:       false,
-						StartTimestamp:   time.Now(),
-						StopTimestamp:    time.Now().Add(5 * time.Minute),
-						TotalInputDigest: "1234567890",
-						Result:           storage.ResultSuccess,
-					},
-					Inputs: storage.Inputs{
-						Files: []*storage.InputFile{
-							{
-								Path:   "main.go",
-								Digest: "45",
-							},
-						},
-					},
-				},
-			},
-			expectSuccess: []bool{true},
-		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/storage/postgres/migrations/4.sql
+++ b/pkg/storage/postgres/migrations/4.sql
@@ -1,0 +1,12 @@
+CREATE TABLE release (
+	id serial PRIMARY KEY,
+	name text NOT NULL,
+	user_data bytea,
+	CONSTRAINT release_name_uniq UNIQUE (name)
+);
+
+CREATE TABLE release_task_run (
+	release_id integer NOT NULL REFERENCES release (id) ON DELETE CASCADE,
+	task_run_id integer NOT NULL REFERENCES task_run (id) ON DELETE CASCADE,
+	PRIMARY KEY(release_id, task_run_id)
+);

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -17,7 +17,7 @@ import (
 )
 
 // schemaVer is the database schema version required by this package.
-const schemaVer int32 = 3
+const schemaVer int32 = 4
 
 // migration represents a database schema migration.
 type migration struct {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 )
 
@@ -144,4 +145,9 @@ type Storer interface {
 	// the method returns ErrNotExist.
 	Inputs(ctx context.Context, taskRunID int) (*Inputs, error)
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
+
+	// CreateRelease creates a new release called releaseName, that consists of the the passed task runs.
+	// Metadata is arbitrary data stored together with the release, it is
+	// optional and can be nil.
+	CreateRelease(_ context.Context, releaseName string, taskRunIDs []int, metadata io.Reader) error
 }


### PR DESCRIPTION
Introduce a "release create" command.
It creates a named snapshot of the state of a list of tasks in EXIST state.
Optionally user-specified metadata (arbitrary data) can be stored with the
release. Metadata is read from a file and stored in the database.

Releases will provide a static view of baur runs, including their
outputs, without having to ensure that the environment must be the same
when the outputs have been created.
When "baur status" + "baur ls outputs" is used there can be various
factors that make the result hard to reproduce, e.g:
- outputs might have been overwritten for the same input files via
  "baur run --force",
- change of the used tooling (go list) or  different environment
  variables used as inputs can result in different total input digests

In follow up further commands are added to interact with releases.