### PR TITLE
ci(golangci-lint): upgrade golangci-lint and update code

### DIFF
--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
-          lint-version: "v2.4"
+          lint-version: "v2.6.1"
       - uses: actions/checkout@v5
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/diff_inputs_test.go
+++ b/internal/command/diff_inputs_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/ls_inputs_test.go
+++ b/internal/command/ls_inputs_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/ls_runs_test.go
+++ b/internal/command/ls_runs_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/command/taskinput_test.go
+++ b/internal/command/taskinput_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package command
 

--- a/internal/fs/fileglob_test.go
+++ b/internal/fs/fileglob_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/simplesurance/baur/v5/internal/testutils/fstest"
-	"github.com/simplesurance/baur/v5/internal/testutils/strtest"
 )
 
 func createFiles(t *testing.T, basedir string, paths []string) {
@@ -45,10 +44,9 @@ func checkFilesInResolvedFiles(t *testing.T, tempdir string, resolvedFiles []str
 			t.Errorf("getting Relpath of %q to %q failed", e, tempdir)
 		}
 
-		if !strtest.InSlice(tc.expectedMatches, relPath) {
-			t.Errorf("%q (%q) was returned but is not in expected return slice (%+v), testcase: %+v",
-				e, relPath, tc.expectedMatches, tc)
-		}
+		assert.Contains(t, tc.expectedMatches, relPath,
+			"%q (%q) was returned but is not in expected return slice (%+v), testcase: %+v",
+			e, relPath, tc.expectedMatches, tc)
 	}
 }
 

--- a/internal/resolve/gosource/gosource_test.go
+++ b/internal/resolve/gosource/gosource_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/simplesurance/baur/v5/internal/log"
 	"github.com/simplesurance/baur/v5/internal/prettyprint"
-	"github.com/simplesurance/baur/v5/internal/testutils/strtest"
 )
 
 type testCfg struct {
@@ -79,15 +79,11 @@ func TestResolve(t *testing.T) {
 			t.Logf("gosources resolved to: %s", prettyprint.AsString(resolvedFiles))
 
 			for _, path := range resolvedFiles {
-				if !strtest.InSlice(testCfg.ExpectedResults, path) {
-					t.Errorf("resolved file contain %q but it's not part of the ExpectedResult slice: %+v", path, testCfg.ExpectedResults)
-				}
+				assert.Contains(t, testCfg.ExpectedResults, path, "unexpected file in result")
 			}
 
 			for _, path := range testCfg.ExpectedResults {
-				if !strtest.InSlice(resolvedFiles, path) {
-					t.Errorf("resolved go source is missing %q in %+v", path, resolvedFiles)
-				}
+				assert.Contains(t, resolvedFiles, path, "resolved go source is missing file")
 			}
 		})
 	}

--- a/internal/resolve/gosource/testdata/query_fileglob_all_test_files_buildtag/generator/generator_test.go
+++ b/internal/resolve/gosource/testdata/query_fileglob_all_test_files_buildtag/generator/generator_test.go
@@ -1,4 +1,4 @@
-//+build generatortest
+//go:build generatortest
 
 package generator
 

--- a/internal/resolve/gosource/testdata/query_fileglob_all_test_files_buildtag/main_test.go
+++ b/internal/resolve/gosource/testdata/query_fileglob_all_test_files_buildtag/main_test.go
@@ -1,4 +1,4 @@
-// +build maintest
+//go:build maintest
 
 package main
 

--- a/internal/testutils/strtest/strtest.go
+++ b/internal/testutils/strtest/strtest.go
@@ -2,6 +2,7 @@
 package strtest
 
 // InSlice returns true if the slice contains the passed string
+//
 // Deprecated: use assert.Contains() instead
 func InSlice(slice []string, wanted string) bool {
 	for _, elem := range slice {

--- a/pkg/storage/postgres/init_test.go
+++ b/pkg/storage/postgres/init_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package postgres
 

--- a/pkg/storage/postgres/insert_test.go
+++ b/pkg/storage/postgres/insert_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package postgres
 

--- a/pkg/storage/postgres/query_test.go
+++ b/pkg/storage/postgres/query_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package postgres
 

--- a/pkg/storage/postgres/schema_test.go
+++ b/pkg/storage/postgres/schema_test.go
@@ -1,5 +1,4 @@
 //go:build dbtest
-// +build dbtest
 
 package postgres
 


### PR DESCRIPTION
This commit upgrades the golangci-lint version in the .github/workflows/golangcilint.yml file from v2.4 to v2.6.1.

This change results in some linting errors that also got handled.