### PR TITLE
resolve/gosource: remove files in GOMODCACHE from discovered inputs

### DIFF
--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -268,8 +268,6 @@ func withoutStdblibAndCacheFiles(result *[]string, env *goEnv, paths []string) e
 			continue
 		}
 
-		// use HasPrefix() + Replace() to ensure we only replace the
-		// path if is the prefix
 		if strings.HasPrefix(abs, env.GoModCache) {
 			abs = strings.Replace(abs, env.GoModCache, "$GOMODCACHE", 1)
 		}

--- a/internal/resolve/gosource/gosource.go
+++ b/internal/resolve/gosource/gosource.go
@@ -81,9 +81,10 @@ func toAbsFilePatternPaths(workDir string, queries []string) {
 
 // Resolve returns the Go source files in the passed directories plus all
 // source files of the imported packages.
-// Testfiles and stdlib dependencies are ignored.
-func (r *Resolver) Resolve(
-	ctx context.Context,
+// Testcase files are ignored when false is passed for withTests.
+// Files in GOROOT (stdlib packages) and in the GOMODCACHE (non-vendored
+// 3. party package dependencies) are omitted from the result.
+func (r *Resolver) Resolve(ctx context.Context,
 	workdir string,
 	environment []string,
 	buildFlags []string,
@@ -232,8 +233,8 @@ func (r *Resolver) resolve(
 	return srcFiles, nil
 }
 
-// sourceFiles returns GoFiles and OtherFiles of the package that are not part
-// of the stdlib
+// sourceFiles returns GoFiles, OtherFiles and EmbedFiles of the package that
+// aren't stored in a Go Cache directory or part of the stdlib.
 func sourceFiles(result *[]string, env *goEnv, pkg *packages.Package) error {
 	err := withoutStdblibAndCacheFiles(result, env, pkg.GoFiles)
 	if err != nil {
@@ -269,7 +270,7 @@ func withoutStdblibAndCacheFiles(result *[]string, env *goEnv, paths []string) e
 		}
 
 		if strings.HasPrefix(abs, env.GoModCache) {
-			abs = strings.Replace(abs, env.GoModCache, "$GOMODCACHE", 1)
+			continue
 		}
 
 		*result = append(*result, abs)

--- a/internal/resolve/gosource/testdata/go_mod_non_vendored_deps/test_config.json
+++ b/internal/resolve/gosource/testdata/go_mod_non_vendored_deps/test_config.json
@@ -11,18 +11,6 @@
 	},
 	"ExpectedResults": [
 		"$TESTDIR/main.go",
-		"$TESTDIR/generator/generator.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/dce.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/doc.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/hash.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/marshal.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/node.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/node_net.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/sql.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/time.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/util.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/uuid.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/version1.go",
-		"$GOMODCACHE/github.com/google/uuid@v1.1.1/version4.go"
+		"$TESTDIR/generator/generator.go"
 	]
 }

--- a/pkg/baur/inputfile.go
+++ b/pkg/baur/inputfile.go
@@ -9,7 +9,8 @@ import (
 
 type InputFileOpt func(*InputFile)
 
-// InputFile represent a file.
+// InputFile represents a file with it's content and executable state,
+// that is required to build the output of a task.
 type InputFile struct {
 	absPath                string
 	repoRelPath            string
@@ -44,9 +45,8 @@ func WithRealpath(repoRelRealPath string) InputFileOpt {
 }
 
 // NewInputFile creates an InputFile.
-// absPath is the absolute path to the file. It is used to create the digest.
-// relPath is a relative path to the file. It is used as part of the digest. To
-// which base path relPath is relative is arbitrary.
+// absPath is the absolute path to the file. It is used as part of it's digest.
+// relPath is a relative path to the file, it is a subset of absPath.
 func NewInputFile(absPath, relPath string, ownerHasExecutablePerm bool, opts ...InputFileOpt) *InputFile {
 	i := InputFile{
 		absPath:                absPath,
@@ -59,12 +59,14 @@ func NewInputFile(absPath, relPath string, ownerHasExecutablePerm bool, opts ...
 	return &i
 }
 
-// String returns RelPath()
+// String returns the relative path of the input.
 func (f *InputFile) String() string {
 	return f.repoRelPath
 }
 
-// RelPath returns the path of the file relative to the baur repository root.
+// RelPath returns the relative path of the file.
+// It is either relative to the baur repository directory or a special path
+// (e.g. is prefixed with $GOMODCACHE).
 func (f *InputFile) RelPath() string {
 	return f.repoRelPath
 }
@@ -76,7 +78,7 @@ func (f *InputFile) AbsPath() string {
 
 // CalcDigest calculates the digest of the file.
 // The Digest is the sha384 sum of the repoRelPath and the content of the file.
-// If neither a file hash functon nor the content digest was provided on
+// If neither a file hash function nor the content digest was provided on
 // construction of f, errors.ErrUnsupported is returned.
 func (f *InputFile) CalcDigest() (*digest.Digest, error) {
 	if f.contentDigest == nil && f.fileHasher == nil {

--- a/pkg/baur/inputfile.go
+++ b/pkg/baur/inputfile.go
@@ -64,9 +64,7 @@ func (f *InputFile) String() string {
 	return f.repoRelPath
 }
 
-// RelPath returns the relative path of the file.
-// It is either relative to the baur repository directory or a special path
-// (e.g. is prefixed with $GOMODCACHE).
+// RelPath returns the baur repository relative path of the file.
 func (f *InputFile) RelPath() string {
 	return f.repoRelPath
 }


### PR DESCRIPTION
This fixes that when the Gosource input resolver is used on a Go
application that uses non-vendored 3. party packages, baur fails with:

  ERROR: [..] evaluating task status failed: Rel: can't make
  $GOMODCACHE/[..] relative to /home/[...]

Imported 3. party packages that aren't vendored are stored by Go in the
GOMODCACHE directory.
When the Gosource resolver resolves a task to sources in the GOMODCACHE,
it replaces the path to the GOMODCACHE in the input file path with
'$GOMODCACHE'. This is done to always have the same reproducible input
files paths, independent of what the actual GOMODCACHE directory is.

The inputresolver afterwards tries to evaluate the repository relative
path of the input file containing the '$GOMODCACHE' which fails with the
error.
The real path to the input file is not known by the inputresolver, which
makes it difficult to track changes in the GOMODCACHE.

Instead of replacing the GOMODCACHE directory in paths, omit returning
files in the GOMODCACHE, same procedure as it is done for stdlib input files.

Instead a task can track and rely on the information in the go.mod or
go.sum files to track changes of 3. party libraries.
If the files in the GOMODCACHE of a downloaded 3. party packages are
modified manually, baur won't notice the change.

Fixes #637 

Follow-up: https://github.com/simplesurance/baur/issues/642