### PR TITLE
baur cleanup db: speed up deletion

### DIFF
--- a/internal/command/cleanup_db.go
+++ b/internal/command/cleanup_db.go
@@ -118,7 +118,7 @@ func (c *cleanupDbCmd) run(cmd *cobra.Command, args []string) {
 	}
 
 	stdout.Printf(
-		"%s %s older then %s",
+		"%s %s older than %s",
 		op, subject,
 		term.Highlight(c.before.Format(timeFormat)),
 	)

--- a/pkg/storage/postgres/delete.go
+++ b/pkg/storage/postgres/delete.go
@@ -106,9 +106,10 @@ func (*Client) deleteOldTaskRuns(ctx context.Context, tx pgx.Tx, before time.Tim
 	const query = `
 	      DELETE FROM task_run
 	       WHERE start_timestamp < $1
-	        AND task_run.id NOT IN (
-			SELECT task_run_id FROM release_task_run
-		)
+	         AND NOT EXISTS (
+			SELECT 1 FROM release_task_run
+			 WHERE task_run.id = release_task_run.task_run_id
+	       )
 	`
 
 	t, err := tx.Exec(ctx, query, before)

--- a/pkg/storage/postgres/delete.go
+++ b/pkg/storage/postgres/delete.go
@@ -186,9 +186,9 @@ func (*Client) deleteUnusedUploads(ctx context.Context, tx pgx.Tx) (int64, error
 func (*Client) deleteUnusedVCS(ctx context.Context, tx pgx.Tx) (int64, error) {
 	const query = `
 		DELETE FROM vcs
-	 	 WHERE id NOT IN (
-			 SELECT task_run.vcs_id
-			   FROM task_run
+	 	 WHERE NOT EXISTS (
+			 SELECT 1 FROM task_run
+			  WHERE vcs.id = task_run.vcs_id
 		 )
 		`
 	t, err := tx.Exec(ctx, query)

--- a/pkg/storage/postgres/delete.go
+++ b/pkg/storage/postgres/delete.go
@@ -123,8 +123,9 @@ func (*Client) deleteOldTaskRuns(ctx context.Context, tx pgx.Tx, before time.Tim
 func (*Client) deleteUnusedTasks(ctx context.Context, tx pgx.Tx) (int64, error) {
 	const query = `
 		DELETE FROM task
-	 	 WHERE id NOT IN (
-			 SELECT task_run.task_id FROM task_run
+	 	 WHERE NOT EXISTS (
+			SELECT 1 FROM task_run
+			 WHERE task.id = task_run.task_id
 		 )
 		`
 	t, err := tx.Exec(ctx, query)

--- a/pkg/storage/postgres/delete.go
+++ b/pkg/storage/postgres/delete.go
@@ -203,9 +203,9 @@ func (*Client) deleteUnusedInputs(ctx context.Context, tx pgx.Tx) (int64, error)
 	var cnt int64
 	const qInputFiles = `
 		DELETE FROM input_file
-	 	 WHERE id NOT IN (
-			 SELECT task_run_file_input.input_file_id
-			   FROM task_run_file_input
+	 	 WHERE NOT EXISTS (
+			SELECT 1 FROM task_run_file_input
+			 WHERE input_file.id = task_run_file_input.input_file_id
 		 )
 		`
 	t, err := tx.Exec(ctx, qInputFiles)


### PR DESCRIPTION
On big databases "baur cleanup db" is running hours.
This PR introduces multiple changes to speed up the deletion.
See the commit messages for details.