### PR TITLE
add "release exists" command

### DIFF
--- a/internal/command/diff_inputs.go
+++ b/internal/command/diff_inputs.go
@@ -226,7 +226,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 
 	taskRun := getTaskRun(repo, argDetails)
 
-	psql := mustNewCompatibleStorage(repo)
+	psql := mustNewCompatibleStorageRepo(repo)
 	defer psql.Close()
 
 	storageInputs, err := psql.Inputs(ctx, taskRun.ID)
@@ -236,7 +236,7 @@ func (c *diffInputsCmd) getTaskRunInputs(repo *baur.Repository, argDetails *diff
 }
 
 func getTaskRun(repo *baur.Repository, argDetails *diffInputArgDetails) *storage.TaskRunWithID {
-	psql := mustNewCompatibleStorage(repo)
+	psql := mustNewCompatibleStorageRepo(repo)
 	defer psql.Close()
 
 	if strings.Contains(argDetails.runID, "^") {

--- a/internal/command/exitcodes.go
+++ b/internal/command/exitcodes.go
@@ -5,4 +5,5 @@ const (
 	exitCodeError            = 1
 	exitCodeAlreadyExist     = 2
 	exitCodeTaskRunIsPending = 3
+	exitCodeNotExist         = 4
 )

--- a/internal/command/ls_inputs.go
+++ b/internal/command/ls_inputs.go
@@ -75,7 +75,7 @@ func (c *lsInputsCmd) run(_ *cobra.Command, args []string) {
 func (c *lsInputsCmd) mustGetTaskRunInputs(taskRunID int) *baur.Inputs {
 	repo := mustFindRepository()
 
-	storageClt := mustNewCompatibleStorage(repo)
+	storageClt := mustNewCompatibleStorageRepo(repo)
 	defer storageClt.Close()
 
 	inputs, err := storageClt.Inputs(ctx, taskRunID)

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -64,7 +64,7 @@ func (c *lsOutputsCmd) run(_ *cobra.Command, args []string) {
 	}
 
 	repo := mustFindRepository()
-	pgClient := mustNewCompatibleStorage(repo)
+	pgClient := mustNewCompatibleStorageRepo(repo)
 	defer pgClient.Close()
 
 	_, err = pgClient.TaskRun(ctx, taskRunID)

--- a/internal/command/ls_runs.go
+++ b/internal/command/ls_runs.go
@@ -135,7 +135,7 @@ func (c *lsRunsCmd) run(_ *cobra.Command, args []string) {
 	c.app, c.task = parseSpec(args[0])
 
 	repo := mustFindRepository()
-	psql := mustNewCompatibleStorage(repo)
+	psql := mustNewCompatibleStorageRepo(repo)
 	defer psql.Close()
 
 	var formatter Formatter

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -131,7 +131,7 @@ func (c *releaseCreateCmd) run(cmd *cobra.Command, args []string) {
 		fatal("could not find any tasks in the baur repository")
 	}
 
-	storageClt := mustNewCompatibleStorage(repo)
+	storageClt := mustNewCompatibleStorageRepo(repo)
 	runIDs := c.mustFetchTaskIDs(ctx, repo, storageClt, tasks)
 
 	var metadataReader io.Reader

--- a/internal/command/release_exists.go
+++ b/internal/command/release_exists.go
@@ -1,0 +1,80 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/simplesurance/baur/v3/internal/command/term"
+
+	"github.com/spf13/cobra"
+)
+
+var releaseExistsLongHelp = fmt.Sprintf(`
+Check if a release with a given name exists.
+
+The command can be run without access to the baur repository, by specifying
+the PostgreSQL URI via the environment variable %s.
+
+Exit Codes:
+  %d - Success, release exists
+  %d - Error
+  %d - Release does not exist
+  `,
+	term.Highlight(envVarPSQLURL),
+	exitCodeSuccess,
+	exitCodeError,
+	exitCodeNotExist,
+)
+
+type releaseExistsCmd struct {
+	cobra.Command
+	quiet bool
+}
+
+func init() {
+	releaseCmd.AddCommand(&newReleaseExistsCmd().Command)
+}
+
+func newReleaseExistsCmd() *releaseExistsCmd {
+	cmd := releaseExistsCmd{
+		Command: cobra.Command{
+			Use:               "exists NAME",
+			Short:             "check if a release exists",
+			Long:              strings.TrimSpace(releaseExistsLongHelp),
+			Args:              cobra.ExactArgs(1),
+			ValidArgsFunction: cobra.NoFileCompletions,
+		},
+	}
+
+	cmd.Run = cmd.run
+	cmd.Flags().BoolVarP(
+		&cmd.quiet,
+		"quiet", "q",
+		false,
+		"suppress printing a result message",
+	)
+
+	return &cmd
+}
+
+func (c *releaseExistsCmd) run(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	releaseName := args[0]
+	psqlURL, err := postgresqlURL()
+	exitOnErr(err)
+
+	storageClt := mustNewCompatibleStorage(psqlURL)
+
+	exists, err := storageClt.ReleaseExists(ctx, releaseName)
+	exitOnErr(err)
+	if !exists {
+		if !c.quiet {
+			stdout.Printf("release %s does not exist\n", term.Highlight(args[0]))
+		}
+		exitFunc(exitCodeNotExist)
+	}
+
+	if !c.quiet {
+		stdout.Printf("release %s exists\n", term.Highlight(args[0]))
+	}
+}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -160,7 +160,7 @@ func (c *runCmd) run(_ *cobra.Command, args []string) {
 
 	mustUntrackedFilesNotExist(c.requireCleanGitWorktree, c.gitRepo)
 
-	c.storage = mustNewCompatibleStorage(repo)
+	c.storage = mustNewCompatibleStorageRepo(repo)
 	defer c.storage.Close()
 
 	inputResolver := baur.NewInputResolver(

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -115,7 +115,7 @@ func newRunCmd() *runCmd {
 		Command: cobra.Command{
 			Use:               "run [TARGET|APP_DIR]...",
 			Short:             "run tasks",
-			Long:              runLongHelp,
+			Long:              strings.TrimSpace(runLongHelp),
 			Example:           strings.TrimSpace(runExample),
 			ValidArgsFunction: newCompleteTargetFunc(completeTargetFuncOpts{}),
 		},

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -345,7 +345,7 @@ func vcsStr(v *storage.TaskRun) string {
 
 func (*showCmd) showBuild(taskRunID int) {
 	repo := mustFindRepository()
-	storageClt := mustNewCompatibleStorage(repo)
+	storageClt := mustNewCompatibleStorageRepo(repo)
 	defer storageClt.Close()
 
 	taskRun, err := storageClt.TaskRun(ctx, taskRunID)

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -198,7 +198,7 @@ func (c *statusCmd) run(_ *cobra.Command, args []string) {
 	storageQueryNeeded := c.storageQueryIsNeeded()
 
 	if storageQueryNeeded {
-		storageClt = mustNewCompatibleStorage(repo)
+		storageClt = mustNewCompatibleStorageRepo(repo)
 		defer storageClt.Close()
 	}
 

--- a/internal/testutils/repotest/repotest.go
+++ b/internal/testutils/repotest/repotest.go
@@ -222,6 +222,7 @@ func (r *Repo) WriteAdditionalFileContents(t *testing.T, appName, fileName, cont
 }
 
 type Repo struct {
+	Cfg                 *cfg.Repository
 	AppCfgs             []*cfg.App
 	Dir                 string
 	FilecopyArtifactDir string
@@ -338,6 +339,7 @@ func CreateBaurRepository(t *testing.T, opts ...Opt) *Repo {
 	t.Logf("changed working directory to baur repository: %q", tempDir)
 
 	return &Repo{
+		Cfg:                 &cfgR,
 		Dir:                 tempDir,
 		FilecopyArtifactDir: artifactDir,
 	}

--- a/pkg/storage/postgres/query.go
+++ b/pkg/storage/postgres/query.go
@@ -465,3 +465,19 @@ func (c *Client) TaskRuns(
 
 	return nil
 }
+
+func (c *Client) ReleaseExists(ctx context.Context, name string) (bool, error) {
+	const query = `
+	SELECT COUNT(id)
+	  FROM release
+	 WHERE name = $1
+	 LIMIT 1
+	 `
+	var count int
+	err := c.db.QueryRow(ctx, query, name).Scan(&count)
+	if err != nil {
+		return false, newQueryError(query, err, name)
+	}
+
+	return count == 1, nil
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -150,4 +150,5 @@ type Storer interface {
 	// Metadata is arbitrary data stored together with the release, it is
 	// optional and can be nil.
 	CreateRelease(_ context.Context, releaseName string, taskRunIDs []int, metadata io.Reader) error
+	ReleaseExists(_ context.Context, name string) (bool, error)
 }


### PR DESCRIPTION
Add the command "release exists". It checks if a release with give name
exists.

It can be used without a baur repository by setting the
BAUR_POSTGRESQL_URL environment variable.