### PR TITLE
upgrade configs: succeed with a clear message when cfgs are up to date

### DIFF
--- a/internal/command/upgrade_configs.go
+++ b/internal/command/upgrade_configs.go
@@ -34,7 +34,16 @@ func (c *upgradeConfigsCmd) run(_ *cobra.Command, _ []string) {
 	cwd, err := os.Getwd()
 	exitOnErr(err)
 
-	err = baur.NewCfgUpgrader(cwd).Upgrade()
+	upgrader := baur.NewCfgUpgrader(cwd)
+
+	uptodate, err := upgrader.IsUpToDate()
+	exitOnErr(err)
+	if uptodate {
+		stdout.Println("configuration files are up to date, nothing to do")
+		return
+	}
+
+	err = upgrader.Upgrade()
 	exitOnErr(err)
 
 	stdout.Println("configuration files upgraded successfully")

--- a/pkg/baur/cfgupgrade.go
+++ b/pkg/baur/cfgupgrade.go
@@ -55,6 +55,17 @@ func (u *CfgUpgrader) Upgrade() error {
 	return nil
 }
 
+// IsUpToDate returns true if the configuration are up to date.
+func (u *CfgUpgrader) IsUpToDate() (bool, error) {
+	p := filepath.Join(u.repoRootDir, RepositoryCfgFile)
+	repoCfg, err := cfg.RepositoryFromFile(p)
+	if err != nil {
+		return false, fmt.Errorf("loading repository config %q failed: %w", p, err)
+	}
+
+	return repoCfg.ConfigVersion == cfg.Version, nil
+}
+
 func (u *CfgUpgrader) upgradeCfgVersion(repoCfgPath string) error {
 	oldRepoCfg, err := cfg.RepositoryFromFile(repoCfgPath)
 	if err != nil {


### PR DESCRIPTION
When "baur upgrade configs" is run for configuration files that are in the latest version, the command fails with an error message stating that configs can only be upgraded from version 5 or 6.
Failing when everything is fine is confusing.

Succeed instead and print that the configs are already up to date and nothings needs to be done.