### PR TITLE
ls runs: fix: before and after times without TZ are in UTC

### DIFF
--- a/internal/command/flag/datetime.go
+++ b/internal/command/flag/datetime.go
@@ -31,9 +31,9 @@ func (v *DateTimeFlagValue) Set(timeStr string) error {
 	var t time.Time
 	var err error
 
-	t, err = time.Parse(DateTimeFormat, timeStr)
+	t, err = time.ParseInLocation(DateTimeFormat, timeStr, time.Local)
 	if err != nil {
-		t, err = time.Parse(DateTimeFormatTz, timeStr)
+		t, err = time.ParseInLocation(DateTimeFormatTz, timeStr, time.Local)
 		if err != nil {
 			return err
 		}

--- a/internal/command/flag/datetime_test.go
+++ b/internal/command/flag/datetime_test.go
@@ -1,0 +1,38 @@
+package flag
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDateTimeFlagValueSetWithoutTZIsInLocalTimezone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// test fails on windows because dt.Location().String() returns
+		// "local" instead of "Pacific/Samoa".
+		// A possible fix would be to check the time offset instead of
+		// the tz name.
+		t.Skip("test not adapted for windows")
+	}
+	const locName = "Pacific/Samoa"
+	loc, err := time.LoadLocation(locName)
+	require.NoError(t, err)
+
+	t.Setenv("TZ", locName)
+
+	dt := DateTimeFlagValue{}
+	err = dt.Set(DateTimeFormat)
+	require.NoError(t, err)
+	assert.Equal(t, loc.String(), dt.Location().String())
+}
+
+func TestDateTimeFlagWithTimezone(t *testing.T) {
+	dt := DateTimeFlagValue{}
+	err := dt.Set("2019.01.02-09:08:21-MUT")
+	require.NoError(t, err)
+
+	assert.Equal(t, "MUT", dt.Location().String())
+}

--- a/internal/command/ls.go
+++ b/internal/command/ls.go
@@ -6,7 +6,7 @@ import (
 
 var lsCmd = &cobra.Command{
 	Use:   "ls",
-	Short: "list apps, builds, inputs",
+	Short: "list apps, runs, inputs",
 }
 
 func init() {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -156,7 +156,8 @@ type Storer interface {
 	Inputs(ctx context.Context, taskRunID int) (*Inputs, error)
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
 
-	// CreateRelease creates a new release called releaseName, that consists of the the passed task runs.
+	// CreateRelease creates a new release called releaseName, that
+	// consists of the passed task runs.
 	// Metadata is arbitrary data stored together with the release, it is
 	// optional and can be nil.
 	CreateRelease(_ context.Context, releaseName string, taskRunIDs []int, metadata io.Reader) error
@@ -170,6 +171,6 @@ type Storer interface {
 	ReleaseTaskRuns(ctx context.Context, releaseName string) ([]*ReleaseTaskRunsResult, error)
 	// ReleaseMetadata returns the metadata of a release.
 	// If the release does not exist ErrNotExist is returned.
-	// If the release has no metadata the returned []byte  is empty.
+	// If the release has no metadata the returned []byte is empty.
 	ReleaseMetadata(ctx context.Context, releaseName string) ([]byte, error)
 }


### PR DESCRIPTION
storage: fix: minor issues in godoc

-------------------------------------------------------------------------------
ls: replace "builds" with "runs" in usage

-------------------------------------------------------------------------------
ls runs: fix: before and after times without TZ are in UTC

When timestamps are passed to the --before or --after flags they are
interpreted as being in the UTC timezone instead in local time.

-------------------------------------------------------------------------------