### PR TITLE
support cleaning up old releases

### DIFF
--- a/internal/command/flag/datetime.go
+++ b/internal/command/flag/datetime.go
@@ -19,6 +19,7 @@ const (
 // DateTimeFlagValue is the DateTime pflag flag
 type DateTimeFlagValue struct {
 	time.Time
+	IsSet bool
 }
 
 // String returns the default value in the usage output
@@ -40,6 +41,7 @@ func (v *DateTimeFlagValue) Set(timeStr string) error {
 	}
 
 	v.Time = t
+	v.IsSet = true
 
 	return nil
 }

--- a/internal/command/flag/datetime.go
+++ b/internal/command/flag/datetime.go
@@ -19,7 +19,6 @@ const (
 // DateTimeFlagValue is the DateTime pflag flag
 type DateTimeFlagValue struct {
 	time.Time
-	IsSet bool
 }
 
 // String returns the default value in the usage output
@@ -41,7 +40,6 @@ func (v *DateTimeFlagValue) Set(timeStr string) error {
 	}
 
 	v.Time = t
-	v.IsSet = true
 
 	return nil
 }

--- a/internal/command/release_create.go
+++ b/internal/command/release_create.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/simplesurance/baur/v4/internal/command/term"
 	"github.com/simplesurance/baur/v4/internal/log"
@@ -141,7 +142,7 @@ func (c *releaseCreateCmd) run(cmd *cobra.Command, args []string) {
 		metadataReader = fd
 	}
 
-	err = storageClt.CreateRelease(ctx, releaseName, runIDs, metadataReader)
+	err = storageClt.CreateRelease(ctx, releaseName, time.Now(), runIDs, metadataReader)
 	if errors.Is(err, storage.ErrExists) {
 		stderr.PrintErrf("release with name %q already exists, release names must be unique\n", releaseName)
 		exitFunc(exitCodeAlreadyExist)

--- a/internal/command/upgrade_db_test.go
+++ b/internal/command/upgrade_db_test.go
@@ -64,5 +64,5 @@ func TestUpgradeDb(t *testing.T) {
 	upgradeDbCmd := newUpgradeDatabaseCmd()
 	upgradeDbCmd.Command.Run(&upgradeDbCmd.Command, nil)
 
-	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 3")
+	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 4")
 }

--- a/pkg/storage/postgres/migrations/4.sql
+++ b/pkg/storage/postgres/migrations/4.sql
@@ -1,0 +1,3 @@
+ALTER TABLE release ADD COLUMN created_at timestamp with time zone;
+UPDATE release SET created_at = now();
+ALTER TABLE release ALTER COLUMN created_at SET NOT NULL;

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -17,7 +17,7 @@ import (
 )
 
 // schemaVer is the database schema version required by this package.
-const schemaVer int32 = 3
+const schemaVer int32 = 4
 
 // migration represents a database schema migration.
 type migration struct {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -124,6 +124,9 @@ type TaskRunsDeleteResult struct {
 	DeletedInputs   int64
 	DeletedVCS      int64
 }
+type ReleasesDeleteResult struct {
+	DeletedReleases int64
+}
 
 // Storer is an interface for storing and retrieving baur task runs
 type Storer interface {
@@ -168,10 +171,9 @@ type Storer interface {
 	Outputs(ctx context.Context, taskRunID int) ([]*Output, error)
 
 	// CreateRelease creates a new release called releaseName, that
-	// consists of the passed task runs.
-	// Metadata is arbitrary data stored together with the release, it is
-	// optional and can be nil.
-	CreateRelease(_ context.Context, releaseName string, taskRunIDs []int, metadata io.Reader) error
+	// consists of the passed task runs. Metadata is arbitrary data stored
+	// together with the release, it is optional and can be nil.
+	CreateRelease(_ context.Context, releaseName string, createdAt time.Time, taskRunIDs []int, metadata io.Reader) error
 	ReleaseExists(_ context.Context, name string) (bool, error)
 	// ReleaseTaskRuns the task runs and their outputs for the release
 	// named releaseName.
@@ -184,4 +186,5 @@ type Storer interface {
 	// If the release does not exist ErrNotExist is returned.
 	// If the release has no metadata the returned []byte is empty.
 	ReleaseMetadata(ctx context.Context, releaseName string) ([]byte, error)
+	ReleasesDelete(ctx context.Context, before time.Time, pretend bool) (*ReleasesDeleteResult, error)
 }


### PR DESCRIPTION
```
support cleaning up old releases

- change the "db cleanup" command syntax to accept a positional argument
  to specify if releases or tasks should be deleted,
- rename the --task-runs-before parameter to --before
- implement ad DeletedReleases method for the psql storage client, that
  works analogous to DeletedTaskRuns

-------------------------------------------------------------------------------
add created_at timestamp to release table

This will allow to cleanup releases that are older then X.

For all existing releases the created_at timestamp is set to the current
timestamp.
```