### PR TITLE
cmd: add baur release show

### DIFF
--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -65,14 +65,12 @@ func init() {
 func newReleaseCreateCmd() *releaseCreateCmd {
 	cmd := releaseCreateCmd{
 		Command: cobra.Command{
-			Use:     "create NAME",
-			Short:   "create a release",
-			Long:    strings.TrimSpace(releaseCreateLongHelp),
-			Args:    cobra.ExactArgs(1),
-			Example: strings.TrimSpace(releaseCreateExample),
-			ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			},
+			Use:               "create NAME",
+			Short:             "create a release",
+			Long:              strings.TrimSpace(releaseCreateLongHelp),
+			Args:              cobra.ExactArgs(1),
+			Example:           strings.TrimSpace(releaseCreateExample),
+			ValidArgsFunction: cobra.NoFileCompletions,
 		},
 	}
 

--- a/internal/command/release_download.go
+++ b/internal/command/release_download.go
@@ -22,8 +22,8 @@ belong to the release.
 Only outputs that have been uploaded to S3 are downloaded, others are ignored.
 The downloaded outputs are stored at the path: %s.
 
-The command can be run without access to the baur repository, by specifying
-the PostgreSQL URI via the environment variable %s.
+The command can be run without access to the baur repository by specifying the
+PostgreSQL URI via the environment variable %s.
 
 When task IDS are specified via %s, the command fails if any of them is not
 part of the release or does not have >1 output uploaded to S3.

--- a/internal/command/release_exists.go
+++ b/internal/command/release_exists.go
@@ -12,8 +12,8 @@ import (
 var releaseExistsLongHelp = fmt.Sprintf(`
 Check if a release with a given name exists.
 
-The command can be run without access to the baur repository, by specifying
-the PostgreSQL URI via the environment variable %s.
+The command can be run without access to the baur repository by specifying the
+PostgreSQL URI via the environment variable %s.
 
 Exit Codes:
   %d - Success, release exists

--- a/internal/command/release_show.go
+++ b/internal/command/release_show.go
@@ -51,8 +51,8 @@ func newReleaseShowCmd() *releaseShowCmd {
 
 	cmd.Flags().StringVarP(
 		&cmd.metadataFilePath, "metadata", "m", "",
-		"write the stored metadata to the given file path\n"+
-			"instead of including it in the JSON output",
+		"write the stored metadata to the given file path,\n"+
+			" instead of including it in the JSON output",
 	)
 
 	cmd.Run = cmd.run

--- a/internal/command/release_show.go
+++ b/internal/command/release_show.go
@@ -1,0 +1,96 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/simplesurance/baur/v3/internal/command/term"
+	"github.com/simplesurance/baur/v3/internal/log"
+	"github.com/simplesurance/baur/v3/pkg/baur"
+	"github.com/simplesurance/baur/v3/pkg/storage"
+
+	"github.com/spf13/cobra"
+)
+
+var releaseShowLongHelp = fmt.Sprintf(`
+Display information about a release.
+The information are printed to stdout in JSON format.
+
+The command can be run without access to the baur repository, by specifying
+the PostgreSQL URI via the environment variable %s.
+
+  1 - Error
+  %d - Release does not exist
+`,
+	term.Highlight(envVarPSQLURL),
+	exitCodeNotExist,
+)
+
+type releaseShowCmd struct {
+	cobra.Command
+
+	metadataFilePath string
+}
+
+func init() {
+	releaseCmd.AddCommand(&newReleaseShowCmd().Command)
+}
+
+func newReleaseShowCmd() *releaseShowCmd {
+	cmd := releaseShowCmd{
+		Command: cobra.Command{
+			Use:               "show NAME",
+			Short:             "display information about a release",
+			Long:              strings.TrimSpace(releaseShowLongHelp),
+			Args:              cobra.ExactArgs(1),
+			ValidArgsFunction: cobra.NoFileCompletions,
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&cmd.metadataFilePath, "metadata", "m", "",
+		"write the stored metadata to the given file path\n"+
+			"instead of including it in the JSON output",
+	)
+
+	cmd.Run = cmd.run
+	return &cmd
+}
+
+func (c *releaseShowCmd) run(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	releaseName := args[0]
+	writeMetadataTofile := c.metadataFilePath != ""
+
+	psqlURL, err := postgresqlURL()
+	exitOnErr(err)
+
+	storageClt := mustNewCompatibleStorage(psqlURL)
+
+	rm := baur.NewReleaseManager(&storageClt, nil, log.StdLogger)
+	release, err := rm.GetRelease(ctx, releaseName)
+	if errors.Is(err, storage.ErrNotExist) {
+		stderr.Printf(
+			"release %s does not exist\n",
+			term.Highlight(args[0]),
+		)
+		exitFunc(exitCodeNotExist)
+	}
+	exitOnErr(err)
+
+	if writeMetadataTofile {
+		f, err := os.Create(c.metadataFilePath)
+		exitOnErrf(err, "creating metadata file %s failed", c.metadataFilePath)
+
+		err = release.WriteMetadata(f)
+		exitOnErrf(err, "writing to metadata file %s failed", c.metadataFilePath)
+
+		err = f.Close()
+		exitOnErrf(err, "writing to metadata file %s failed", c.metadataFilePath)
+	}
+
+	err = release.ToJSON(stdout, writeMetadataTofile)
+	exitOnErr(err)
+}

--- a/internal/command/release_test.go
+++ b/internal/command/release_test.go
@@ -130,10 +130,11 @@ func TestRelease(t *testing.T) {
 		showStdout, _ := interceptCmdOutput(t)
 		showCmd.SetArgs([]string{"buildCheck"})
 		require.NotPanics(t, func() { require.NoError(t, showCmd.Execute()) })
+
 		var release baur.Release
 		err := json.Unmarshal(showStdout.Bytes(), &release)
 		require.NoError(t, err, showStdout.String())
-		require.Equal(t, metadataSrc, release.Metadata)
+		require.Equal(t, string(metadataSrc), string(release.Metadata))
 	})
 
 	t.Run("ExistsWithBaurCfg", func(t *testing.T) {

--- a/pkg/baur/release.go
+++ b/pkg/baur/release.go
@@ -1,0 +1,49 @@
+package baur
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Release struct {
+	ReleaseName  string
+	Metadata     []byte `json:",omitempty"`
+	Applications map[string]*ReleaseApp
+}
+
+type ReleaseApp struct {
+	TaskRuns map[string]*ReleaseTaskRun
+}
+
+type ReleaseTaskRun struct {
+	RunID   int
+	Outputs map[int]*ReleaseOutput
+}
+
+type ReleaseOutput struct {
+	Uploads []*ReleaseUpload
+}
+
+type ReleaseUpload struct {
+	UploadMethod string
+	URI          string
+}
+
+// ToJSON encodes the Release to JSON and writes the result to w.
+// If excludeMetadata is true or no Metadata exists, the Metadata field is omitted from the result.
+func (r *Release) ToJSON(w io.Writer, excludeMetadata bool) error {
+	enc := json.NewEncoder(w)
+
+	if !excludeMetadata {
+		return enc.Encode(r)
+	}
+
+	cp := *r
+	cp.Metadata = nil
+	return enc.Encode(cp)
+}
+
+func (r *Release) WriteMetadata(w io.Writer) error {
+	_, err := w.Write(r.Metadata)
+	return err
+}

--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -748,7 +748,7 @@ func (c *Client) CreateRelease(ctx context.Context, releaseName string, taskRunI
 
 func (*Client) insertRelease(ctx context.Context, tx pgx.Tx, name string, metadata io.Reader) (int, error) {
 	const query = `
-		INSERT INTO release (name, user_data)
+		INSERT INTO release (name, metadata)
 	        VALUES($1, $2)
 	     RETURNING id
 	`

--- a/pkg/storage/postgres/migrations/4.sql
+++ b/pkg/storage/postgres/migrations/4.sql
@@ -1,7 +1,7 @@
 CREATE TABLE release (
 	id serial PRIMARY KEY,
 	name text NOT NULL,
-	user_data bytea,
+	metadata bytea,
 	CONSTRAINT release_name_uniq UNIQUE (name)
 );
 

--- a/pkg/storage/postgres/query.go
+++ b/pkg/storage/postgres/query.go
@@ -552,3 +552,22 @@ func (c *Client) ReleaseTaskRuns(ctx context.Context, releaseName string) ([]*st
 
 	return result, nil
 }
+
+func (c *Client) ReleaseMetadata(ctx context.Context, releaseName string) ([]byte, error) {
+	const query = `
+	SELECT metadata
+	  FROM release
+	 WHERE release.name = $1
+	 `
+	var metadata []byte
+
+	err := c.db.QueryRow(ctx, query, releaseName).Scan(&metadata)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, storage.ErrNotExist
+		}
+		return nil, newQueryError(query, err, releaseName)
+	}
+
+	return metadata, nil
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -168,4 +168,8 @@ type Storer interface {
 	// [ReleaseTaskRunsResult.UploadMethod] fields are unset.
 	// If the release does not exist, ErrNotExist is returned.
 	ReleaseTaskRuns(ctx context.Context, releaseName string) ([]*ReleaseTaskRunsResult, error)
+	// ReleaseMetadata returns the metadata of a release.
+	// If the release does not exist ErrNotExist is returned.
+	// If the release has no metadata the returned []byte  is empty.
+	ReleaseMetadata(ctx context.Context, releaseName string) ([]byte, error)
 }


### PR DESCRIPTION
Add the command "baur release show", it prints information about a
stored release in JSON format.
The metadata of a release can either be written to a separate file by
providing the "--metadata" parameter or when not specified, included
base64 encoded in the printed JSON format.