### PR TITLE
cfg: fix: wrong casing of template var and func in example config

### DIFF
--- a/pkg/cfg/app.go
+++ b/pkg/cfg/app.go
@@ -58,7 +58,7 @@ func ExampleApp(name string) *App {
 				Output: Output{
 					File: []FileOutput{
 						{
-							Path: "dist/{{ .appname }}.tar.xz",
+							Path: "dist/{{ .AppName }}.tar.xz",
 							S3Upload: []S3Upload{
 								{
 									Bucket: "go-artifacts/",
@@ -74,11 +74,11 @@ func ExampleApp(name string) *App {
 					},
 					DockerImage: []DockerImageOutput{
 						{
-							IDFile: "{{ .appname }}-container.id",
+							IDFile: "{{ .AppName }}-container.id",
 							RegistryUpload: []DockerImageRegistryUpload{
 								{
 									Repository: "my-company/{{ .AppName }}",
-									Tag:        "{{ ENV BRANCH_NAME }}-{{ gitCommit }}",
+									Tag:        "{{ env BRANCH_NAME }}-{{ gitCommit }}",
 								},
 							},
 						},


### PR DESCRIPTION
The example configuration created by "baur init app" contained 2 mentions with wrong casing of the ".AppName" variable and of the "env" function.

Correct both, function names are all lowercase, variables are PascalCase.