### PR TITLE
ci: update Go version to 1.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Checkout Git
         uses: actions/checkout@v4
       - name: Setup Git
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Checkout Git
         uses: actions/checkout@v4
       - name: Setup Git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simplesurance/baur/v5
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/docker/docker v28.0.0+incompatible // indirect


### PR DESCRIPTION
This commit updates the Go version from 1.24 to 1.25 across all GitHub Actions CI workflows.

Upgrading to the latest Go release ensures that our build and test environments are aligned with the current toolchain. This practice helps to verify compatibility, catch potential regressions early, and enables us to take advantage of new language features, performance improvements, and standard library updates included in Go 1.25.

The change affects the build, lint, and test workflows, ensuring consistent Go versioning across the entire CI pipeline.