### PR TITLE
release create: support to pass comma separated includes

### DIFF
--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -81,9 +81,10 @@ func newReleaseCreateCmd() *releaseCreateCmd {
 	)
 
 	const includeFlagName = "include"
-	cmd.Flags().StringArrayVar(&cmd.includes, includeFlagName, nil,
+	cmd.Flags().StringSliceVar(&cmd.includes, includeFlagName, nil,
 		"tasks matching a TARGET string to include in the release,\n"+
 			"TARGET has the same syntax as used in 'baur run',\n"+
+			"TARGETS can be separated by commas,"+
 			"the flag can be specified multiple times",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(

--- a/internal/command/release_test.go
+++ b/internal/command/release_test.go
@@ -106,6 +106,16 @@ func TestRelease(t *testing.T) {
 		execCheck(t, releaseCmd, exitCodeAlreadyExist)
 	})
 
+	t.Run("CreateWithCommaSeparatedIncludes", func(t *testing.T) {
+		initTest(t)
+		releaseCmd := newReleaseCreateCmd()
+
+		releaseCmd.SetArgs([]string{
+			"--include", "*.build", "--include", "*.check,simpleApp.build", t.Name(),
+		})
+		require.NotPanics(t, func() { require.NoError(t, releaseCmd.Execute()) })
+	})
+
 	t.Run("CreateAndShowWithMetadataAndMultipleIncludes", func(t *testing.T) {
 		initTest(t)
 		releaseCmd := newReleaseCreateCmd()

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -426,9 +426,33 @@ func findAppConfigs(repoDir string, searchDirs []string, searchDepth int, logger
 }
 
 func dedupApps(apps []*App) []*App {
-	return set.From(apps).Slice()
+	dedupMap := make(map[string]*App, len(apps))
+
+	for _, app := range apps {
+		dedupMap[app.Path] = app
+	}
+
+	result := make([]*App, 0, len(dedupMap))
+
+	for _, app := range dedupMap {
+		result = append(result, app)
+	}
+
+	return result
 }
 
 func dedupTasks(tasks []*Task) []*Task {
-	return set.From(tasks).Slice()
+	dedupMap := make(map[string]*Task, len(tasks))
+
+	for _, task := range tasks {
+		dedupMap[task.ID] = task
+	}
+
+	result := make([]*Task, 0, len(dedupMap))
+
+	for _, task := range dedupMap {
+		result = append(result, task)
+	}
+
+	return result
 }

--- a/pkg/cfg/validation.go
+++ b/pkg/cfg/validation.go
@@ -10,6 +10,7 @@ import (
 
 var forbiddenNameRunes = [...]rune{
 	'.',
+	',',
 	'*',
 	'#',
 }


### PR DESCRIPTION
```
loader: fix: duplicate apps and tasks are returned

Since commit 6151b481 (loader: simplify code by using set datatype,
2024-04-08) duplicate Apps and Tasks are returned by the Loader if
multiple specs matches the same app or tasks.
This results in duplicate results in "baur status" "baur ls runs" and
duplicate task executions.

Deduplicate Tasks again by task id and apps by their path.

-------------------------------------------------------------------------------
release create: support to pass comma separated includes

Support to pass a comma-separated list of task names to "baur release
create --include".
This makes it a bit easier to use, then having to pass the "--include"
arg per task.

-------------------------------------------------------------------------------
cfg: forbid comma characters in app and task names

Making ',' a reserved character will allow to pass a comma separated
list to "baur release create --include".
```