### PR TITLE
Fix godoc comment + remove unused interface

### DIFF
--- a/internal/exec/command.go
+++ b/internal/exec/command.go
@@ -70,7 +70,7 @@ func (c *Cmd) Stdout(w io.Writer) *Cmd {
 	return c
 }
 
-// Stdout streams the standard error output to w during execution.
+// Stderr streams the standard error output to w during execution.
 func (c *Cmd) Stderr(w io.Writer) *Cmd {
 	c.stderr = w
 	return c

--- a/pkg/baur/taskrunner.go
+++ b/pkg/baur/taskrunner.go
@@ -24,11 +24,6 @@ func (e *ErrUntrackedGitFilesExist) Error() string {
 // ErrTaskRunSkipped is returned when a task run was skipped instead of executed.
 var ErrTaskRunSkipped = errors.New("task run skipped")
 
-type TaskInfoRetriever interface {
-	Inputs(*Task) (*Inputs, error)
-	Task(id string) (*Task, error)
-}
-
 // TaskRunner executes the command of a task.
 type TaskRunner struct {
 	skipAfterError      bool


### PR DESCRIPTION
- remove unused TaskInfoRetriever interface
- command: fix: godoc starting with wrong method name
