### PR TITLE
Increase `input_file.id` column to `bigint`

### DIFF
--- a/internal/command/upgrade_db_test.go
+++ b/internal/command/upgrade_db_test.go
@@ -64,5 +64,5 @@ func TestUpgradeDb(t *testing.T) {
 	upgradeDbCmd := newUpgradeDatabaseCmd()
 	upgradeDbCmd.Run(&upgradeDbCmd.Command, nil)
 
-	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 5")
+	assert.Contains(t, stdoutBuf.String(), "database schema successfully upgraded from version 1 to 6")
 }

--- a/pkg/storage/postgres/insert.go
+++ b/pkg/storage/postgres/insert.go
@@ -113,6 +113,22 @@ func scanIDs(rows pgx.Rows, res *[]int) error {
 	return rows.Err()
 }
 
+func scanInt64IDs(rows pgx.Rows, res *[]int64) error {
+	for rows.Next() {
+		var id int64
+
+		err := rows.Scan(&id)
+		if err != nil {
+			rows.Close()
+			return err
+		}
+
+		*res = append(*res, id)
+	}
+
+	return rows.Err()
+}
+
 func insertAppIfNotExist(ctx context.Context, db dbConn, appName string) (int, error) {
 	const query = `
 	   INSERT INTO application (name)
@@ -219,7 +235,7 @@ func clonedSortedInputTasks(result []*storage.InputTaskInfo) []*storage.InputTas
 	return result
 }
 
-func insertInputFilesIfNotExist(ctx context.Context, db dbConn, inputs []*storage.InputFile) ([]int, error) {
+func insertInputFilesIfNotExist(ctx context.Context, db dbConn, inputs []*storage.InputFile) ([]int64, error) {
 	const stmt1 = `
            INSERT INTO input_file (path, digest)
 	   VALUES
@@ -249,8 +265,8 @@ func insertInputFilesIfNotExist(ctx context.Context, db dbConn, inputs []*storag
 		return nil, newQueryError(query, err, queryArgs...)
 	}
 
-	ids := make([]int, 0, len(inputs))
-	if err := scanIDs(rows, &ids); err != nil {
+	ids := make([]int64, 0, len(inputs))
+	if err := scanInt64IDs(rows, &ids); err != nil {
 		return nil, newQueryError(query, err, queryArgs...)
 	}
 

--- a/pkg/storage/postgres/insert_test.go
+++ b/pkg/storage/postgres/insert_test.go
@@ -91,3 +91,47 @@ func TestSaveTaskRun(t *testing.T) {
 		})
 	}
 }
+
+func TestSaveTaskRunWithBigIntInputFileID(t *testing.T) {
+	client, cleanupFn := newTestClient(t)
+	defer cleanupFn()
+
+	require.NoError(t, client.Init(ctx))
+	const maxBigInt int64 = 1<<63 - 1
+	_, err := client.db.Exec(ctx, "SELECT setval('input_file_id_seq', $1, true)", maxBigInt-1)
+	require.NoError(t, err)
+
+	_, err = client.SaveTaskRun(ctx, &storage.TaskRunFull{
+		TaskRun: storage.TaskRun{
+			ApplicationName:  "baurHimself",
+			TaskName:         "build",
+			VCSRevision:      "1",
+			VCSIsDirty:       false,
+			StartTimestamp:   time.Now(),
+			StopTimestamp:    time.Now().Add(5 * time.Minute),
+			Result:           storage.ResultSuccess,
+			TotalInputDigest: "1234567890",
+		},
+		Inputs: storage.Inputs{
+			Files: []*storage.InputFile{
+				{
+					Path:   "main.go",
+					Digest: "45",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var inputFileID, inputFileFK int64
+	err = client.db.QueryRow(ctx, `
+		SELECT input_file.id, task_run_file_input.input_file_id
+		  FROM input_file
+		  JOIN task_run_file_input ON input_file.id = task_run_file_input.input_file_id
+		 WHERE input_file.path = 'main.go'
+		   AND input_file.digest = '45'
+	`).Scan(&inputFileID, &inputFileFK)
+	require.NoError(t, err)
+	require.Equal(t, maxBigInt, inputFileID)
+	require.Equal(t, maxBigInt, inputFileFK)
+}

--- a/pkg/storage/postgres/migrations/6.sql
+++ b/pkg/storage/postgres/migrations/6.sql
@@ -1,0 +1,22 @@
+LOCK TABLE input_file, task_run_file_input IN ACCESS EXCLUSIVE MODE;
+
+ALTER TABLE task_run_file_input
+	DROP CONSTRAINT task_run_file_input_input_file_id_fkey;
+
+ALTER TABLE input_file
+	ALTER COLUMN id TYPE bigint;
+
+ALTER TABLE task_run_file_input
+	ALTER COLUMN input_file_id TYPE bigint;
+
+ALTER SEQUENCE input_file_id_seq AS bigint NO MAXVALUE;
+
+WITH input_file_max_id AS (
+	SELECT max(id) AS id FROM input_file
+)
+SELECT setval('input_file_id_seq', COALESCE(id, 1), id IS NOT NULL)
+  FROM input_file_max_id;
+
+ALTER TABLE task_run_file_input
+	ADD CONSTRAINT task_run_file_input_input_file_id_fkey
+	FOREIGN KEY (input_file_id) REFERENCES input_file(id) ON DELETE CASCADE;

--- a/pkg/storage/postgres/schema.go
+++ b/pkg/storage/postgres/schema.go
@@ -20,7 +20,7 @@ const (
 	// minSchemaVer is the minimum required database schema version
 	minSchemaVer int32 = 4
 	// maxSchemaVer is the highest database schema version that is compatible
-	maxSchemaVer int32 = 5
+	maxSchemaVer int32 = 6
 )
 
 // migration represents a database schema migration.


### PR DESCRIPTION
  Fix Baur PostgreSQL metadata DB exhaustion by migrating input_file.id and task_run_file_input.input_file_id from integer to bigint, and widening input_file_id_seq to a bigint sequence.

  The migration also resets input_file_id_seq to the current max input_file.id, so databases with an exhausted sequence can continue from the real table state after upgrade.