### PR TITLE
run: fix: run not aborted when task execution fails

### DIFF
--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -369,3 +369,56 @@ func TestRunFailsWhenGitWorktreeIsDirty(t *testing.T) {
 	require.Contains(t, stderrBuf.String(), fname)
 	require.Contains(t, stderrBuf.String(), "expecting only tracked unmodified files")
 }
+
+func TestRunAbortsAfterError(t *testing.T) {
+	initTest(t)
+	r := repotest.CreateBaurRepository(t, repotest.WithNewDB())
+
+	appCfg := cfg.App{
+		Name: "testapp",
+		Tasks: cfg.Tasks{
+			{
+				Name:    "build",
+				Command: []string{"bash", "-c", "exit 1"},
+				Input: cfg.Input{
+					Files: []cfg.FileInputs{
+						{Paths: []string{".app.toml"}},
+					},
+				},
+			},
+			{
+				Name:    "xbuild",
+				Command: []string{"bash", "-c", "exit 0"},
+				Input: cfg.Input{
+					Files: []cfg.FileInputs{
+						{Paths: []string{".app.toml"}},
+					},
+				},
+			},
+		},
+	}
+
+	err := appCfg.ToFile(filepath.Join(r.Dir, ".app.toml"))
+	require.NoError(t, err)
+
+	doInitDb(t)
+
+	runCmdTest := newRunCmd()
+	_, stderr := interceptCmdOutput(t)
+
+	oldExitFunc := exitFunc
+	var exitCode int
+	exitFunc = func(code int) {
+		exitCode = code
+	}
+	t.Cleanup(func() {
+		exitFunc = oldExitFunc
+	})
+
+	err = runCmdTest.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, 1, exitCode)
+
+	assert.Contains(t, stderr.String(), "terminating, skipping execution of queued task runs")
+	assert.Contains(t, stderr.String(), "testapp.xbuild: execution skipped")
+}

--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -245,14 +245,14 @@ func (c *Cmd) Run(ctx context.Context) (*Result, error) {
 		Command:  cmd.String(),
 		Dir:      cmd.Dir,
 		ExitCode: cmd.ProcessState.ExitCode(),
-		success:  cmd.ProcessState.Success(),
+		Success:  cmd.ProcessState.Success(),
 		stdout:   &stdoutPss,
 		stderr:   &stderrPss,
 		ee:       ee,
 	}
 	c.logf("command terminated with exit code: %d\n", result.ExitCode)
 
-	if c.expectSuccess && !result.success {
+	if c.expectSuccess && !result.Success {
 		return nil, &ExitCodeError{Result: &result}
 	}
 

--- a/internal/exec/command_test.go
+++ b/internal/exec/command_test.go
@@ -25,7 +25,7 @@ func TestCombinedStdoutOutput(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 0, res.ExitCode, "exit code is not 0")
-	assert.True(t, res.success, "result.succces is not true")
+	assert.True(t, res.Success, "result.succces is not true")
 	assert.Nil(t, res.ExpectSuccess(), "expect success returns an error") //nolint:testifylint
 	assert.Equal(t, echoStr, res.StrOutput())
 }

--- a/internal/exec/result.go
+++ b/internal/exec/result.go
@@ -66,7 +66,7 @@ type Result struct {
 	Dir      string
 	ExitCode int
 	ee       *exec.ExitError
-	success  bool
+	Success  bool
 
 	stdout *prefixSuffixSaver
 	stderr *prefixSuffixSaver
@@ -75,7 +75,7 @@ type Result struct {
 // ExpectSuccess the command did not execute successful
 // (e.g. exit code != 0 on unix), a ExitCodeError is returned.
 func (r *Result) ExpectSuccess() error {
-	if !r.success {
+	if !r.Success {
 		return &ExitCodeError{Result: r}
 	}
 

--- a/pkg/baur/taskrunner.go
+++ b/pkg/baur/taskrunner.go
@@ -90,6 +90,9 @@ func (t *TaskRunner) createTaskInfoEnv(ctx context.Context, task *Task) ([]strin
 // Run executes the command of a task and returns the execution result.
 // The output of the commands are logged with debug log level.
 func (t *TaskRunner) Run(task *Task) (*RunResult, error) {
+	if t.SkipRunsIsEnabled() {
+		return nil, ErrTaskRunSkipped
+	}
 	if t.GitUntrackedFilesFn != nil {
 		untracked, err := t.GitUntrackedFilesFn(task.RepositoryRoot)
 		if err != nil {


### PR DESCRIPTION
baur does not terminate when it runs multiple tasks and the execution of one failed.
This is the intended behavior but the check in the TaskRunner is missing, add it.


Closes #609 