### PR TITLE
loader: fail if app names are not unique

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -259,14 +259,9 @@ func RealPath(path string) (string, error) {
 
 // RealPath resolves all symlinks and returns the path relative to basepath.
 func RealPathRel(basepath, path string) (string, error) {
-	path, err := filepath.EvalSymlinks(path)
+	absPath, err := RealPath(path)
 	if err != nil {
-		return "", fmt.Errorf("resolving symlinks in path failed: %w", err)
-	}
-
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", fmt.Errorf("computing absolute path of %q failed: %w", path, err)
+		return "", err
 	}
 
 	relPath, err := filepath.Rel(basepath, absPath)

--- a/pkg/baur/errors.go
+++ b/pkg/baur/errors.go
@@ -1,0 +1,16 @@
+package baur
+
+import "fmt"
+
+type ErrDuplicateAppNames struct {
+	AppName  string
+	AppPath1 string
+	AppPath2 string
+}
+
+func (e *ErrDuplicateAppNames) Error() string {
+	return fmt.Sprintf(
+		"app names must be unique but the following app configs use the same app name %q: %s, %s",
+		e.AppName, e.AppPath1, e.AppPath2,
+	)
+}

--- a/pkg/baur/loader.go
+++ b/pkg/baur/loader.go
@@ -453,13 +453,7 @@ func dedupApps(apps []*App) ([]*App, error) {
 		dedupMap[app.Name] = app
 	}
 
-	result := make([]*App, 0, len(dedupMap))
-
-	for _, app := range dedupMap {
-		result = append(result, app)
-	}
-
-	return result, nil
+	return maps.Values(dedupMap), nil
 }
 
 func dedupTasks(tasks []*Task) []*Task {
@@ -469,11 +463,5 @@ func dedupTasks(tasks []*Task) []*Task {
 		dedupMap[task.ID] = task
 	}
 
-	result := make([]*Task, 0, len(dedupMap))
-
-	for _, task := range dedupMap {
-		result = append(result, task)
-	}
-
-	return result
+	return maps.Values(dedupMap)
 }

--- a/pkg/baur/testdata/duplicate_app_names/.baur.toml
+++ b/pkg/baur/testdata/duplicate_app_names/.baur.toml
@@ -1,0 +1,17 @@
+
+# Internal field, version of baur configuration format
+config_version = 6
+
+[Database]
+
+  # PostgreSQL database Connection string (https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
+  # The setting is overwritten by the environment variable BAUR_POSTGRESQL_URL.
+  postgresql_url = "INVALID"
+
+[Discover]
+
+  # Directories in which applications (.app.toml files) are discovered
+  application_dirs = ["."]
+
+  # Descend at most search_depth levels to find application configs
+  search_depth = 1

--- a/pkg/baur/testdata/duplicate_app_names/app1/.app.toml
+++ b/pkg/baur/testdata/duplicate_app_names/app1/.app.toml
@@ -1,0 +1,9 @@
+name = "app1"
+
+[[Task]]
+  name = "check"
+  command = [ "./check.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]

--- a/pkg/baur/testdata/duplicate_app_names/app2/.app.toml
+++ b/pkg/baur/testdata/duplicate_app_names/app2/.app.toml
@@ -1,0 +1,9 @@
+name = "app1"
+
+[[Task]]
+  name = "build"
+  command = [ "./build.sh" ]
+
+  [Task.Input]
+    [[Task.Input.Files]]
+      paths = ["**"]


### PR DESCRIPTION
```
loader: use maps.Values() function

-------------------------------------------------------------------------------
loader: fail if app names are not unique

Having multiple apps with the same app name is error prone.
When configuration files are loaded and the specifier is not
app-specific, fail if multiple app configs are found that use the same
app name value.

When loader specifiers are passed that are specific for an app like a
task id or "<APP-NAME>.*" multiple app configs defining the same app
name are not found. This is because the loader aborts the search as soon
as the wanted app is found.

-------------------------------------------------------------------------------
fs: remove duplicate code

call RealPath() from RealPathRel() instead of duplicating it's code

-------------------------------------------------------------------------------
```