### PR TITLE
build: upgrade to go 1.25 and golangci-lint to v2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -19,10 +19,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
+          lint-version: "v2.4"
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: ${{ matrix.lint }}
           args: --timeout 3m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Checkout Git
         uses: actions/checkout@v4
       - name: Setup Git
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Checkout Git
         uses: actions/checkout@v4
       - name: Setup Git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simplesurance/baur/v5
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/docker/docker v28.0.0+incompatible // indirect


### PR DESCRIPTION
This commit updates the Go version from 1.24.6 to 1.25 across all GitHub Actions CI workflows.