### PR TITLE
commands: replace --csv flags with --format

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -29,7 +29,7 @@ func runInitDb(t *testing.T) {
 	initDb(initDbCmd, nil)
 }
 
-// baurCSVLsApps runs "baur ls apps --csv" and returns a slice where each
+// baurCSVLsApps runs "baur ls apps --format=csv" and returns a slice where each
 // element is a slice of csv fields per line
 func baurCSVLsApps(t *testing.T) [][]string {
 	t.Helper()
@@ -47,7 +47,7 @@ func baurCSVLsApps(t *testing.T) [][]string {
 	return statusOut
 }
 
-// baurCSVLsInputs runs "baur ls inputs --csv" and returns the list of files as
+// baurCSVLsInputs runs "baur ls inputs --format=csv" and returns the list of files as
 // string slice. args is passed as argument to the "baur ls inputs" command.
 func baurCSVLsInputs(t *testing.T, args ...string) []string {
 	t.Helper()
@@ -55,7 +55,7 @@ func baurCSVLsInputs(t *testing.T, args ...string) []string {
 	stdoutBuf, _ := interceptCmdOutput(t)
 
 	lsInputsCmd := newLsInputsCmd()
-	lsInputsCmd.csv = true
+	lsInputsCmd.format.Val = "csv"
 
 	lsInputsCmd.Command.Run(&lsInputsCmd.Command, args)
 
@@ -75,7 +75,7 @@ func baurCSVStatusCmd(t *testing.T, cmd *statusCmd) []*csvStatus {
 
 	stdoutBuf, _ := interceptCmdOutput(t)
 
-	cmd.format = &flag.Format{Val: flag.FormatCSV}
+	cmd.format.Val = "csv"
 	cmd.quiet = true
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -97,12 +97,12 @@ func baurCSVStatusCmd(t *testing.T, cmd *statusCmd) []*csvStatus {
 	return result
 }
 
-// baurCSVStatus runs "baur status --csv" and returns the result.
+// baurCSVStatus runs "baur status --format=csv" and returns the result.
 func baurCSVStatus(t *testing.T, inputStr []string, lookupInputStr string) []*csvStatus {
 	t.Helper()
 
 	statusCmd := newStatusCmd()
-	statusCmd.csv = true
+	statusCmd.format.Val = "csv"
 	statusCmd.quiet = true
 	statusCmd.inputStr = inputStr
 	statusCmd.lookupInputStr = lookupInputStr

--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -378,7 +378,7 @@ func TestDifferencesOutputWithCorrectState(t *testing.T) {
 
 	stdoutBuf, _ := interceptCmdOutput(t)
 	diffInputsCmd := newDiffInputsCmd()
-	diffInputsCmd.csv = true
+	diffInputsCmd.format.Val = "csv"
 	diffInputsCmd.quiet = true
 	diffInputsCmd.SetArgs([]string{fmt.Sprintf("%s^^", appOneWithBuildTask), fmt.Sprintf("%s^", appOneWithBuildTask)})
 	execCheck(t, diffInputsCmd, -1)
@@ -405,7 +405,7 @@ func TestInputStringsAreAppliedToFirstArg(t *testing.T) {
 
 	stdoutBuf, _ := interceptCmdOutput(t)
 	diffInputsCmd := newDiffInputsCmd()
-	diffInputsCmd.csv = true
+	diffInputsCmd.format.Val = "csv"
 	diffInputsCmd.quiet = true
 	diffInputsCmd.inputStr = []string{"hello"}
 	diffInputsCmd.SetArgs([]string{appOneWithBuildTask, appTwoWithBuildTask})

--- a/internal/command/flag/format.go
+++ b/internal/command/flag/format.go
@@ -1,57 +1,21 @@
 package flag
 
-import (
-	"errors"
-	"fmt"
-	"strings"
-
-	"github.com/spf13/cobra"
-)
-
 const (
-	FormatCSV   = "csv"
-	FormatJSON  = "json"
-	FormatPlain = "plain"
+	FormatFlagName = "format"
+	FormatCSV      = "csv"
+	FormatJSON     = "json"
+	FormatPlain    = "plain"
 )
-
-const formatUsage = "one of: " + FormatCSV + ", " + FormatJSON + ", " + FormatPlain
 
 type Format struct {
 	Val string
 }
 
-func NewFormatFlag() *Format {
-	return &Format{Val: FormatPlain}
-}
-
-// Set parses the passed string and sets the SortFlagValue
-func (f *Format) Set(val string) error {
-	switch v := strings.ToLower(val); v {
-	case FormatPlain, FormatJSON, FormatCSV:
-		f.Val = v
-	default:
-		return errors.New("format must be " + formatUsage)
-	}
-
-	return nil
-}
-
-func (f *Format) String() string {
-	return f.Val
-}
-
-func (f *Format) Type() string {
-	return "FORMAT"
-}
-
-func (f *Format) Usage(highlightFn func(a ...any) string) string {
-	return fmt.Sprintf("output format\none of: %s, %s, %s",
-		highlightFn(FormatCSV), highlightFn(FormatJSON), highlightFn(FormatPlain),
+func NewFormatFlag() *OneOf {
+	return NewOneOfFlag(
+		FormatFlagName,
+		FormatPlain,
+		"output format",
+		FormatCSV, FormatJSON, FormatPlain,
 	)
-}
-
-func (f *Format) RegisterFlagCompletion(cmd *cobra.Command) error {
-	return cmd.RegisterFlagCompletionFunc("format", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-		return []string{FormatCSV, FormatJSON, FormatPlain}, cobra.ShellCompDirectiveDefault
-	})
 }

--- a/internal/command/flag/oneof.go
+++ b/internal/command/flag/oneof.go
@@ -1,0 +1,93 @@
+package flag
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+
+	"github.com/simplesurance/baur/v3/internal/set"
+
+	"github.com/spf13/cobra"
+)
+
+// OneOf is a command line flag that accepts one of multiple possible values.
+type OneOf struct {
+	Val       string
+	supported set.Set[string]
+	flagName  string
+	usage     string
+}
+
+func NewOneOfFlag(flagName, defaultVal, usage string, supportedVals ...string) *OneOf {
+	for _, v := range supportedVals {
+		if !isLower(v) {
+			panic(fmt.Sprintf("oneOf flag values must be lowercase, got: %q", v))
+		}
+	}
+
+	return &OneOf{
+		flagName:  flagName,
+		Val:       defaultVal,
+		supported: set.From(supportedVals),
+		usage:     usage,
+	}
+}
+
+func (f *OneOf) Set(val string) error {
+	sl := strings.ToLower(val)
+	if !f.supported.Contains(sl) {
+		sortedVals := f.supported.Slice()
+		slices.Sort(sortedVals)
+		return fmt.Errorf("%s must be one of: %s",
+			f.flagName, strings.Join(sortedVals, ", "))
+	}
+
+	f.Val = sl
+	return nil
+}
+
+func (f *OneOf) Value() string {
+	return f.Val
+}
+
+func (f *OneOf) String() string {
+	return f.Val
+}
+
+func (f *OneOf) Type() string {
+	return strings.ToUpper(f.flagName)
+}
+
+func (f *OneOf) Usage(highlightFn func(a ...any) string) string {
+	var res strings.Builder
+	res.WriteString(f.usage)
+	res.WriteRune('\n')
+	res.WriteString("one of: ")
+
+	var cnt int
+	for v := range f.supported {
+		res.WriteString(highlightFn(v))
+		cnt++
+		if len(f.supported) > cnt {
+			res.WriteString(", ")
+		}
+	}
+
+	return res.String()
+}
+
+func (f *OneOf) RegisterFlagCompletion(cmd *cobra.Command) error {
+	return cmd.RegisterFlagCompletionFunc(f.flagName, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return f.supported.Slice(), cobra.ShellCompDirectiveDefault
+	})
+}
+
+func isLower(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLower(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/command/ls_apps.go
+++ b/internal/command/ls_apps.go
@@ -28,7 +28,7 @@ type lsAppsCmd struct {
 	quiet    bool
 	absPaths bool
 	fields   *flag.Fields
-	format   *flag.Format
+	format   *flag.OneOf
 }
 
 func newLsAppsCmd() *lsAppsCmd {
@@ -55,7 +55,7 @@ func newLsAppsCmd() *lsAppsCmd {
 
 	cmd.Run = cmd.run
 
-	cmd.Flags().Var(cmd.format, "format", cmd.format.Usage(term.Highlight))
+	cmd.Flags().Var(cmd.format, flag.FormatFlagName, cmd.format.Usage(term.Highlight))
 	_ = cmd.format.RegisterFlagCompletion(&cmd.Command)
 
 	cmd.Flags().BoolVar(&cmd.csv, "csv", false,

--- a/internal/command/ls_apps_test.go
+++ b/internal/command/ls_apps_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/testutils/gittest"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +22,7 @@ func TestLsAppsJSON(t *testing.T) {
 	gittest.CreateRepository(t, repoDir)
 
 	lsAppsCmd := newLsAppsCmd()
-	lsAppsCmd.format = &flag.Format{Val: flag.FormatJSON}
+	lsAppsCmd.format.Val = "json"
 	stdoutBuf, _ := interceptCmdOutput(t)
 	require.NoError(t, lsAppsCmd.Execute())
 

--- a/internal/command/ls_inputs_test.go
+++ b/internal/command/ls_inputs_test.go
@@ -27,7 +27,7 @@ func TestLsInputsTaskAndRunInputsAreTheSame(t *testing.T) {
 	stdout, _ := interceptCmdOutput(t)
 
 	lsInputsCmd := newLsInputsCmd()
-	lsInputsCmd.SetArgs([]string{"--csv", "--digests", taskSpec})
+	lsInputsCmd.SetArgs([]string{"--format=csv", "--digests", taskSpec})
 	err := lsInputsCmd.Execute()
 	require.NoError(t, err)
 
@@ -37,7 +37,7 @@ func TestLsInputsTaskAndRunInputsAreTheSame(t *testing.T) {
 	runCmd.run(&runCmd.Command, []string{taskSpec})
 
 	stdout.Reset()
-	lsInputsCmd.SetArgs([]string{"--csv", "--digests", "1"})
+	lsInputsCmd.SetArgs([]string{"--format=csv", "--digests", "1"})
 	err = lsInputsCmd.Execute()
 	require.NoError(t, err)
 

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -16,7 +16,6 @@ type lsOutputsCmd struct {
 	cobra.Command
 
 	quiet  bool
-	csv    bool
 	format *flag.OneOf
 }
 
@@ -40,18 +39,8 @@ func newLsOutputsCmd() *lsOutputsCmd {
 	cmd.Flags().Var(cmd.format, flag.FormatFlagName, cmd.format.Usage(term.Highlight))
 	_ = cmd.format.RegisterFlagCompletion(&cmd.Command)
 
-	cmd.Flags().BoolVar(&cmd.csv, "csv", false,
-		"show output in RFC4180 CSV format")
-	_ = cmd.Flags().MarkDeprecated("csv", "use --format=csv instead")
-
 	cmd.Flags().BoolVarP(&cmd.quiet, "quiet", "q", false,
 		"only show the URIs of the outputs in plain and csv format")
-
-	cmd.PreRun = func(*cobra.Command, []string) {
-		if cmd.csv {
-			cmd.format.Val = flag.FormatCSV
-		}
-	}
 
 	return &cmd
 }

--- a/internal/command/ls_outputs.go
+++ b/internal/command/ls_outputs.go
@@ -17,7 +17,7 @@ type lsOutputsCmd struct {
 
 	quiet  bool
 	csv    bool
-	format *flag.Format
+	format *flag.OneOf
 }
 
 func init() {
@@ -37,7 +37,7 @@ func newLsOutputsCmd() *lsOutputsCmd {
 
 	cmd.Run = cmd.run
 
-	cmd.Flags().Var(cmd.format, "format", cmd.format.Usage(term.Highlight))
+	cmd.Flags().Var(cmd.format, flag.FormatFlagName, cmd.format.Usage(term.Highlight))
 	_ = cmd.format.RegisterFlagCompletion(&cmd.Command)
 
 	cmd.Flags().BoolVar(&cmd.csv, "csv", false,

--- a/internal/command/ls_runs_test.go
+++ b/internal/command/ls_runs_test.go
@@ -29,7 +29,7 @@ func TestLsRunsHasInput(t *testing.T) {
 
 	stdoutBuf, _ := interceptCmdOutput(t)
 	lsRunsCmd := newLsRunsCmd()
-	lsRunsCmd.csv = true
+	lsRunsCmd.format.Val = "csv"
 
 	relAppCfgPath, err := filepath.Rel(r.Dir, app.FilePath())
 	require.NoError(t, err)

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -286,14 +286,14 @@ func TestEnvVarInput_Required(t *testing.T) {
 			stdout, _ = interceptCmdOutput(t)
 			statusCmd := newStatusCmd()
 			statusCmd.SetArgs([]string{
-				"--csv", "-q", "-f", "run-id", fmt.Sprintf("%s.%s", appName, taskName)},
+				"--format=csv", "-q", "-f", "run-id", fmt.Sprintf("%s.%s", appName, taskName)},
 			)
 			require.NoError(t, statusCmd.Execute())
 			runID := strings.TrimSpace(stdout.String())
 
 			stdout, stderr := interceptCmdOutput(t)
 			lsInputsCmd := newLsInputsCmd()
-			lsInputsCmd.SetArgs([]string{"--csv", runID})
+			lsInputsCmd.SetArgs([]string{"--format=csv", runID})
 			require.NoError(t, lsInputsCmd.Execute())
 			assert.Contains(t, stdout.String(), "$"+envVarName, "env var is missing in 'ls inputs' output")
 

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -41,7 +41,6 @@ func init() {
 type statusCmd struct {
 	cobra.Command
 
-	csv                     bool
 	quiet                   bool
 	absPaths                bool
 	inputStr                []string
@@ -86,12 +85,6 @@ func newStatusCmd() *statusCmd {
 	cmd.Flags().Var(cmd.format, flag.FormatFlagName, cmd.format.Usage(term.Highlight))
 	_ = cmd.format.RegisterFlagCompletion(&cmd.Command)
 
-	cmd.Flags().BoolVar(&cmd.csv, "csv", false,
-		"output status in RFC4180 CSV format")
-	_ = cmd.Flags().MarkDeprecated("csv", "use --format=csv instead")
-
-	cmd.MarkFlagsMutuallyExclusive("format", "csv")
-
 	cmd.Flags().BoolVarP(&cmd.quiet, "quiet", "q", false,
 		"suppress printing a header and progress dots")
 
@@ -112,12 +105,6 @@ func newStatusCmd() *statusCmd {
 
 	cmd.Flags().BoolVarP(&cmd.requireCleanGitWorktree, flagNameRequireCleanGitWorktree, "c", false,
 		"fail if the git repository contains modified or untracked files")
-
-	cmd.PreRun = func(*cobra.Command, []string) {
-		if cmd.csv {
-			cmd.format.Val = flag.FormatCSV
-		}
-	}
 
 	return &cmd
 }

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -49,7 +49,7 @@ type statusCmd struct {
 	buildStatus             flag.TaskStatus
 	fields                  *flag.Fields
 	requireCleanGitWorktree bool
-	format                  *flag.Format
+	format                  *flag.OneOf
 }
 
 func newStatusCmd() *statusCmd {
@@ -83,7 +83,7 @@ func newStatusCmd() *statusCmd {
 	}
 	cmd.Run = cmd.run
 
-	cmd.Flags().Var(cmd.format, "format", cmd.format.Usage(term.Highlight))
+	cmd.Flags().Var(cmd.format, flag.FormatFlagName, cmd.format.Usage(term.Highlight))
 	_ = cmd.format.RegisterFlagCompletion(&cmd.Command)
 
 	cmd.Flags().BoolVar(&cmd.csv, "csv", false,

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/simplesurance/baur/v3/internal/command/flag"
 	"github.com/simplesurance/baur/v3/internal/testutils/dbtest"
 	"github.com/simplesurance/baur/v3/internal/testutils/fstest"
 	"github.com/simplesurance/baur/v3/internal/testutils/gittest"
@@ -265,7 +264,7 @@ func TestStatusJson(t *testing.T) {
 	t.Run("default fields", func(t *testing.T) {
 		initTest(t)
 		statusCmd := newStatusCmd()
-		statusCmd.format = &flag.Format{Val: flag.FormatJSON}
+		statusCmd.format.Val = "json"
 		stdoutBuf, _ := interceptCmdOutput(t)
 		require.NoError(t, statusCmd.Execute())
 
@@ -284,7 +283,7 @@ func TestStatusJson(t *testing.T) {
 	t.Run("custom fields", func(t *testing.T) {
 		initTest(t)
 		statusCmd := newStatusCmd()
-		statusCmd.format = &flag.Format{Val: flag.FormatJSON}
+		statusCmd.format.Val = "json"
 		require.NoError(t, statusCmd.fields.Set("app-name,git-commit"))
 		statusCmd.SetArgs([]string{"app3.check"})
 		stdoutBuf, _ := interceptCmdOutput(t)

--- a/internal/command/upgrade_configs_test.go
+++ b/internal/command/upgrade_configs_test.go
@@ -56,7 +56,7 @@ func TestUpgrade(t *testing.T) {
 
 	stdoutBuf.Truncate(0)
 	statusCmd := newStatusCmd()
-	statusCmd.format = &flag.Format{Val: flag.FormatCSV}
+	statusCmd.format.Val = "csv"
 	statusCmd.quiet = true
 	statusCmd.fields = &flag.Fields{Fields: []string{statusTaskIDParam}}
 	statusCmd.Run(&statusCmd.Command, nil)


### PR DESCRIPTION
```
commands: replace --csv flags with --format

- replace --csv flag in all commans with --format=csv
- remove the deprecated --csv flags

-------------------------------------------------------------------------------
command: introduce OneOf flag

Refactor the implementation of the format flag to be a generic OneOf
string flag.
This will allow to reuse it for format flag parameters that only support
a subset of formats.

-------------------------------------------------------------------------------
```